### PR TITLE
Report code coverage to Codacy

### DIFF
--- a/.github/workflows/main-workflow.yml
+++ b/.github/workflows/main-workflow.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/test-base.yml
+    secrets:
+      codacyProjectToken: ${{ secrets.CODACY_PROJECT_TOKEN }}
   test_cypress:
     needs: test
     uses: ./.github/workflows/test-cypress.yml
@@ -26,4 +28,4 @@ jobs:
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       npmToken: ${{ secrets.NPM_CHROMATIC_COM_PUBLISH_TOKEN }}
-    
+

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/test-base.yml
+    secrets:
+      codacyProjectToken: ${{ secrets.CODACY_PROJECT_TOKEN }}
   test_cypress:
     needs: test
     uses: ./.github/workflows/test-cypress.yml
@@ -28,4 +30,4 @@ jobs:
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}
       npmToken: ${{ secrets.NPM_CHROMATIC_COM_PUBLISH_TOKEN }}
-    
+

--- a/.github/workflows/test-base.yml
+++ b/.github/workflows/test-base.yml
@@ -1,7 +1,11 @@
 # Runs linting and unit tests
 name: Test Base
 
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      codacyProjectToken:
+        required: true
 
 jobs:
   test:
@@ -21,7 +25,7 @@ jobs:
 
       - name: Install Playwright
         run: |
-          yarn playwright install    
+          yarn playwright install
 
       - name: Build
         run: |
@@ -34,3 +38,9 @@ jobs:
       - name: Run tests
         run: |
           yarn run test:unit
+
+      - name: Report code coverage to Codacy
+        run: |
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r packages/cypress/coverage/lcov.info -r packages/playwright/coverage/lcov.info -r packages/shared/coverage/lcov.info
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.codacyProjectToken }}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ test-archives
 **/playwright/.cache/
 packages/playwright/test-results/
 packages/cypress/tests/cypress/downloads/
+packages/*/coverage/

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -54,7 +54,7 @@
     "build:watch": "yarn build --watch",
     "test:cypress": "start-server-and-test 'yarn run test:server' 3000 'yarn run test:do-cypress'",
     "test:do-cypress": "ELECTRON_EXTRA_LAUNCH_ARGS=--remote-debugging-port=8192 cypress run --project tests",
-    "test:unit": "jest --passWithNoTests",
+    "test:unit": "jest --passWithNoTests --coverage",
     "start": "yarn build:watch",
     "lint": "eslint src/*",
     "prettier": "prettier"

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -42,7 +42,7 @@
     "prebuild": "yarn clean",
     "build": "yarn prebuild && tsup",
     "build:watch": "yarn build --watch",
-    "test:unit": "jest --passWithNoTests",
+    "test:unit": "jest --passWithNoTests --coverage",
     "test:playwright": "playwright test",
     "start": "yarn build:watch",
     "lint": "eslint src/*",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -69,7 +69,7 @@
     "prebuild": "yarn clean",
     "build": "yarn prebuild && tsup",
     "build:watch": "yarn build --watch",
-    "test:unit": "jest",
+    "test:unit": "jest --coverage",
     "lint": "eslint src/*",
     "prettier": "prettier"
   },


### PR DESCRIPTION
Issue: #

## What Changed

This adjusts the `test:unit` scripts to generate coverage reports and upload them to Codacy in the GitHub Action.

## How to test

Go to the Codacy UI for this branch and see the code coverage reported.
