### PR TITLE
Network idle watcher for Cypress

### DIFF
--- a/packages/cypress/src/network-idle-watcher.test.ts
+++ b/packages/cypress/src/network-idle-watcher.test.ts
@@ -1,0 +1,76 @@
+import { NetworkIdleWatcher } from './network-idle-watcher';
+
+jest.useFakeTimers();
+
+it('Resolves when there is no network activity', async () => {
+  const watcher = new NetworkIdleWatcher();
+  await expect(watcher.idle()).resolves.toBeDefined();
+});
+
+it('Resolves when there is a single request and response', async () => {
+  const watcher = new NetworkIdleWatcher();
+
+  watcher.onRequest();
+  watcher.onResponse();
+
+  await expect(watcher.idle()).resolves.toBeDefined();
+});
+
+it('Resolves when there are an equal amount of requests and responses', async () => {
+  const watcher = new NetworkIdleWatcher();
+  // in total 4 requests, and 4 responses
+  watcher.onRequest();
+  watcher.onResponse();
+
+  watcher.onRequest();
+  watcher.onResponse();
+
+  watcher.onRequest();
+  watcher.onRequest();
+
+  watcher.onResponse();
+  watcher.onResponse();
+
+  await expect(watcher.idle()).resolves.toBeDefined();
+});
+
+it('Rejects if response never sent for request', async () => {
+  const watcher = new NetworkIdleWatcher();
+  // fire off request
+  watcher.onRequest();
+  const promise = watcher.idle();
+  jest.runAllTimers();
+  // no response fired off
+  await expect(promise).rejects.toBeDefined();
+});
+
+it("Resolves if response hasn't happened at time of idle(), but comes back before timeout", async () => {
+  const watcher = new NetworkIdleWatcher();
+  // fire off request
+  watcher.onRequest();
+
+  const promise = watcher.idle();
+
+  watcher.onResponse();
+  // makes sure we finish the idle watcher as soon as the reponse comes back, and not waiting the full timeout duration
+  jest.advanceTimersByTime(1);
+
+  await expect(promise).resolves.toBeDefined();
+});
+
+it("Rejects if response hasn't happened at time of idle(), and doesn't come back before timeout", async () => {
+  const watcher = new NetworkIdleWatcher();
+  // fire off request
+  watcher.onRequest();
+
+  const promise = watcher.idle();
+
+  // response returns after idle() has been called, but will take too long
+  setTimeout(() => {
+    watcher.onResponse();
+  }, 10000);
+
+  jest.runAllTimers();
+
+  await expect(promise).rejects.toBeDefined();
+});

--- a/packages/cypress/src/network-idle-watcher.ts
+++ b/packages/cypress/src/network-idle-watcher.ts
@@ -1,0 +1,39 @@
+const TOTAL_TIMEOUT_DURATION = 3000;
+
+export class NetworkIdleWatcher {
+  private numInFlightRequests = 0;
+
+  private idleTimer: NodeJS.Timeout | null = null;
+
+  private exitIdleOnResponse: () => void | null = null;
+
+  async idle() {
+    return new Promise((resolve, reject) => {
+      if (this.numInFlightRequests === 0) {
+        resolve(true);
+      } else {
+        this.idleTimer = setTimeout(() => {
+          reject(new Error('some responses have not returned'));
+        }, TOTAL_TIMEOUT_DURATION);
+
+        // assign a function that resolves... and it can be used...
+        this.exitIdleOnResponse = () => {
+          resolve(true);
+        };
+      }
+    });
+  }
+
+  onRequest() {
+    this.numInFlightRequests += 1;
+  }
+
+  onResponse() {
+    this.numInFlightRequests -= 1;
+    // resolve if the in-flight request amount is now zero
+    if (this.numInFlightRequests === 0) {
+      clearTimeout(this.idleTimer);
+      this.exitIdleOnResponse?.();
+    }
+  }
+}

--- a/packages/cypress/src/network-idle-watcher.ts
+++ b/packages/cypress/src/network-idle-watcher.ts
@@ -1,5 +1,8 @@
 const TOTAL_TIMEOUT_DURATION = 3000;
 
+// A Cypress equivalent of Playwright's `page.waitForLoadState()` (https://playwright.dev/docs/api/class-page#page-wait-for-load-state).
+// Intentionally simplistic since in Cypress this is just used to make sure there aren't any pending requests hanging around
+// after the test has finished.
 export class NetworkIdleWatcher {
   private numInFlightRequests = 0;
 
@@ -16,7 +19,7 @@ export class NetworkIdleWatcher {
           reject(new Error('some responses have not returned'));
         }, TOTAL_TIMEOUT_DURATION);
 
-        // assign a function that resolves... and it can be used...
+        // assign a function that'll be called as soon as responses are all back
         this.exitIdleOnResponse = () => {
           resolve(true);
         };
@@ -30,7 +33,7 @@ export class NetworkIdleWatcher {
 
   onResponse() {
     this.numInFlightRequests -= 1;
-    // resolve if the in-flight request amount is now zero
+    // resolve immediately if the in-flight request amount is now zero
     if (this.numInFlightRequests === 0) {
       clearTimeout(this.idleTimer);
       this.exitIdleOnResponse?.();


### PR DESCRIPTION
Issue: #AP-3843

## What Changed

<!-- Insert a description below. -->
Created a `NetworkIdleWatcher` class for Cypress that approximates what `page.waitForLoadState('networkIdle')` [does](https://github.com/chromaui/chromatic-e2e/blob/main/packages/playwright/src/createResourceArchive.ts#L28) in [Playwright](https://playwright.dev/docs/api/class-page#page-wait-for-load-state).

It's a very simplistic class since we're only using it _after_ the Cypress test has run, to wait longer if there are any pending requests.

## Limitations

This class isn't used anywhere yet. In a following PR I'll hook it up so the `onRequest` and `onResponse` callbacks are accepted as parameters into the `ResourceArchiver()` constructor, so that when the CDP detects requests or responses, there's a callback to the `NetworkIdleWatcher`. Then, when the test is done, we'll call `await networkIdleWatcher.idle()`, like we do for [Playwright](https://github.com/chromaui/chromatic-e2e/blob/main/packages/playwright/src/createResourceArchive.ts#L50).


## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
Run the unit tests! As in, have CI run them for you 😜 
