### PR TITLE
Do not assume where in the DOM tree the HTML element will be

### DIFF
--- a/.changeset/big-bulldogs-search.md
+++ b/.changeset/big-bulldogs-search.md
@@ -1,0 +1,6 @@
+---
+'@chromatic-com/playwright': patch
+'@chromatic-com/cypress': patch
+---
+
+fix to find the html element node on snapshots without a doctype node

--- a/packages/cypress/tests/cypress/e2e/no-doctype.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/no-doctype.cy.ts
@@ -1,0 +1,3 @@
+it('pages without a doctype are archived', () => {
+  cy.visit('/no-doctype');
+});

--- a/packages/playwright/tests/no-doctype.spec.ts
+++ b/packages/playwright/tests/no-doctype.spec.ts
@@ -1,0 +1,5 @@
+import { test } from '../src';
+
+test('pages without a doctype are archived', async ({ page }) => {
+  await page.goto('/no-doctype');
+});

--- a/packages/shared/storybook-config/preview.ts
+++ b/packages/shared/storybook-config/preview.ts
@@ -21,8 +21,8 @@ const findHtmlNode = async (
 
   if ('childNodes' in node) {
     for (const childNode of node.childNodes) {
-      const checkNode = await findHtmlNode(childNode);
-      if (checkNode) return checkNode;
+      const htmlNode = await findHtmlNode(childNode);
+      if (htmlNode) return htmlNode;
     }
   }
 };

--- a/packages/shared/storybook-config/preview.ts
+++ b/packages/shared/storybook-config/preview.ts
@@ -12,19 +12,18 @@ export interface RRWebFramework extends WebRenderer {
   storyResult: Record<string, never>;
 }
 
-const findHtmlNode = async (
-  node: serializedNodeWithId
-): Promise<serializedNodeWithId | undefined> => {
+const findHtmlNode = (node: serializedNodeWithId): serializedNodeWithId | undefined => {
   if (node.type === NodeType.Element && node.tagName === 'html') {
     return node;
   }
 
   if ('childNodes' in node) {
-    for (const childNode of node.childNodes) {
-      const htmlNode = await findHtmlNode(childNode);
-      if (htmlNode) return htmlNode;
-    }
+    return node.childNodes.find((childNode) => {
+      return findHtmlNode(childNode);
+    });
   }
+
+  return undefined;
 };
 
 const renderToCanvas: RenderToCanvas<RRWebFramework> = async (context, element) => {
@@ -33,7 +32,7 @@ const renderToCanvas: RenderToCanvas<RRWebFramework> = async (context, element) 
   const snapshot = (await response.json()) as serializedNodeWithId;
 
   // The snapshot is a representation of a complete HTML document
-  const htmlNode = await findHtmlNode(snapshot);
+  const htmlNode = findHtmlNode(snapshot);
 
   // If you rebuild the full snapshot with rrweb (the document) it will replace the
   // current document and call `document.open()` in the process, which unbinds all event handlers

--- a/packages/shared/storybook-config/preview.ts
+++ b/packages/shared/storybook-config/preview.ts
@@ -1,5 +1,6 @@
 import type { RenderToCanvas, WebRenderer } from '@storybook/types';
-import { rebuild } from 'rrweb-snapshot';
+import type { serializedNodeWithId } from 'rrweb-snapshot';
+import { NodeType, rebuild } from 'rrweb-snapshot';
 
 const pageUrl = new URL(window.location.href);
 pageUrl.pathname = '';
@@ -11,14 +12,28 @@ export interface RRWebFramework extends WebRenderer {
   storyResult: Record<string, never>;
 }
 
+const findHtmlNode = async (
+  node: serializedNodeWithId
+): Promise<serializedNodeWithId | undefined> => {
+  if (node.type === NodeType.Element && node.tagName === 'html') {
+    return node;
+  }
+
+  if ('childNodes' in node) {
+    for (const childNode of node.childNodes) {
+      const checkNode = await findHtmlNode(childNode);
+      if (checkNode) return checkNode;
+    }
+  }
+};
+
 const renderToCanvas: RenderToCanvas<RRWebFramework> = async (context, element) => {
   const { url, id } = context.storyContext.parameters.server;
   const response = await fetch(`${url}/${id}`);
-  const snapshot = await response.json();
+  const snapshot = (await response.json()) as serializedNodeWithId;
 
-  // The snapshot is a representation of a complete HTML document. The first child is the
-  // doc type declaration and the second is the html element.
-  const htmlNode = snapshot.childNodes[1];
+  // The snapshot is a representation of a complete HTML document
+  const htmlNode = await findHtmlNode(snapshot);
 
   // If you rebuild the full snapshot with rrweb (the document) it will replace the
   // current document and call `document.open()` in the process, which unbinds all event handlers

--- a/test-server/fixtures/no-doctype.html
+++ b/test-server/fixtures/no-doctype.html
@@ -1,0 +1,8 @@
+<html>
+    <head>
+        <title>No Doctype</title>
+    </head>
+    <body>
+      <p>No doctype archives and renders</p>
+    </body>
+</html>

--- a/test-server/server.js
+++ b/test-server/server.js
@@ -70,6 +70,10 @@ app.get('/forms', (req, res) => {
   res.sendFile(path.join(__dirname, 'fixtures/forms.html'));
 });
 
+app.get('/no-doctype', (req, res) => {
+  res.sendFile(path.join(__dirname, 'fixtures/no-doctype.html'));
+});
+
 // Send a redirect to the GET handler with the same path to ensure we're not caching POST responses and serving
 // it instead of the real GET response.
 app.post('/form-success', (req, res) => {


### PR DESCRIPTION
Issue: #

## What Changed
This searches the DOM tree for the HTML element rather than assume it's in a given position.

<!-- Insert a description below. -->

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
* See all Chromatic tests render and pass
* See new `No Doctype` also render
