### PR TITLE
fix: `disableAutoSnapshot` not working as expected

### DIFF
--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -24,7 +24,8 @@ afterEach(() => {
   }
   // can we be sure this always fires after all the requests are back?
   cy.document().then((doc) => {
-    const automaticSnapshots = !Cypress.env('disableAutoSnapshot') ? [{ snapshot: snapshot(doc) }] : [];
+    const automaticSnapshots = !Cypress.env('disableAutoSnapshot') 
+      ? [{ snapshot: snapshot(doc) }] : [];
     // @ts-expect-error will fix when Cypress has its own package
     cy.get('@manualSnapshots').then((manualSnapshots = []) => {
       cy.url().then((url) => {

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -19,12 +19,12 @@ beforeEach(() => {
 
 afterEach(() => {
   // don't take snapshots when running `cypress open`
-  if (Cypress.env('disableAutoSnapshot') || !Cypress.config('isTextTerminal')) {
+  if (Cypress.config('isTextTerminal')) {
     return;
   }
   // can we be sure this always fires after all the requests are back?
   cy.document().then((doc) => {
-    const automaticSnapshot = snapshot(doc);
+    const automaticSnapshots = Cypress.env('disableAutoSnapshot') ? [{ snapshot: snapshot(doc) }] : [];
     // @ts-expect-error will fix when Cypress has its own package
     cy.get('@manualSnapshots').then((manualSnapshots = []) => {
       cy.url().then((url) => {
@@ -34,7 +34,7 @@ afterEach(() => {
           payload: {
             // @ts-expect-error relativeToCommonRoot is on spec (but undocumented)
             testTitlePath: [Cypress.spec.relativeToCommonRoot, ...Cypress.currentTest.titlePath],
-            domSnapshots: [...manualSnapshots, { snapshot: automaticSnapshot }],
+            domSnapshots: [...manualSnapshots, ...automaticSnapshots],
             chromaticStorybookParams: {
               ...(Cypress.env('diffThreshold') && { diffThreshold: Cypress.env('diffThreshold') }),
               ...(Cypress.env('delay') && { delay: Cypress.env('delay') }),

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -24,8 +24,9 @@ afterEach(() => {
   }
   // can we be sure this always fires after all the requests are back?
   cy.document().then((doc) => {
-    const automaticSnapshots = !Cypress.env('disableAutoSnapshot') 
-      ? [{ snapshot: snapshot(doc) }] : [];
+    const automaticSnapshots = !Cypress.env('disableAutoSnapshot')
+      ? [{ snapshot: snapshot(doc) }]
+      : [];
     // @ts-expect-error will fix when Cypress has its own package
     cy.get('@manualSnapshots').then((manualSnapshots = []) => {
       cy.url().then((url) => {

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 
 afterEach(() => {
   // don't take snapshots when running `cypress open`
-  if (Cypress.config('isTextTerminal')) {
+  if (!Cypress.config('isTextTerminal')) {
     return;
   }
   // can we be sure this always fires after all the requests are back?

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -24,7 +24,7 @@ afterEach(() => {
   }
   // can we be sure this always fires after all the requests are back?
   cy.document().then((doc) => {
-    const automaticSnapshots = Cypress.env('disableAutoSnapshot') ? [{ snapshot: snapshot(doc) }] : [];
+    const automaticSnapshots = !Cypress.env('disableAutoSnapshot') ? [{ snapshot: snapshot(doc) }] : [];
     // @ts-expect-error will fix when Cypress has its own package
     cy.get('@manualSnapshots').then((manualSnapshots = []) => {
       cy.url().then((url) => {


### PR DESCRIPTION
Issue: https://github.com/chromaui/chromatic-e2e/issues/131

## What Changed

From documentation:

> When `true`, will disable the snapshot that happens automatically at the end of a test when using the Chromatic test fixture.

I believe currently when `disableAutoSnapshot` is set to `true` we are not proceeding to the `prepareArchives` task, so rather than disabling the automatic snapshot we are disabling all snapshots

## How to test

1. set `disableAutoSnapshot: true` globally
2. call `cy.takeSnapshot()`