### PR TITLE
Use configured `downloadsFolder` for Cypress

### DIFF
--- a/.changeset/slimy-cups-protect.md
+++ b/.changeset/slimy-cups-protect.md
@@ -1,0 +1,6 @@
+---
+'@chromatic-com/playwright': patch
+'@chromatic-com/cypress': patch
+---
+
+Use the configured `downloadsFolder` in Cypress as the output dir for archives

--- a/.changeset/slimy-cups-protect.md
+++ b/.changeset/slimy-cups-protect.md
@@ -3,4 +3,5 @@
 '@chromatic-com/cypress': patch
 ---
 
-Use the configured `downloadsFolder` in Cypress as the output dir for archives
+- Use the configured `downloadsFolder` in Cypress as the output dir for archives
+- Move Playwright-related path logic out of the shared package into the Playwright package

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ test-archives
 **/playwright/.cache/
 packages/playwright/test-results/
 packages/cypress/tests/cypress/downloads/
-packages/cypress/tests/cypress/new-downloads/
+packages/cypress/tests/cypress/test-downloads/
 packages/*/coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ test-archives
 **/playwright/.cache/
 packages/playwright/test-results/
 packages/cypress/tests/cypress/downloads/
+packages/cypress/tests/cypress/new-downloads/
 packages/*/coverage/

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "archive-storybook:playwright": "CHROMATIC_ARCHIVE_LOCATION=packages/playwright/test-results packages/playwright/dist/bin/archive-storybook.js",
     "build-archive-storybook:playwright": "CHROMATIC_ARCHIVE_LOCATION=packages/playwright/test-results packages/playwright/dist/bin/build-archive-storybook.js",
-    "archive-storybook:cypress": "CHROMATIC_ARCHIVE_LOCATION=packages/cypress/tests/cypress/new-downloads packages/cypress/dist/bin/archive-storybook.js",
-    "build-archive-storybook:cypress": "CHROMATIC_ARCHIVE_LOCATION=packages/cypress/tests/cypress/new-downloads packages/cypress/dist/bin/build-archive-storybook.js",
+    "archive-storybook:cypress": "CHROMATIC_ARCHIVE_LOCATION=packages/cypress/tests/cypress/test-downloads packages/cypress/dist/bin/archive-storybook.js",
+    "build-archive-storybook:cypress": "CHROMATIC_ARCHIVE_LOCATION=packages/cypress/tests/cypress/test-downloads packages/cypress/dist/bin/build-archive-storybook.js",
     "clean": "yarn workspaces foreach --all --parallel run clean",
     "prebuild": "yarn clean",
     "build": "yarn workspaces foreach --all --topological-dev --parallel run build",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "archive-storybook:playwright": "CHROMATIC_ARCHIVE_LOCATION=packages/playwright/test-results packages/playwright/dist/bin/archive-storybook.js",
     "build-archive-storybook:playwright": "CHROMATIC_ARCHIVE_LOCATION=packages/playwright/test-results packages/playwright/dist/bin/build-archive-storybook.js",
-    "archive-storybook:cypress": "CHROMATIC_ARCHIVE_LOCATION=packages/cypress/tests/cypress/downloads packages/cypress/dist/bin/archive-storybook.js",
-    "build-archive-storybook:cypress": "CHROMATIC_ARCHIVE_LOCATION=packages/cypress/tests/cypress/downloads packages/cypress/dist/bin/build-archive-storybook.js",
+    "archive-storybook:cypress": "CHROMATIC_ARCHIVE_LOCATION=packages/cypress/tests/cypress/new-downloads packages/cypress/dist/bin/archive-storybook.js",
+    "build-archive-storybook:cypress": "CHROMATIC_ARCHIVE_LOCATION=packages/cypress/tests/cypress/new-downloads packages/cypress/dist/bin/build-archive-storybook.js",
     "clean": "yarn workspaces foreach --all --parallel run clean",
     "prebuild": "yarn clean",
     "build": "yarn workspaces foreach --all --topological-dev --parallel run build",

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -21,6 +21,7 @@ interface WriteParams {
   chromaticStorybookParams: ChromaticStorybookParameters;
   pageUrl: string;
   viewport: Viewport;
+  outputDir: string;
 }
 
 interface WriteArchivesParams extends WriteParams {
@@ -34,6 +35,7 @@ const writeArchives = async ({
   chromaticStorybookParams,
   pageUrl,
   viewport,
+  outputDir,
 }: WriteArchivesParams) => {
   const bufferedArchiveList = Object.entries(resourceArchive).map(([key, value]) => {
     return [
@@ -59,9 +61,7 @@ const writeArchives = async ({
   await writeTestResult(
     {
       titlePath: testTitlePath,
-      // this will store it at ./cypress/downloads (the last directory doesn't matter)
-      // TODO: change so we don't have to do this trickery
-      outputDir: './cypress/downloads/some',
+      outputDir,
       pageUrl,
       viewport,
     },

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -60,6 +60,7 @@ afterEach(() => {
               height: Cypress.config('viewportHeight'),
               width: Cypress.config('viewportWidth'),
             },
+            outputDir: Cypress.config('downloadsFolder'),
           },
         });
       });

--- a/packages/cypress/tests/cypress.config.ts
+++ b/packages/cypress/tests/cypress.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'cypress';
 import { installPlugin } from '../dist';
+import { existsSync } from 'node:fs';
 
 export default defineConfig({
+  // `downloadsFolder` cannot be overridden in tests, so we're setting
+  // this to a non-default value for asserting in the tests
+  downloadsFolder: 'cypress/new-downloads',
   // needed since we use common mock images between Cypress and Playwright
   fixturesFolder: '../../../test-server/fixtures',
   screenshotOnRunFailure: false,
@@ -11,7 +15,7 @@ export default defineConfig({
       installPlugin(on, config);
       on('task', {
         directoryExists(directoryName) {
-          return true;
+          return existsSync(directoryName);
         },
       });
     },

--- a/packages/cypress/tests/cypress.config.ts
+++ b/packages/cypress/tests/cypress.config.ts
@@ -5,7 +5,7 @@ import { existsSync } from 'node:fs';
 export default defineConfig({
   // `downloadsFolder` cannot be overridden in tests, so we're setting
   // this to a non-default value for asserting in the tests
-  downloadsFolder: 'cypress/new-downloads',
+  downloadsFolder: 'cypress/test-downloads',
   // needed since we use common mock images between Cypress and Playwright
   fixturesFolder: '../../../test-server/fixtures',
   screenshotOnRunFailure: false,

--- a/packages/cypress/tests/cypress.config.ts
+++ b/packages/cypress/tests/cypress.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
     baseUrl: 'http://localhost:3000',
     setupNodeEvents(on, config) {
       installPlugin(on, config);
+      on('task', {
+        directoryExists(directoryName) {
+          return true;
+        },
+      });
     },
   },
 });

--- a/packages/cypress/tests/cypress/e2e/custom-downloads-directory.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/custom-downloads-directory.cy.ts
@@ -1,3 +1,5 @@
+// Snapshots are disabled because we're asserting on file system concerns,
+// not testing anything visual
 it(
   'downloads archives to the user-specified folder',
   { env: { disableAutoSnapshot: true } },
@@ -5,7 +7,7 @@ it(
     cy.visit('/asset-paths/query-params');
     const chromaticArchivesDir = `${Cypress.config('downloadsFolder')}/chromatic-archives`;
     cy.task('directoryExists', chromaticArchivesDir).then((dirExists) => {
-      expect(dirExists).true;
+      expect(dirExists).to.be.true;
     });
   }
 );

--- a/packages/cypress/tests/cypress/e2e/custom-downloads-directory.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/custom-downloads-directory.cy.ts
@@ -1,0 +1,7 @@
+context('using Cypress.config', () => {
+  it('Downloads archives to the user-specified folder', () => {
+    cy.visit('/viewports');
+    const dirExists = cy.task('directoryExists', '/some-dir');
+    console.log('DIRECTORY EXISTS', dirExists);
+  });
+});

--- a/packages/cypress/tests/cypress/e2e/custom-downloads-directory.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/custom-downloads-directory.cy.ts
@@ -1,7 +1,9 @@
 context('using Cypress.config', () => {
   it('Downloads archives to the user-specified folder', () => {
     cy.visit('/viewports');
-    const dirExists = cy.task('directoryExists', '/some-dir');
-    console.log('DIRECTORY EXISTS', dirExists);
+    const chromaticArchivesDir = `${Cypress.config('downloadsFolder')}/chromatic-archives`;
+    cy.task('directoryExists', chromaticArchivesDir).then((dirExists) => {
+      expect(dirExists).true;
+    });
   });
 });

--- a/packages/cypress/tests/cypress/e2e/custom-downloads-directory.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/custom-downloads-directory.cy.ts
@@ -1,9 +1,11 @@
-context('using Cypress.config', () => {
-  it('Downloads archives to the user-specified folder', () => {
-    cy.visit('/viewports');
+it(
+  'downloads archives to the user-specified folder',
+  { env: { disableAutoSnapshot: true } },
+  () => {
+    cy.visit('/asset-paths/query-params');
     const chromaticArchivesDir = `${Cypress.config('downloadsFolder')}/chromatic-archives`;
     cy.task('directoryExists', chromaticArchivesDir).then((dirExists) => {
       expect(dirExists).true;
     });
-  });
-});
+  }
+);

--- a/packages/playwright/src/makeTest.ts
+++ b/packages/playwright/src/makeTest.ts
@@ -14,6 +14,7 @@ import {
   trackRun,
   DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS,
 } from '@chromatic-com/shared-e2e';
+import { join } from 'node:path';
 import { chromaticSnapshots, takeSnapshot } from './takeSnapshot';
 import { createResourceArchive } from './createResourceArchive';
 
@@ -72,8 +73,11 @@ export const performChromaticSnapshot = async (
       ...(cropToViewport && { cropToViewport }),
     };
 
+    // TestInfo.outputDir gives us the test-specific subfolder (https://playwright.dev/docs/api/class-testconfig#test-config-output-dir);
+    // we want to write one level above that
+    const outputDir = join(testInfo.outputDir, '..');
     await writeTestResult(
-      { ...testInfo, pageUrl: page.url(), viewport: page.viewportSize() },
+      { ...testInfo, outputDir, pageUrl: page.url(), viewport: page.viewportSize() },
       Object.fromEntries(snapshots),
       resourceArchive,
       chromaticStorybookParams

--- a/packages/shared/src/write-archive/index.test.ts
+++ b/packages/shared/src/write-archive/index.test.ts
@@ -34,7 +34,7 @@ describe('writeTestResult', () => {
       // the default output directory in playwright
       {
         titlePath: ['file.spec.ts', 'Test Story'],
-        outputDir: resolve('test-results/test-story-chromium'),
+        outputDir: resolve('test-results'),
         pageUrl: 'http://localhost:3000/',
         viewport: { height: 800, width: 800 },
       },
@@ -90,7 +90,7 @@ describe('writeTestResult', () => {
       // the default output directory in playwright
       {
         titlePath: ['file.spec.ts', 'Toy Story'],
-        outputDir: resolve('test-results/toy-story-chromium'),
+        outputDir: resolve('test-results'),
         pageUrl: 'http://localhost:3000/',
         viewport: { height: 800, width: 800 },
       },
@@ -127,7 +127,7 @@ describe('writeTestResult', () => {
       {
         titlePath: ['file.spec.ts', 'Test Story'],
         // simulates setting a custom output directory in Playwright
-        outputDir: resolve('some-custom-directory/directory/test-story-chromium'),
+        outputDir: resolve('some-custom-directory/directory'),
         pageUrl: 'http://localhost:3000/',
         viewport: { height: 800, width: 800 },
       },
@@ -151,7 +151,7 @@ describe('writeTestResult', () => {
       await writeTestResult(
         {
           titlePath: ['file.spec.ts', 'A grouping', 'Test Story'],
-          outputDir: resolve('test-results/test-story-chromium'),
+          outputDir: resolve('test-results'),
           pageUrl: 'http://localhost:3000/',
           viewport: { height: 800, width: 800 },
         },
@@ -177,7 +177,7 @@ describe('writeTestResult', () => {
             '.someFunction',
             '.someFunction() calls something',
           ],
-          outputDir: resolve('test-results/test-story-chromium'),
+          outputDir: resolve('test-results'),
           pageUrl: 'http://localhost:3000/',
           viewport: { height: 800, width: 800 },
         },
@@ -199,7 +199,7 @@ describe('writeTestResult', () => {
       await writeTestResult(
         {
           titlePath: ['some.file.spec.ts', 'Test Story'],
-          outputDir: resolve('test-results/test-story-chromium'),
+          outputDir: resolve('test-results'),
           pageUrl: 'http://localhost:3000/',
           viewport: { height: 800, width: 800 },
         },
@@ -221,7 +221,7 @@ describe('writeTestResult', () => {
       await writeTestResult(
         {
           titlePath: ['some.file.cy.ts', 'Test Story'],
-          outputDir: resolve('test-results/test-story-chromium'),
+          outputDir: resolve('test-results'),
           pageUrl: 'http://localhost:3000/',
           viewport: { height: 800, width: 800 },
         },
@@ -243,7 +243,7 @@ describe('writeTestResult', () => {
       await writeTestResult(
         {
           titlePath: ['file.ts', 'Test Story'],
-          outputDir: resolve('test-results/test-story-chromium'),
+          outputDir: resolve('test-results'),
           pageUrl: 'http://localhost:3000/',
           viewport: { height: 800, width: 800 },
         },

--- a/packages/shared/src/write-archive/index.ts
+++ b/packages/shared/src/write-archive/index.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { outputFile, ensureDir, outputJSONFile } from '../utils/filePaths';
 import { logger } from '../utils/logger';
 import { ArchiveFile } from './archive-file';

--- a/packages/shared/src/write-archive/index.ts
+++ b/packages/shared/src/write-archive/index.ts
@@ -38,9 +38,7 @@ export async function writeTestResult(
   );
   // in Storybook, `/` splits the title out into hierarchies (folders)
   const title = titlePathWithoutFileExtensions.join('/');
-  // outputDir gives us the test-specific subfolder (https://playwright.dev/docs/api/class-testconfig#test-config-output-dir);
-  // we want to write one level above that
-  const finalOutputDir = join(outputDir, '..', 'chromatic-archives');
+  const finalOutputDir = join(outputDir, 'chromatic-archives');
 
   const archiveDir = join(finalOutputDir, 'archive');
 


### PR DESCRIPTION
Issue: #

## What Changed

The Cypress integration was hardcoded to use Cypress's default value for `downloadsFolder`, `cypress/downloads`. Changes to that in the Cypress config would not be respected, and archive files would always be written to the default. 

This fixes that by reading the correct value from the Cypress config object. 

<!-- Insert a description below. -->

## How to test

* Set `downloadsFolder` to a non-default value in `cypress.config.ts`
* Run Cypress tests, ensure Chromatic archives ouput in the directory set above, not in `cypress/downloads`
* Run a Chromatic build, ensure all is 💯 

<!-- Add an explanation below for the reviewers to help them test your changes. -->
