### PR TITLE
Add failing iframe tests

### DIFF
--- a/packages/playwright/tests/iframe.spec.ts
+++ b/packages/playwright/tests/iframe.spec.ts
@@ -1,0 +1,25 @@
+import { test } from '../src';
+
+// Required for the skipped cross-origin test below
+// test.use({
+//   launchOptions: {
+//     args: ['--disable-web-security'],
+//   }
+// });
+
+test('DOES NOT snapshot iframe contents when same-origin', async ({ page }) => {
+  await page.goto('/iframe-same-origin');
+  await page
+    .frameLocator('iframe[title="the-iframe"]')
+    .getByRole('button', { name: 'The Button' })
+    .click();
+});
+
+test.skip('DOES NOT snapshot iframe contents when cross-origin', async ({ page }) => {
+  await page.goto('/iframe-cross-origin');
+  await page.evaluate(() => {
+    // trigger cross-origin security error (unless `disable-web-security` is set):
+    // Failed to read a named property 'document' from 'Window': Blocked a frame with origin "http://localhost:3000" from accessing a cross-origin frame
+    return document?.querySelector('iframe')?.contentWindow?.document.getElementsByTagName('span');
+  });
+});

--- a/test-server/fixtures/pages/iframe-content.html
+++ b/test-server/fixtures/pages/iframe-content.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+  <head>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body>
+    <div class="flex justify-between m-10">
+      <div><img src="/img?url=fixtures/blue.png"/></div>
+      <div><img src="/img?url=fixtures/pink.png"/></div>
+      <div><img src="/img?url=fixtures/purple.png"/></div>
+    </div>
+    <p>
+      <button id="the-button" onclick="alert('hello!')">The Button</button>
+    </p>
+  </body>
+</html>

--- a/test-server/fixtures/pages/iframe-cross-origin.html
+++ b/test-server/fixtures/pages/iframe-cross-origin.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    <iframe id="the-iframe" src="https://www.chromatic.com"></iframe>
+  </body>
+</html>

--- a/test-server/fixtures/pages/iframe-same-origin.html
+++ b/test-server/fixtures/pages/iframe-same-origin.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    <iframe title="the-iframe" src="/iframe-content" width="700px" height="500px"></iframe>
+  </body>
+</html>

--- a/test-server/server.js
+++ b/test-server/server.js
@@ -104,6 +104,11 @@ app.get('/manual-snapshots', (req, res) => {
   res.sendFile(path.join(__dirname, 'fixtures/manual-snapshots.html'));
 });
 
+// Pages fallback
+app.get('/:page', (req, res) => {
+  res.sendFile(path.join(__dirname, `fixtures/pages/${req.params.page}.html`));
+});
+
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`);
 });


### PR DESCRIPTION
Issue: #

## What Changed

Add failing tests that can be used when we try to add support for capturing iframe contents.

<!-- Insert a description below. -->

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
