### PR TITLE
Remove the  sb-preview/runtime.js file to render Storybook correctly

### DIFF
--- a/.changeset/cuddly-snails-remember.md
+++ b/.changeset/cuddly-snails-remember.md
@@ -1,5 +1,7 @@
 ---
 '@chromatic-com/shared-e2e': patch
+'@chromatic-com/cypress': patch
+'@chromatic-com/playwright': patch
 ---
 
 We have one additional file that needs to be excluded for E2E target storybooks to render correctly.

--- a/.changeset/warm-donkeys-build.md
+++ b/.changeset/warm-donkeys-build.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/shared-e2e': patch
+---
+
+We have one additional file that needs to be excluded for E2E target storybooks to render correctly.

--- a/packages/shared/src/write-archive/archive-file.test.ts
+++ b/packages/shared/src/write-archive/archive-file.test.ts
@@ -113,6 +113,14 @@ describe('ArchiveFile', () => {
 
       expect(filePath).toMatch(new RegExp('/runtime~main.iframe.bundle-[a-z0-9]+.js'));
     });
+
+    it('appends encoded string to reserved SB files: sb-preview/runtime.js', () => {
+      const archiveFile = createArchiveFile('http://localhost:333/sb-preview/runtime.js');
+
+      const filePath = archiveFile.toFileSystemPath();
+
+      expect(filePath).toMatch(new RegExp('/sb-preview/runtime-[a-z0-9]+.js'));
+    });
   });
 
   describe('originalSrc', () => {

--- a/packages/shared/src/write-archive/archive-file.ts
+++ b/packages/shared/src/write-archive/archive-file.ts
@@ -14,6 +14,7 @@ const RESERVED_PATHNAMES: string[] = [
   '/index.html',
   '/main.iframe.bundle.js',
   '/runtime~main.iframe.bundle.js',
+  '/sb-preview/runtime.js',
 ];
 
 /**


### PR DESCRIPTION
Issue: #AP-4700

## What Changed

<!-- Insert a description below. -->

Added another file to exclude from the archive when targeting a Storybook.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
