### PR TITLE
Fix delay test

### DIFF
--- a/test-server/fixtures/options/delay.html
+++ b/test-server/fixtures/options/delay.html
@@ -1,7 +1,8 @@
 <!doctype html>
 <html>
   <body>
-    <img src="/images/animated.gif"/>
+    <!-- Loads the animated gif from an external domain so that capture does not auto-pause it on the first frame -->
+    <img src="https://github.com/chromaui/chromatic-e2e/blob/main/test-server/fixtures/assets/images/animated.gif?raw=true"/>
     <h4>The image should be snapshotted as purple since we're waiting until the delayed-revealed image is visible.</h4>
   </body>
 </html>


### PR DESCRIPTION
Issue: #

## What Changed

<!-- Insert a description below. -->
Load the animated gif used to test the `delay` flag from an external domain so that it's not paused on the first frame by caputure-v6.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
- See the delay tests in the E2E builds rendering purple again
