### PR TITLE
Avoid EISDIR errors by always adding a file extension to archived files

### DIFF
--- a/.changeset/soft-kangaroos-argue.md
+++ b/.changeset/soft-kangaroos-argue.md
@@ -1,0 +1,6 @@
+---
+'@chromatic-com/cypress': patch
+'@chromatic-com/playwright': patch
+---
+
+Fix EISDIR errors caused by file and directory names colliding when writing archived assets to disk

--- a/packages/shared/src/write-archive/archive-file.test.ts
+++ b/packages/shared/src/write-archive/archive-file.test.ts
@@ -60,7 +60,7 @@ describe('ArchiveFile', () => {
       expect(filePath).toEqual('/some/directory/ok.png');
     });
 
-    it('does not add a file extension when response has no content type', () => {
+    it('adds a default tmp file extension when response has no content type', () => {
       const noContentType = { ...response };
       delete noContentType.contentType;
 
@@ -71,7 +71,7 @@ describe('ArchiveFile', () => {
 
       const filePath = archiveFile.toFileSystemPath();
 
-      expect(filePath).toEqual('/some/directory/ok');
+      expect(filePath).toEqual('/some/directory/ok.tmp');
     });
 
     it('prepends domain name (if archiving additional domains)', () => {

--- a/packages/shared/src/write-archive/archive-file.ts
+++ b/packages/shared/src/write-archive/archive-file.ts
@@ -103,15 +103,13 @@ export class ArchiveFile {
   }
 
   private addExtension(pathname: string) {
-    if ('error' in this.response || !this.response.contentType) return pathname;
+    if ('error' in this.response) return pathname;
 
     // Add an extension if needed
     let nameWithExtension = pathname;
     if (!path.extname(nameWithExtension)) {
-      const fileExtension = mime.getExtension(this.response.contentType);
-      if (fileExtension) {
-        nameWithExtension = `${pathname}.${fileExtension}`;
-      }
+      const fileExtension = mime.getExtension(this.response.contentType) || 'tmp';
+      nameWithExtension = `${pathname}.${fileExtension}`;
     }
 
     return nameWithExtension;

--- a/test-server/fixtures/asset-paths/asset-at-directory-name.html
+++ b/test-server/fixtures/asset-paths/asset-at-directory-name.html
@@ -3,5 +3,7 @@
   <body>    
     <img src="/img"/>
     <img src="/img/another"/>
+    <img src="/img/another/no-content-type/first"/>
+    <img src="/img/another/no-content-type"/>
   </body>
 </html>

--- a/test-server/server.js
+++ b/test-server/server.js
@@ -33,6 +33,16 @@ app.get('/img/another', (req, res) => {
   res.sendFile(path.join(__dirname, 'fixtures/pink.png'));
 });
 
+app.get('/img/another/no-content-type', (req, res) => {
+  res.setHeader('content-type', 'fake/content'); // Simulate no matching file extension from mime lib
+  res.sendFile(path.join(__dirname, 'fixtures/purple.png'));
+});
+
+app.get('/img/another/no-content-type/first', (req, res) => {
+  res.setHeader('content-type', 'fake/content'); // Simulate no matching file extension from mime lib
+  res.sendFile(path.join(__dirname, 'fixtures/blue.png'));
+});
+
 app.get('/img/another%Cwith%Cpercents', (req, res) => {
   res.sendFile(path.join(__dirname, 'fixtures/pink.png'));
 });


### PR DESCRIPTION
Issue: #

## What Changed

<!-- Insert a description below. -->

Ensures there's always a file extension even when there's no file extension found for a given content type to avoid EISDIR errors on file/directory collisions.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
* Pull this down, revert the fix in `archive-file.ts`, run `yarn build && yarn test:playwright`, see `EISDIR` errors
* Put the fix back in place, rebuild and rerun playwright tests, see all is 💯 
