### PR TITLE
Update repository and package names

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,5 +8,7 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
-  "useCalculatedVersion": true
+  "snapshot": {
+    "useCalculatedVersion": true
+  }
 }

--- a/.changeset/tiny-olives-warn.md
+++ b/.changeset/tiny-olives-warn.md
@@ -1,0 +1,6 @@
+---
+'@chromatic-com/playwright': patch
+'@chromatic-com/cypress': patch
+---
+
+publish new packages

--- a/.github/workflows/main-workflow.yml
+++ b/.github/workflows/main-workflow.yml
@@ -25,5 +25,5 @@ jobs:
     uses: ./.github/workflows/release.yml
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
-      npmToken: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      npmToken: ${{ secrets.NPM_CHROMATIC_COM_PUBLISH_TOKEN }}
     

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -27,5 +27,5 @@ jobs:
     uses: ./.github/workflows/canary-release.yml
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
-      npmToken: ${{ secrets.NPM_PUBLISH_TOKEN }}
+      npmToken: ${{ secrets.NPM_CHROMATIC_COM_PUBLISH_TOKEN }}
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### 🐛 Bug Fix
 
-- Cypress: User-facing API [#55](https://github.com/chromaui/test-archiver/pull/55) ([@skitterm](https://github.com/skitterm))
+- Cypress: User-facing API [#55](https://github.com/chromaui/chromatic-e2e/pull/55) ([@skitterm](https://github.com/skitterm))
 
 #### Authors: 1
 
@@ -14,7 +14,7 @@
 
 #### 🐛 Bug Fix
 
-- Cypress doesn't wait for idle timeout [#54](https://github.com/chromaui/test-archiver/pull/54) ([@skitterm](https://github.com/skitterm))
+- Cypress doesn't wait for idle timeout [#54](https://github.com/chromaui/chromatic-e2e/pull/54) ([@skitterm](https://github.com/skitterm))
 
 #### Authors: 1
 
@@ -26,7 +26,7 @@
 
 #### 🐛 Bug Fix
 
-- Cypress uses Chrome Devtools Protocol [#53](https://github.com/chromaui/test-archiver/pull/53) ([@skitterm](https://github.com/skitterm))
+- Cypress uses Chrome Devtools Protocol [#53](https://github.com/chromaui/chromatic-e2e/pull/53) ([@skitterm](https://github.com/skitterm))
 
 #### Authors: 1
 
@@ -38,7 +38,7 @@
 
 #### 🐛 Bug Fix
 
-- Common test fixtures, Cypress now has tests [#51](https://github.com/chromaui/test-archiver/pull/51) ([@skitterm](https://github.com/skitterm))
+- Common test fixtures, Cypress now has tests [#51](https://github.com/chromaui/chromatic-e2e/pull/51) ([@skitterm](https://github.com/skitterm))
 
 #### Authors: 1
 
@@ -50,7 +50,7 @@
 
 #### 🐛 Bug Fix
 
-- Chrome Devtools Protocol code is framework-agnostic [#50](https://github.com/chromaui/test-archiver/pull/50) ([@skitterm](https://github.com/skitterm))
+- Chrome Devtools Protocol code is framework-agnostic [#50](https://github.com/chromaui/chromatic-e2e/pull/50) ([@skitterm](https://github.com/skitterm))
 
 #### Authors: 1
 
@@ -62,7 +62,7 @@
 
 #### 🐛 Bug Fix
 
-- Project secret rename [#52](https://github.com/chromaui/test-archiver/pull/52) ([@skitterm](https://github.com/skitterm))
+- Project secret rename [#52](https://github.com/chromaui/chromatic-e2e/pull/52) ([@skitterm](https://github.com/skitterm))
 
 #### Authors: 1
 
@@ -74,7 +74,7 @@
 
 #### 🐛 Bug Fix
 
-- Playwright tests split out by intent [#49](https://github.com/chromaui/test-archiver/pull/49) ([@skitterm](https://github.com/skitterm) [@tevanoff](https://github.com/tevanoff))
+- Playwright tests split out by intent [#49](https://github.com/chromaui/chromatic-e2e/pull/49) ([@skitterm](https://github.com/skitterm) [@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 2
 
@@ -87,7 +87,7 @@
 
 #### 🐛 Bug Fix
 
-- Upgrade to yarn4 [#47](https://github.com/chromaui/test-archiver/pull/47) ([@tevanoff](https://github.com/tevanoff))
+- Upgrade to yarn4 [#47](https://github.com/chromaui/chromatic-e2e/pull/47) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -99,7 +99,7 @@
 
 #### 🐛 Bug Fix
 
-- Cypress e2e testing added [#48](https://github.com/chromaui/test-archiver/pull/48) ([@skitterm](https://github.com/skitterm))
+- Cypress e2e testing added [#48](https://github.com/chromaui/chromatic-e2e/pull/48) ([@skitterm](https://github.com/skitterm))
 
 #### Authors: 1
 
@@ -111,7 +111,7 @@
 
 #### 🐛 Bug Fix
 
-- Use case-insensitive match on header name [#45](https://github.com/chromaui/test-archiver/pull/45) ([@tevanoff](https://github.com/tevanoff))
+- Use case-insensitive match on header name [#45](https://github.com/chromaui/chromatic-e2e/pull/45) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -123,7 +123,7 @@
 
 #### 🐛 Bug Fix
 
-- Remove problematic chars from asset filenames [#44](https://github.com/chromaui/test-archiver/pull/44) ([@tevanoff](https://github.com/tevanoff))
+- Remove problematic chars from asset filenames [#44](https://github.com/chromaui/chromatic-e2e/pull/44) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -135,7 +135,7 @@
 
 #### 🐛 Bug Fix
 
-- Remove asset caching [#43](https://github.com/chromaui/test-archiver/pull/43) ([@tevanoff](https://github.com/tevanoff))
+- Remove asset caching [#43](https://github.com/chromaui/chromatic-e2e/pull/43) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -147,7 +147,7 @@
 
 #### 🐛 Bug Fix
 
-- Upgrade archive-storybook [#42](https://github.com/chromaui/test-archiver/pull/42) ([@tevanoff](https://github.com/tevanoff))
+- Upgrade archive-storybook [#42](https://github.com/chromaui/chromatic-e2e/pull/42) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -159,7 +159,7 @@
 
 #### 🐛 Bug Fix
 
-- :white_check_mark: Add tests for ignored regions in test archiver. [#41](https://github.com/chromaui/test-archiver/pull/41) ([@jwir3](https://github.com/jwir3))
+- :white_check_mark: Add tests for ignored regions in test archiver. [#41](https://github.com/chromaui/chromatic-e2e/pull/41) ([@jwir3](https://github.com/jwir3))
 
 #### Authors: 1
 
@@ -171,7 +171,7 @@
 
 #### 🐛 Bug Fix
 
-- Archive assets from img srcsets [#40](https://github.com/chromaui/test-archiver/pull/40) ([@tevanoff](https://github.com/tevanoff))
+- Archive assets from img srcsets [#40](https://github.com/chromaui/chromatic-e2e/pull/40) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -183,7 +183,7 @@
 
 #### 🐛 Bug Fix
 
-- Removing duplicate documentation [#39](https://github.com/chromaui/test-archiver/pull/39) ([@skitterm](https://github.com/skitterm))
+- Removing duplicate documentation [#39](https://github.com/chromaui/chromatic-e2e/pull/39) ([@skitterm](https://github.com/skitterm))
 
 #### Authors: 1
 
@@ -195,7 +195,7 @@
 
 #### 🐛 Bug Fix
 
-- Put Cypress archives in temp directory [#38](https://github.com/chromaui/test-archiver/pull/38) ([@skitterm](https://github.com/skitterm))
+- Put Cypress archives in temp directory [#38](https://github.com/chromaui/chromatic-e2e/pull/38) ([@skitterm](https://github.com/skitterm))
 
 #### Authors: 1
 
@@ -207,7 +207,7 @@
 
 #### 🐛 Bug Fix
 
-- Allow archiving from specified external domains [#37](https://github.com/chromaui/test-archiver/pull/37) ([@skitterm](https://github.com/skitterm))
+- Allow archiving from specified external domains [#37](https://github.com/chromaui/chromatic-e2e/pull/37) ([@skitterm](https://github.com/skitterm))
 
 #### Authors: 1
 
@@ -219,7 +219,7 @@
 
 #### 🐛 Bug Fix
 
-- Use non-forked rrweb [#34](https://github.com/chromaui/test-archiver/pull/34) ([@tevanoff](https://github.com/tevanoff))
+- Use non-forked rrweb [#34](https://github.com/chromaui/chromatic-e2e/pull/34) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -231,7 +231,7 @@
 
 #### 🐛 Bug Fix
 
-- Fix mapping of CSS URLs [#33](https://github.com/chromaui/test-archiver/pull/33) ([@tevanoff](https://github.com/tevanoff))
+- Fix mapping of CSS URLs [#33](https://github.com/chromaui/chromatic-e2e/pull/33) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -243,7 +243,7 @@
 
 #### 🐛 Bug Fix
 
-- Cypress support (basic) [#29](https://github.com/chromaui/test-archiver/pull/29) ([@skitterm](https://github.com/skitterm))
+- Cypress support (basic) [#29](https://github.com/chromaui/chromatic-e2e/pull/29) ([@skitterm](https://github.com/skitterm))
 
 #### Authors: 1
 
@@ -255,7 +255,7 @@
 
 #### 🐛 Bug Fix
 
-- Only archive assets fetched via GET [#32](https://github.com/chromaui/test-archiver/pull/32) ([@tevanoff](https://github.com/tevanoff))
+- Only archive assets fetched via GET [#32](https://github.com/chromaui/chromatic-e2e/pull/32) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -267,7 +267,7 @@
 
 #### 🐛 Bug Fix
 
-- Consolidate all asset path Playwright testing into one page [#31](https://github.com/chromaui/test-archiver/pull/31) ([@tevanoff](https://github.com/tevanoff))
+- Consolidate all asset path Playwright testing into one page [#31](https://github.com/chromaui/chromatic-e2e/pull/31) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -279,7 +279,7 @@
 
 #### 🐛 Bug Fix
 
-- Publish Archive Storybook to Chromatic [#30](https://github.com/chromaui/test-archiver/pull/30) ([@tevanoff](https://github.com/tevanoff))
+- Publish Archive Storybook to Chromatic [#30](https://github.com/chromaui/chromatic-e2e/pull/30) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -291,7 +291,7 @@
 
 #### 🐛 Bug Fix
 
-- Consolidate asset path modifications and mappings [#28](https://github.com/chromaui/test-archiver/pull/28) ([@tevanoff](https://github.com/tevanoff))
+- Consolidate asset path modifications and mappings [#28](https://github.com/chromaui/chromatic-e2e/pull/28) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -303,7 +303,7 @@
 
 #### 🐛 Bug Fix
 
-- Add a file extension based on Content-Type header for files that have it [#27](https://github.com/chromaui/test-archiver/pull/27) ([@jwir3](https://github.com/jwir3))
+- Add a file extension based on Content-Type header for files that have it [#27](https://github.com/chromaui/chromatic-e2e/pull/27) ([@jwir3](https://github.com/jwir3))
 
 #### Authors: 1
 
@@ -315,7 +315,7 @@
 
 #### 🐛 Bug Fix
 
-- :bug: Fix issue where the networkTimeout wasn't renamed everywhere. [#26](https://github.com/chromaui/test-archiver/pull/26) ([@jwir3](https://github.com/jwir3))
+- :bug: Fix issue where the networkTimeout wasn't renamed everywhere. [#26](https://github.com/chromaui/chromatic-e2e/pull/26) ([@jwir3](https://github.com/jwir3))
 
 #### Authors: 1
 
@@ -327,7 +327,7 @@
 
 #### 🐛 Bug Fix
 
-- :goal_net: Make Watcher not throw an exception if network idle times out [#25](https://github.com/chromaui/test-archiver/pull/25) ([@jwir3](https://github.com/jwir3))
+- :goal_net: Make Watcher not throw an exception if network idle times out [#25](https://github.com/chromaui/chromatic-e2e/pull/25) ([@jwir3](https://github.com/jwir3))
 
 #### Authors: 1
 
@@ -339,7 +339,7 @@
 
 #### 🐛 Bug Fix
 
-- Allow Chromatic configuration options [#22](https://github.com/chromaui/test-archiver/pull/22) ([@tevanoff](https://github.com/tevanoff))
+- Allow Chromatic configuration options [#22](https://github.com/chromaui/chromatic-e2e/pull/22) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -351,7 +351,7 @@
 
 #### 🐛 Bug Fix
 
-- Truncate and map filenames that are too long in test archiver [#24](https://github.com/chromaui/test-archiver/pull/24) ([@jwir3](https://github.com/jwir3))
+- Truncate and map filenames that are too long in test archiver [#24](https://github.com/chromaui/chromatic-e2e/pull/24) ([@jwir3](https://github.com/jwir3))
 
 #### Authors: 1
 
@@ -363,7 +363,7 @@
 
 #### 🐛 Bug Fix
 
-- Exported test function typed [#23](https://github.com/chromaui/test-archiver/pull/23) ([@skitterm](https://github.com/skitterm))
+- Exported test function typed [#23](https://github.com/chromaui/chromatic-e2e/pull/23) ([@skitterm](https://github.com/skitterm))
 
 #### Authors: 1
 
@@ -375,7 +375,7 @@
 
 #### 🐛 Bug Fix
 
-- Wait for all resources to load before indicating Watcher is idle [#16](https://github.com/chromaui/test-archiver/pull/16) ([@jwir3](https://github.com/jwir3))
+- Wait for all resources to load before indicating Watcher is idle [#16](https://github.com/chromaui/chromatic-e2e/pull/16) ([@jwir3](https://github.com/jwir3))
 
 #### Authors: 1
 
@@ -387,7 +387,7 @@
 
 #### 🐛 Bug Fix
 
-- Spelling fix [#18](https://github.com/chromaui/test-archiver/pull/18) ([@codykaup](https://github.com/codykaup))
+- Spelling fix [#18](https://github.com/chromaui/chromatic-e2e/pull/18) ([@codykaup](https://github.com/codykaup))
 
 #### Authors: 1
 
@@ -399,7 +399,7 @@
 
 #### 🐛 Bug Fix
 
-- Do not archive top level page requests [#19](https://github.com/chromaui/test-archiver/pull/19) ([@tevanoff](https://github.com/tevanoff))
+- Do not archive top level page requests [#19](https://github.com/chromaui/chromatic-e2e/pull/19) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -411,7 +411,7 @@
 
 #### 🐛 Bug Fix
 
-- Fix repository url [#20](https://github.com/chromaui/test-archiver/pull/20) ([@tevanoff](https://github.com/tevanoff))
+- Fix repository url [#20](https://github.com/chromaui/chromatic-e2e/pull/20) ([@tevanoff](https://github.com/tevanoff))
 
 #### Authors: 1
 
@@ -423,7 +423,7 @@
 
 #### 🐛 Bug Fix
 
-- Write archives to Playwright-created folder [#17](https://github.com/chromaui/test-archiver/pull/17) ([@skitterm](https://github.com/skitterm))
+- Write archives to Playwright-created folder [#17](https://github.com/chromaui/chromatic-e2e/pull/17) ([@skitterm](https://github.com/skitterm))
 
 #### Authors: 1
 
@@ -435,7 +435,7 @@
 
 #### 🐛 Bug Fix
 
-- Fix infinite loading for 307 and 308 response statuses [#15](https://github.com/chromaui/test-archiver/pull/15) ([@joshuajaco](https://github.com/joshuajaco))
+- Fix infinite loading for 307 and 308 response statuses [#15](https://github.com/chromaui/chromatic-e2e/pull/15) ([@joshuajaco](https://github.com/joshuajaco))
 
 #### Authors: 1
 
@@ -447,7 +447,7 @@
 
 #### 🐛 Bug Fix
 
-- Respect viewport set via Playwright [#10](https://github.com/chromaui/test-archiver/pull/10) ([@thafryer](https://github.com/thafryer))
+- Respect viewport set via Playwright [#10](https://github.com/chromaui/chromatic-e2e/pull/10) ([@thafryer](https://github.com/thafryer))
 
 #### Authors: 1
 
@@ -459,12 +459,12 @@
 
 #### 🐛 Bug Fix
 
-- Use GH token for releases [#9](https://github.com/chromaui/test-archiver/pull/9) ([@tmeasday](https://github.com/tmeasday))
-- Add very minimal analytics [#8](https://github.com/chromaui/test-archiver/pull/8) ([@tmeasday](https://github.com/tmeasday))
-- Document how to install archive storybook with peer deps [#6](https://github.com/chromaui/test-archiver/pull/6) ([@tmeasday](https://github.com/tmeasday))
-- Skip over CDP errors, but record to an error log [#7](https://github.com/chromaui/test-archiver/pull/7) ([@tmeasday](https://github.com/tmeasday))
-- Update docs [#4](https://github.com/chromaui/test-archiver/pull/4) ([@kylegach](https://github.com/kylegach))
-- Update Documentation.md [#3](https://github.com/chromaui/test-archiver/pull/3) ([@JonathanKolnik](https://github.com/JonathanKolnik))
+- Use GH token for releases [#9](https://github.com/chromaui/chromatic-e2e/pull/9) ([@tmeasday](https://github.com/tmeasday))
+- Add very minimal analytics [#8](https://github.com/chromaui/chromatic-e2e/pull/8) ([@tmeasday](https://github.com/tmeasday))
+- Document how to install archive storybook with peer deps [#6](https://github.com/chromaui/chromatic-e2e/pull/6) ([@tmeasday](https://github.com/tmeasday))
+- Skip over CDP errors, but record to an error log [#7](https://github.com/chromaui/chromatic-e2e/pull/7) ([@tmeasday](https://github.com/tmeasday))
+- Update docs [#4](https://github.com/chromaui/chromatic-e2e/pull/4) ([@kylegach](https://github.com/kylegach))
+- Update Documentation.md [#3](https://github.com/chromaui/chromatic-e2e/pull/3) ([@JonathanKolnik](https://github.com/JonathanKolnik))
 
 #### ⚠️ Pushed to `main`
 
@@ -483,7 +483,7 @@
 
 #### 🐛 Bug Fix
 
-- Continue failed requests too [#2](https://github.com/chromaui/test-archiver/pull/2) ([@tmeasday](https://github.com/tmeasday))
+- Continue failed requests too [#2](https://github.com/chromaui/chromatic-e2e/pull/2) ([@tmeasday](https://github.com/tmeasday))
 
 #### Authors: 1
 
@@ -495,7 +495,7 @@
 
 #### 🐛 Bug Fix
 
-- Don't cache resources from external URLs [#1](https://github.com/chromaui/test-archiver/pull/1) ([@tmeasday](https://github.com/tmeasday))
+- Don't cache resources from external URLs [#1](https://github.com/chromaui/chromatic-e2e/pull/1) ([@tmeasday](https://github.com/tmeasday))
 
 #### Authors: 1
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,11 +2,11 @@
 
 This repository is a Yarn 4 monorepo containing the following packages:
 
-- [cypress](https://github.com/chromaui/test-archiver/tree/main/packages/cypress)
+- [cypress](https://github.com/chromaui/chromatic-e2e/tree/main/packages/cypress)
   - Chromatic E2E Visual Test integration for Cypress
-- [playwright](https://github.com/chromaui/test-archiver/tree/main/packages/playwright)
+- [playwright](https://github.com/chromaui/chromatic-e2e/tree/main/packages/playwright)
   - Chromatic E2E Visual Test integration for Playwright
-- [shared](https://github.com/chromaui/test-archiver/tree/main/packages/shared)
+- [shared](https://github.com/chromaui/chromatic-e2e/tree/main/packages/shared)
   - Internal workspace package shared by the integrations above
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Chromatic E2E Visual Tests
 
-Chromatic E2E monorepo containing the `chromatic-playwright` and `chromatic-cypress` packages.
+Chromatic E2E monorepo containing the `@chromatic-com/playwright` and `@chromatic-com/cypress` packages.
 
 ## Getting Started with Chromatic E2E Visual Tests
 

--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Please see our [development guide](DEVELOPMENT.md)
 
 ## License
 
-[MIT](https://github.com/chromaui/test-archiver/blob/main/LICENSE)
+[MIT](https://github.com/chromaui/chromatic-e2e/blob/main/LICENSE)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Archive end-to-end tests to be replayed in Storybook and Chromatic",
   "repository": {
     "type": "git",
-    "url": "https://github.com/chromaui/test-archiver.git"
+    "url": "https://github.com/chromaui/chromatic-e2e.git"
   },
   "author": "Chromatic <tom@chromatic.com>",
   "license": "MIT",

--- a/packages/cypress/CHANGELOG.md
+++ b/packages/cypress/CHANGELOG.md
@@ -41,5 +41,5 @@
 ### Minor Changes
 
 - 0070406: - introduce `chromatic-cypress` package
-  - add Chromatic options for Cypress: https://github.com/chromaui/test-archiver/pull/59
-  - use fullscreen layout for Storybook: https://github.com/chromaui/test-archiver/pull/64
+  - add Chromatic options for Cypress: https://github.com/chromaui/chromatic-e2e/pull/59
+  - use fullscreen layout for Storybook: https://github.com/chromaui/chromatic-e2e/pull/64

--- a/packages/cypress/README.md
+++ b/packages/cypress/README.md
@@ -1,4 +1,4 @@
-## chromatic-cypress
+## @chromatic-com/cypress
 
 Chromatic E2E Visual Tests for Cypress
 

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chromatic-cypress",
+  "name": "@chromatic-com/cypress",
   "version": "0.4.1",
   "description": "Chromatic Visual Regression Testing for Cypress",
   "repository": {
@@ -50,7 +50,7 @@
     "prettier": "prettier"
   },
   "devDependencies": {
-    "@chromaui/shared-e2e": "workspace:*",
+    "@chromatic-com/shared-e2e": "workspace:*",
     "@storybook/types": "^7.0.2",
     "cypress": "^13.4.0",
     "start-server-and-test": "^2.0.3"

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chromatic-com/cypress",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Chromatic Visual Regression Testing for Cypress",
   "repository": {
     "type": "git",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -4,7 +4,7 @@
   "description": "Chromatic Visual Regression Testing for Cypress",
   "repository": {
     "type": "git",
-    "url": "https://github.com/chromaui/test-archiver.git",
+    "url": "https://github.com/chromaui/chromatic-e2e.git",
     "directory": "packages/cypress"
   },
   "author": "Chromatic <tom@chromatic.com>",

--- a/packages/cypress/src/bin/archive-storybook.ts
+++ b/packages/cypress/src/bin/archive-storybook.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { archiveStorybook } from '@chromaui/shared-e2e/archive-storybook';
+import { archiveStorybook } from '@chromatic-com/shared-e2e/archive-storybook';
 import path from 'path';
 
 // Discard first two entries (exec path and file path)

--- a/packages/cypress/src/bin/build-archive-storybook.ts
+++ b/packages/cypress/src/bin/build-archive-storybook.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { buildArchiveStorybook } from '@chromaui/shared-e2e/archive-storybook';
+import { buildArchiveStorybook } from '@chromatic-com/shared-e2e/archive-storybook';
 import path from 'path';
 
 // Discard first two entries (exec path and file path)

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -5,7 +5,7 @@ import {
   writeTestResult,
   ChromaticStorybookParameters,
   ResourceArchive,
-} from '@chromaui/shared-e2e';
+} from '@chromatic-com/shared-e2e';
 
 interface CypressSnapshot {
   // the name of the snapshot (optionally provided for manual snapshots, never provided for automatic snapshots)

--- a/packages/playwright/CHANGELOG.md
+++ b/packages/playwright/CHANGELOG.md
@@ -29,5 +29,5 @@
 ### Minor Changes
 
 - df06cbe: - introduce `chromatic-playwright` package
-  - update function and parameter names: https://github.com/chromaui/test-archiver/pull/58
-  - use fullscreen layout for Storybook: https://github.com/chromaui/test-archiver/pull/64
+  - update function and parameter names: https://github.com/chromaui/chromatic-e2e/pull/58
+  - use fullscreen layout for Storybook: https://github.com/chromaui/chromatic-e2e/pull/64

--- a/packages/playwright/README.md
+++ b/packages/playwright/README.md
@@ -1,4 +1,4 @@
-## chromatic-playwright
+## @chromatic-com/playwright
 
 Chromatic E2E Visual Tests for Playwright
 

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chromatic-com/playwright",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Chromatic Visual Regression Testing for Playwright",
   "repository": {
     "type": "git",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "chromatic-playwright",
+  "name": "@chromatic-com/playwright",
   "version": "0.4.1",
   "description": "Chromatic Visual Regression Testing for Playwright",
   "repository": {
@@ -44,7 +44,7 @@
     "prettier": "prettier"
   },
   "devDependencies": {
-    "@chromaui/shared-e2e": "workspace:*",
+    "@chromatic-com/shared-e2e": "workspace:*",
     "@playwright/test": "^1.39.0",
     "@storybook/types": "^7.0.2",
     "express": "^4.18.2",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -4,7 +4,7 @@
   "description": "Chromatic Visual Regression Testing for Playwright",
   "repository": {
     "type": "git",
-    "url": "https://github.com/chromaui/test-archiver.git",
+    "url": "https://github.com/chromaui/chromatic-e2e.git",
     "directory": "packages/playwright"
   },
   "author": "Chromatic <tom@chromatic.com>",

--- a/packages/playwright/src/bin/archive-storybook.ts
+++ b/packages/playwright/src/bin/archive-storybook.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { archiveStorybook } from '@chromaui/shared-e2e/archive-storybook';
+import { archiveStorybook } from '@chromatic-com/shared-e2e/archive-storybook';
 import path from 'path';
 
 // Discard first two entries (exec path and file path)

--- a/packages/playwright/src/bin/build-archive-storybook.ts
+++ b/packages/playwright/src/bin/build-archive-storybook.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { buildArchiveStorybook } from '@chromaui/shared-e2e/archive-storybook';
+import { buildArchiveStorybook } from '@chromatic-com/shared-e2e/archive-storybook';
 import path from 'path';
 
 // Discard first two entries (exec path and file path)

--- a/packages/playwright/src/createResourceArchive.test.ts
+++ b/packages/playwright/src/createResourceArchive.test.ts
@@ -3,7 +3,7 @@ import express, { type Request } from 'express';
 import { Server } from 'http';
 import { Browser, chromium, Page } from 'playwright';
 
-import { logger } from '@chromaui/shared-e2e';
+import { logger } from '@chromatic-com/shared-e2e';
 import { createResourceArchive } from './createResourceArchive';
 
 const TEST_PORT = 13337;

--- a/packages/playwright/src/createResourceArchive.ts
+++ b/packages/playwright/src/createResourceArchive.ts
@@ -4,7 +4,7 @@ import {
   ResourceArchive,
   DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS,
   logger,
-} from '@chromaui/shared-e2e';
+} from '@chromatic-com/shared-e2e';
 
 const idle = async (page: Page, networkTimeoutMs = DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS) => {
   let globalNetworkTimerId: null | ReturnType<typeof setTimeout> = null;

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -6,4 +6,4 @@ export const test = makeTest(base);
 export { expect };
 
 export { takeSnapshot } from './takeSnapshot';
-export type { ChromaticConfig } from '@chromaui/shared-e2e';
+export type { ChromaticConfig } from '@chromatic-com/shared-e2e';

--- a/packages/playwright/src/makeTest.ts
+++ b/packages/playwright/src/makeTest.ts
@@ -5,13 +5,13 @@ import type {
   PlaywrightWorkerArgs,
   PlaywrightWorkerOptions,
 } from '@playwright/test';
-import type { ChromaticConfig } from '@chromaui/shared-e2e';
+import type { ChromaticConfig } from '@chromatic-com/shared-e2e';
 import {
   writeTestResult,
   trackComplete,
   trackRun,
   DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS,
-} from '@chromaui/shared-e2e';
+} from '@chromatic-com/shared-e2e';
 import { contentType, takeSnapshot } from './takeSnapshot';
 import { createResourceArchive } from './createResourceArchive';
 

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -4,7 +4,7 @@ import type { elementNode } from 'rrweb-snapshot';
 
 import dedent from 'ts-dedent';
 
-import { logger } from '@chromaui/shared-e2e';
+import { logger } from '@chromatic-com/shared-e2e';
 
 const rrweb = readFileSync(require.resolve('rrweb-snapshot/dist/rrweb-snapshot.js'), 'utf8');
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@chromaui/shared-e2e",
+  "name": "@chromatic-com/shared-e2e",
   "private": true,
   "version": "0.1.1",
   "description": "Shared Chromatic E2E",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chromatic-com/shared-e2e",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.5.0",
   "description": "Shared Chromatic E2E",
   "repository": {
     "type": "git",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,7 +5,7 @@
   "description": "Shared Chromatic E2E",
   "repository": {
     "type": "git",
-    "url": "https://github.com/chromaui/test-archiver.git",
+    "url": "https://github.com/chromaui/chromatic-e2e.git",
     "directory": "packages/shared"
   },
   "author": "Chromatic <tom@chromatic.com>",

--- a/packages/shared/storybook-config/main.ts
+++ b/packages/shared/storybook-config/main.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { archivesDir } from '@chromaui/shared-e2e/utils/filePaths';
+import { archivesDir } from '@chromatic-com/shared-e2e/utils/filePaths';
 
 /** @type { import('@storybook/server-webpack5').StorybookConfig } */
 export default {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,6 +3295,99 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chromatic-com/cypress@workspace:packages/cypress":
+  version: 0.0.0-use.local
+  resolution: "@chromatic-com/cypress@workspace:packages/cypress"
+  dependencies:
+    "@chromatic-com/shared-e2e": "workspace:*"
+    "@segment/analytics-node": "npm:^1.1.0"
+    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/types": "npm:^7.0.2"
+    chrome-remote-interface: "npm:^0.33.0"
+    cypress: "npm:^13.4.0"
+    rrweb-snapshot: "npm:^2.0.0-alpha.4"
+    start-server-and-test: "npm:^2.0.3"
+  peerDependencies:
+    "@storybook/addon-essentials": ^7.0.0 || ^8.0.x
+    "@storybook/server-webpack5": ^7.0.0 || ^8.0.x
+    storybook: ^7.0.0 || ^8.0.x
+  bin:
+    archive-storybook: dist/bin/archive-storybook.js
+    build-archive-storybook: dist/bin/build-archive-storybook.js
+  languageName: unknown
+  linkType: soft
+
+"@chromatic-com/playwright@workspace:packages/playwright":
+  version: 0.0.0-use.local
+  resolution: "@chromatic-com/playwright@workspace:packages/playwright"
+  dependencies:
+    "@chromatic-com/shared-e2e": "workspace:*"
+    "@playwright/test": "npm:^1.39.0"
+    "@segment/analytics-node": "npm:^1.1.0"
+    "@storybook/csf": "npm:^0.1.0"
+    "@storybook/types": "npm:^7.0.2"
+    express: "npm:^4.18.2"
+    playwright: "npm:^1.32.2"
+    playwright-core: "npm:^1.32.2"
+    rrweb-snapshot: "npm:^2.0.0-alpha.4"
+    ts-dedent: "npm:^2.2.0"
+  peerDependencies:
+    "@playwright/test": ^1.0.0
+    "@storybook/addon-essentials": ^7.0.0 || ^8.0.x
+    "@storybook/server-webpack5": ^7.0.0 || ^8.0.x
+    storybook: ^7.0.0 || ^8.0.x
+  bin:
+    archive-storybook: dist/bin/archive-storybook.js
+    build-archive-storybook: dist/bin/build-archive-storybook.js
+  languageName: unknown
+  linkType: soft
+
+"@chromatic-com/shared-e2e@workspace:*, @chromatic-com/shared-e2e@workspace:packages/shared":
+  version: 0.0.0-use.local
+  resolution: "@chromatic-com/shared-e2e@workspace:packages/shared"
+  dependencies:
+    "@babel/preset-env": "npm:^7.21.4"
+    "@babel/preset-react": "npm:^7.18.6"
+    "@babel/preset-typescript": "npm:^7.21.4"
+    "@jest/types": "npm:^27.0.6"
+    "@playwright/test": "npm:^1.39.0"
+    "@segment/analytics-node": "npm:^1.1.0"
+    "@storybook/addon-essentials": "npm:^7.5.2"
+    "@storybook/eslint-config-storybook": "npm:^3.1.2"
+    "@storybook/server-webpack5": "npm:^7.5.2"
+    "@testing-library/dom": "npm:^8.1.0"
+    "@testing-library/react": "npm:^12.0.0"
+    "@testing-library/user-event": "npm:^13.2.1"
+    "@types/fs-extra": "npm:^11.0.1"
+    "@types/jest": "npm:^27.0.3"
+    "@types/node": "npm:^16.4.1"
+    "@types/node-fetch": "npm:^2.6.6"
+    babel-jest: "npm:^27.0.6"
+    concurrently: "npm:^7.0.0"
+    eslint: "npm:^7.32.0"
+    fs-extra: "npm:^11.1.1"
+    jest: "npm:^27.0.6"
+    jest-environment-jsdom: "npm:^27.0.6"
+    lint-staged: "npm:>=10"
+    mime: "npm:^3.0.0"
+    node-fetch: "npm:2"
+    playwright: "npm:^1.32.2"
+    playwright-core: "npm:^1.32.2"
+    prettier: "npm:^2.3.1"
+    prompts: "npm:^2.4.2"
+    react: "npm:^17.0.1"
+    react-dom: "npm:^17.0.1"
+    rimraf: "npm:^3.0.2"
+    rrweb-snapshot: "npm:^2.0.0-alpha.4"
+    srcset: "npm:^4.0.0"
+    storybook: "npm:^7.5.2"
+    ts-dedent: "npm:^2.2.0"
+    ts-jest: "npm:^27.0.4"
+    tsup: "npm:^6.7.0"
+    typescript: "npm:^4.2.4"
+  languageName: unknown
+  linkType: soft
+
 "@chromaui/chromatic-e2e@workspace:.":
   version: 0.0.0-use.local
   resolution: "@chromaui/chromatic-e2e@workspace:."
@@ -3337,52 +3430,6 @@ __metadata:
     rimraf: "npm:^3.0.2"
     start-server-and-test: "npm:^2.0.3"
     storybook: "npm:^7.5.2"
-    ts-jest: "npm:^27.0.4"
-    tsup: "npm:^6.7.0"
-    typescript: "npm:^4.2.4"
-  languageName: unknown
-  linkType: soft
-
-"@chromaui/shared-e2e@workspace:*, @chromaui/shared-e2e@workspace:packages/shared":
-  version: 0.0.0-use.local
-  resolution: "@chromaui/shared-e2e@workspace:packages/shared"
-  dependencies:
-    "@babel/preset-env": "npm:^7.21.4"
-    "@babel/preset-react": "npm:^7.18.6"
-    "@babel/preset-typescript": "npm:^7.21.4"
-    "@jest/types": "npm:^27.0.6"
-    "@playwright/test": "npm:^1.39.0"
-    "@segment/analytics-node": "npm:^1.1.0"
-    "@storybook/addon-essentials": "npm:^7.5.2"
-    "@storybook/eslint-config-storybook": "npm:^3.1.2"
-    "@storybook/server-webpack5": "npm:^7.5.2"
-    "@testing-library/dom": "npm:^8.1.0"
-    "@testing-library/react": "npm:^12.0.0"
-    "@testing-library/user-event": "npm:^13.2.1"
-    "@types/fs-extra": "npm:^11.0.1"
-    "@types/jest": "npm:^27.0.3"
-    "@types/node": "npm:^16.4.1"
-    "@types/node-fetch": "npm:^2.6.6"
-    babel-jest: "npm:^27.0.6"
-    concurrently: "npm:^7.0.0"
-    eslint: "npm:^7.32.0"
-    fs-extra: "npm:^11.1.1"
-    jest: "npm:^27.0.6"
-    jest-environment-jsdom: "npm:^27.0.6"
-    lint-staged: "npm:>=10"
-    mime: "npm:^3.0.0"
-    node-fetch: "npm:2"
-    playwright: "npm:^1.32.2"
-    playwright-core: "npm:^1.32.2"
-    prettier: "npm:^2.3.1"
-    prompts: "npm:^2.4.2"
-    react: "npm:^17.0.1"
-    react-dom: "npm:^17.0.1"
-    rimraf: "npm:^3.0.2"
-    rrweb-snapshot: "npm:^2.0.0-alpha.4"
-    srcset: "npm:^4.0.0"
-    storybook: "npm:^7.5.2"
-    ts-dedent: "npm:^2.2.0"
     ts-jest: "npm:^27.0.4"
     tsup: "npm:^6.7.0"
     typescript: "npm:^4.2.4"
@@ -8799,53 +8846,6 @@ __metadata:
   checksum: 594754e1303672171cc04e50f6c398ae16128eb134a88f801bf5354fd96f205320f23536a045d9abd8b51024a149696e51231565891d4efdab8846021ecf88e6
   languageName: node
   linkType: hard
-
-"chromatic-cypress@workspace:packages/cypress":
-  version: 0.0.0-use.local
-  resolution: "chromatic-cypress@workspace:packages/cypress"
-  dependencies:
-    "@chromaui/shared-e2e": "workspace:*"
-    "@segment/analytics-node": "npm:^1.1.0"
-    "@storybook/csf": "npm:^0.1.0"
-    "@storybook/types": "npm:^7.0.2"
-    chrome-remote-interface: "npm:^0.33.0"
-    cypress: "npm:^13.4.0"
-    rrweb-snapshot: "npm:^2.0.0-alpha.4"
-    start-server-and-test: "npm:^2.0.3"
-  peerDependencies:
-    "@storybook/addon-essentials": ^7.0.0 || ^8.0.x
-    "@storybook/server-webpack5": ^7.0.0 || ^8.0.x
-    storybook: ^7.0.0 || ^8.0.x
-  bin:
-    archive-storybook: dist/bin/archive-storybook.js
-    build-archive-storybook: dist/bin/build-archive-storybook.js
-  languageName: unknown
-  linkType: soft
-
-"chromatic-playwright@workspace:packages/playwright":
-  version: 0.0.0-use.local
-  resolution: "chromatic-playwright@workspace:packages/playwright"
-  dependencies:
-    "@chromaui/shared-e2e": "workspace:*"
-    "@playwright/test": "npm:^1.39.0"
-    "@segment/analytics-node": "npm:^1.1.0"
-    "@storybook/csf": "npm:^0.1.0"
-    "@storybook/types": "npm:^7.0.2"
-    express: "npm:^4.18.2"
-    playwright: "npm:^1.32.2"
-    playwright-core: "npm:^1.32.2"
-    rrweb-snapshot: "npm:^2.0.0-alpha.4"
-    ts-dedent: "npm:^2.2.0"
-  peerDependencies:
-    "@playwright/test": ^1.0.0
-    "@storybook/addon-essentials": ^7.0.0 || ^8.0.x
-    "@storybook/server-webpack5": ^7.0.0 || ^8.0.x
-    storybook: ^7.0.0 || ^8.0.x
-  bin:
-    archive-storybook: dist/bin/archive-storybook.js
-    build-archive-storybook: dist/bin/build-archive-storybook.js
-  languageName: unknown
-  linkType: soft
 
 "chrome-remote-interface@npm:^0.33.0":
   version: 0.33.0


### PR DESCRIPTION
Issue: #

## What Changed
- Update `chromaui/test-archiver` repo mentions to `chromaui/chromatic-e2e`
- Update `chromatic-playwright` package to `@chromatic-com/playwright`
- Update `chromatic-cypress` package to `@chromatic-com/cypress`
- Update `@chromaui/shared-e2e` package to `@chromatic-com/shared-e2e`
- Start new packages at version `0.5.0`

<!-- Insert a description below. -->

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
- Canary publish is working with the new package names
