### PR TITLE
pin rrweb-snapshot version to fix import error

### DIFF
--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -68,7 +68,7 @@
     "@storybook/csf": "^0.1.0",
     "@storybook/manager-api": "^8.1.5",
     "@storybook/server-webpack5": "^8.1.5",
-    "rrweb-snapshot": "^2.0.0-alpha.11",
+    "rrweb-snapshot": "2.0.0-alpha.14",
     "storybook": "^8.1.5",
     "ts-dedent": "^2.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3604,7 +3604,7 @@ __metadata:
     express: "npm:^4.18.2"
     playwright: "npm:^1.32.2"
     playwright-core: "npm:^1.32.2"
-    rrweb-snapshot: "npm:^2.0.0-alpha.11"
+    rrweb-snapshot: "npm:2.0.0-alpha.14"
     storybook: "npm:^8.1.5"
     ts-dedent: "npm:^2.2.0"
   peerDependencies:
@@ -17291,6 +17291,13 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: f8311b90e8d4cc46abbc14c3b292c4992438f5fd7e821d2094a7e940eaf6f67af2850c209f6412c2de5b66b4110af25226374950e90a3b3085929c104b127d48
+  languageName: node
+  linkType: hard
+
+"rrweb-snapshot@npm:2.0.0-alpha.14":
+  version: 2.0.0-alpha.14
+  resolution: "rrweb-snapshot@npm:2.0.0-alpha.14"
+  checksum: 977a87df4ba00f1a5cd1f13cca61532dd5a9c9baeb21715f8394a6aaa1daf9d47f27280f86915e7cc312eb7a0b92cc25d5eb4d6ccf9dc4fdd5de35347aafdaac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: https://chromaticqa.slack.com/archives/C04QR9ZN6A0/p1718300982485899

`rrweb-snapshot` version `2.0.0-alpha.15` added an `exports` field to their `package.json` which is breaking the import within our playwright package. When running Playwright tests, using `@chromatic-com/playwright`, we get this error:

```
Error: Package subpath './dist/rrweb-snapshot.js' is not defined by "exports" in /mealdrop-demo/node_modules/rrweb-snapshot/package.json
```

## What Changed

Pinned `rrweb-snapshot` version to `2.0.0-alpha.14` 

## How to test

Playwright tests with using `@chromatic-com/playwright` should run successfully 