### PR TITLE
Remove the runtime~main file to render Storybook correctly

### DIFF
--- a/.changeset/ninety-rabbits-peel.md
+++ b/.changeset/ninety-rabbits-peel.md
@@ -1,5 +1,0 @@
----
-'@chromatic-com/shared-e2e': patch
----
-
-Add another file to the reserved pathnames list

--- a/.changeset/ninety-rabbits-peel.md
+++ b/.changeset/ninety-rabbits-peel.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/shared-e2e': patch
+---
+
+Add another file to the reserved pathnames list

--- a/.changeset/thick-months-pay.md
+++ b/.changeset/thick-months-pay.md
@@ -1,0 +1,7 @@
+---
+'@chromatic-com/shared-e2e': patch
+'@chromatic-com/cypress': patch
+'@chromatic-com/playwright': patch
+---
+
+Update for Storybook target

--- a/packages/shared/src/write-archive/archive-file.test.ts
+++ b/packages/shared/src/write-archive/archive-file.test.ts
@@ -97,6 +97,22 @@ describe('ArchiveFile', () => {
 
       expect(filePath).toMatch(new RegExp('/index-[a-z0-9]+.json'));
     });
+
+    it('appends encoded string to reserved SB files: main.iframe', () => {
+      const archiveFile = createArchiveFile('http://localhost:333/main.iframe.bundle.js');
+
+      const filePath = archiveFile.toFileSystemPath();
+
+      expect(filePath).toMatch(new RegExp('/main.iframe.bundle-[a-z0-9]+.js'));
+    });
+
+    it('appends encoded string to reserved SB files: runtime~main.iframe', () => {
+      const archiveFile = createArchiveFile('http://localhost:333/runtime~main.iframe.bundle.js');
+
+      const filePath = archiveFile.toFileSystemPath();
+
+      expect(filePath).toMatch(new RegExp('/runtime~main.iframe.bundle-[a-z0-9]+.js'));
+    });
   });
 
   describe('originalSrc', () => {

--- a/packages/shared/src/write-archive/archive-file.ts
+++ b/packages/shared/src/write-archive/archive-file.ts
@@ -12,8 +12,8 @@ const RESERVED_PATHNAMES: string[] = [
   '/index.json',
   '/iframe.html',
   '/index.html',
-  '/runtime~main.iframe.bundle.js',
   '/main.iframe.bundle.js',
+  '/runtime~main.iframe.bundle.js',
 ];
 
 /**

--- a/packages/shared/src/write-archive/archive-file.ts
+++ b/packages/shared/src/write-archive/archive-file.ts
@@ -12,8 +12,8 @@ const RESERVED_PATHNAMES: string[] = [
   '/index.json',
   '/iframe.html',
   '/index.html',
-  'runtime~main.iframe.bundle.js',
-  'main.iframe.bundle.js',
+  '/runtime~main.iframe.bundle.js',
+  '/main.iframe.bundle.js',
 ];
 
 /**

--- a/packages/shared/src/write-archive/archive-file.ts
+++ b/packages/shared/src/write-archive/archive-file.ts
@@ -13,6 +13,7 @@ const RESERVED_PATHNAMES: string[] = [
   '/iframe.html',
   '/index.html',
   'runtime~main.iframe.bundle.js',
+  'main.iframe.bundle.js',
 ];
 
 /**

--- a/packages/shared/src/write-archive/archive-file.ts
+++ b/packages/shared/src/write-archive/archive-file.ts
@@ -12,6 +12,7 @@ const RESERVED_PATHNAMES: string[] = [
   '/index.json',
   '/iframe.html',
   '/index.html',
+  'runtime~main.iframe.bundle.js',
 ];
 
 /**


### PR DESCRIPTION
Issue: #

## What Changed

<!-- Insert a description below. -->

We have one additional file that needs to be excluded for E2E target storybooks to render correctly.
## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
