### PR TITLE
Fix errors creating snapshot and stories files due to long test names

### DIFF
--- a/.changeset/lemon-otters-march.md
+++ b/.changeset/lemon-otters-march.md
@@ -1,0 +1,7 @@
+---
+'@chromatic-com/playwright': patch
+'@chromatic-com/cypress': patch
+'@chromatic-com/shared-e2e': patch
+---
+
+Fix ENAMETOOLONG errors by truncating snapshot and stories file names to ensure they are not too long to be written to the file system

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -6,3 +6,5 @@ engines:
       - 'packages/playwright/tests/**/*.spec.*'
       - 'packages/cypress/tests/cypress/e2e/*.cy.*'
       - 'packages/cypress/tests/cypress/e2e/**/*.cy.*'
+      - 'packages/**/*.test.*'
+      

--- a/packages/cypress/tests/cypress/e2e/long-test-names.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/long-test-names.cy.ts
@@ -1,0 +1,5 @@
+describe('this is a very long story name it just keeps going and going and it cannot stop and it will not stop ba bada da da dum dum dum', () => {
+  it('and this is also an incredibly long test name because there are just a bunch of random chars at the end like this ldlk elke lekj felk felkf lkf lsf lkef lse flskef ls fls eflsj flksef', () => {
+    cy.visit('/');
+  });
+});

--- a/packages/cypress/tests/cypress/e2e/long-test-names.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/long-test-names.cy.ts
@@ -2,4 +2,8 @@ describe('this is a very long story name it just keeps going and going and it ca
   it('and this is also an incredibly long test name because there are just a bunch of random chars at the end like this ldlk elke lekj felk felkf lkf lsf lkef lse flskef ls fls eflsj flksef', () => {
     cy.visit('/');
   });
+
+  it('and this is also an incredibly long test name because there are just a bunch of random chars at the end like this ldlk elke lekj felk felkf lkf lsf lkef lse flskef ls fls eflsj flksef 2', () => {
+    cy.visit('/');
+  });
 });

--- a/packages/playwright/tests/long-test-names.spec.ts
+++ b/packages/playwright/tests/long-test-names.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '../src';
+
+test.describe('this is a very long story name it just keeps going and going and it cannot stop and it will not stop ba bada da da dum dum dum', () => {
+  test('and this is also an incredibly long test name because there are just a bunch of random chars at the end like this ldlk elke lekj felk felkf lkf lsf lkef lse flskef ls fls eflsj flksef', async ({
+    page,
+  }) => {
+    await page.goto('/');
+  });
+});

--- a/packages/playwright/tests/long-test-names.spec.ts
+++ b/packages/playwright/tests/long-test-names.spec.ts
@@ -6,4 +6,10 @@ test.describe('this is a very long story name it just keeps going and going and 
   }) => {
     await page.goto('/');
   });
+
+  test('and this is also an incredibly long test name because there are just a bunch of random chars at the end like this ldlk elke lekj felk felkf lkf lsf lkef lse flskef ls fls eflsj flksef 2', async ({
+    page,
+  }) => {
+    await page.goto('/');
+  });
 });

--- a/packages/shared/src/utils/filePaths.ts
+++ b/packages/shared/src/utils/filePaths.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync } from 'fs';
 import { readFile, writeFile } from 'fs/promises';
+import { createHash } from 'node:crypto';
 import path from 'path';
 
 function rootDir() {
@@ -47,4 +48,37 @@ export async function outputJSONFile(filePath: string, data: any) {
 export async function readJSONFile(filePath: string) {
   const data = await readFile(filePath);
   return JSON.parse(data.toString());
+}
+
+// Generates a fixed length hash for the given `data`
+function hash(data: string) {
+  // `outputLength` of 2 bytes is 4 chars
+  return createHash('shake256', { outputLength: 2 }).update(data).digest('hex');
+}
+
+// 255 is a good upper bound on file name size to work on most platforms
+export const MAX_FILE_NAME_LENGTH = 255;
+
+// Ensures that the file name part on the given `filePath` is not longer
+// than the given `maxLength`. If truncation is necessary, a hash is added
+// to avoid collisions on the file system.
+export function truncateFileName(filePath: string, maxLength: number = MAX_FILE_NAME_LENGTH) {
+  const filePathParts = filePath.split('/');
+  const fileName = filePathParts.pop();
+  if (fileName.length <= maxLength) {
+    return filePath;
+  }
+
+  const hashedFileName = hash(fileName);
+  const [baseName, ...extensions] = fileName.split('.');
+  const ext = extensions.join('.');
+  const extLength = ext.length === 0 ? 0 : ext.length + 1; // +1 for leading `.` if needed
+
+  const lengthHashAndExt = hashedFileName.length + extLength;
+  const truncatedBaseName = baseName.slice(0, maxLength - lengthHashAndExt);
+  const truncatedFileName = [`${truncatedBaseName}${hashedFileName}`, ext]
+    .filter(Boolean)
+    .join('.');
+
+  return [...filePathParts, truncatedFileName].join('/');
 }

--- a/packages/shared/src/utils/filePaths.ts
+++ b/packages/shared/src/utils/filePaths.ts
@@ -60,8 +60,10 @@ function hash(data: string) {
 export const MAX_FILE_NAME_LENGTH = 255;
 
 // Ensures that the file name part on the given `filePath` is not longer
-// than the given `maxLength`. If truncation is necessary, a hash is added
-// to avoid collisions on the file system.
+// than the given `maxLength`.
+// If truncation is necessary, a hash is added to avoid collisions on the
+// file system in cases where names match up until a differentiating part
+// at the end that is truncated.
 export function truncateFileName(filePath: string, maxLength: number = MAX_FILE_NAME_LENGTH) {
   const filePathParts = filePath.split('/');
   const fileName = filePathParts.pop();

--- a/packages/shared/src/write-archive/index.test.ts
+++ b/packages/shared/src/write-archive/index.test.ts
@@ -3,7 +3,12 @@ import { NodeType } from 'rrweb-snapshot';
 import * as filePaths from '../utils/filePaths';
 import { writeTestResult } from '.';
 
-jest.mock('../utils/filePaths');
+jest.mock('../utils/filePaths', () => ({
+  ...jest.requireActual('../utils/filePaths'),
+  ensureDir: jest.fn(),
+  outputFile: jest.fn(),
+  outputJSONFile: jest.fn(),
+}));
 
 const snapshotJson = {
   childNodes: [

--- a/packages/shared/src/write-archive/snapshot-files.test.ts
+++ b/packages/shared/src/write-archive/snapshot-files.test.ts
@@ -7,6 +7,28 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
+describe('snapshotId', () => {
+  it('sanitizes the snapshot ID', () => {
+    const snapshotId = snapshotFiles.snapshotId(
+      'a title *() with $%& chars',
+      'a snapshot name *() with $%& chars'
+    );
+
+    expect(snapshotId).toEqual('a-title-with-chars-a-snapshot-name-with-chars');
+  });
+
+  it('truncates long snashot IDs', () => {
+    const title =
+      'this title has 260 chars exactly i know because i counted and that is too big for a file system blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah ok this right here this is the end';
+    const snapshotName = 'and this is a snapshot name these should not be too long usually';
+
+    const snapshotId = snapshotFiles.snapshotId(title, snapshotName);
+
+    expect(snapshotId.length).toEqual(230);
+    expect(snapshotId).toMatch(new RegExp('^this-title-has-.*blah-blah-[a-z0-9]{4}$'));
+  });
+});
+
 describe('snapshotFileName', () => {
   it('generates a filename with the id and viewport', () => {
     const fileName = snapshotFiles.snapshotFileName('some-id', { width: 500, height: 720 });

--- a/packages/shared/src/write-archive/snapshot-files.ts
+++ b/packages/shared/src/write-archive/snapshot-files.ts
@@ -1,11 +1,15 @@
 import { readdir } from 'fs/promises';
 import { Viewport, parseViewport, viewportToString } from '../utils/viewport';
 import { sanitize } from './storybook-sanitize';
+import { MAX_FILE_NAME_LENGTH, truncateFileName } from '../utils/filePaths';
 
 const SNAPSHOT_FILE_EXT = 'snapshot.json';
 
 export function snapshotId(testTitle: string, snapshotName: string) {
-  return `${sanitize(testTitle)}-${sanitize(snapshotName)}`;
+  const fullSnapshotId = `${sanitize(testTitle)}-${sanitize(snapshotName)}`;
+  // Leave room for the viewport and extension that will be added when using this
+  // to create a full file path
+  return truncateFileName(fullSnapshotId, MAX_FILE_NAME_LENGTH - 25);
 }
 
 // NOTE: This is duplicated in the shared storybook preview.ts

--- a/packages/shared/src/write-archive/snapshot-files.ts
+++ b/packages/shared/src/write-archive/snapshot-files.ts
@@ -9,7 +9,8 @@ export function snapshotId(testTitle: string, snapshotName: string) {
   const fullSnapshotId = `${sanitize(testTitle)}-${sanitize(snapshotName)}`;
   // Leave room for the viewport and extension that will be added when using this
   // to create a full file path
-  return truncateFileName(fullSnapshotId, MAX_FILE_NAME_LENGTH - 25);
+  const maxLength = MAX_FILE_NAME_LENGTH - 25;
+  return truncateFileName(fullSnapshotId, maxLength);
 }
 
 // NOTE: This is duplicated in the shared storybook preview.ts

--- a/packages/shared/src/write-archive/stories-files.test.ts
+++ b/packages/shared/src/write-archive/stories-files.test.ts
@@ -15,6 +15,23 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
+describe('storiesFileName', () => {
+  it('sanitizes the file name', () => {
+    const fileName = storiesFiles.storiesFileName('a title *() with $%& chars');
+    expect(fileName).toEqual('a-title-with-chars.stories.json');
+  });
+
+  it('truncates long file names', () => {
+    const title =
+      'this title has 260 chars exactly i know because i counted and that is too big for a file system blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah blah ok this right here this is the end';
+    expect(title.length).toBeGreaterThan(255);
+
+    const fileName = storiesFiles.storiesFileName(title);
+    expect(fileName.length).toEqual(230);
+    expect(fileName).toMatch(new RegExp('^this-title-has-.*blah-bl[a-z0-9]{4}.stories.json$'));
+  });
+});
+
 describe('createStories', () => {
   it('creates stories file JSON from DOM snapshots', () => {
     const title = 'some test title';

--- a/packages/shared/src/write-archive/stories-files.ts
+++ b/packages/shared/src/write-archive/stories-files.ts
@@ -3,13 +3,15 @@ import { ChromaticStorybookParameters } from '../types';
 import { snapshotId } from './snapshot-files';
 import { sanitize } from './storybook-sanitize';
 import { Viewport, viewportToString } from '../utils/viewport';
+import { MAX_FILE_NAME_LENGTH, truncateFileName } from '../utils/filePaths';
 
 const STORIES_FILE_EXT = 'stories.json';
 
+// Generates a file-system-safe file name from a story title
 export function storiesFileName(testTitle: string) {
-  const fileNameParts = [sanitize(testTitle), STORIES_FILE_EXT];
-
-  return fileNameParts.join('.');
+  const fileName = [sanitize(testTitle), STORIES_FILE_EXT].join('.');
+  // Leave some room for built storybook extensions that may be added (like `-stories.iframe.bundle.js`)
+  return truncateFileName(fileName, MAX_FILE_NAME_LENGTH - 25);
 }
 
 // Converts the DOM snapshots into a JSON stories file.

--- a/packages/shared/src/write-archive/stories-files.ts
+++ b/packages/shared/src/write-archive/stories-files.ts
@@ -10,8 +10,9 @@ const STORIES_FILE_EXT = 'stories.json';
 // Generates a file-system-safe file name from a story title
 export function storiesFileName(testTitle: string) {
   const fileName = [sanitize(testTitle), STORIES_FILE_EXT].join('.');
-  // Leave some room for built storybook extensions that may be added (like `-stories.iframe.bundle.js`)
-  return truncateFileName(fileName, MAX_FILE_NAME_LENGTH - 25);
+  // Leave room for built storybook extensions that may be added (like `-stories.iframe.bundle.js`)
+  const maxLength = MAX_FILE_NAME_LENGTH - 25;
+  return truncateFileName(fileName, maxLength);
 }
 
 // Converts the DOM snapshots into a JSON stories file.

--- a/test-server/server.js
+++ b/test-server/server.js
@@ -59,7 +59,7 @@ app.use(express.static(path.join(__dirname, 'fixtures/assets')));
 
 // Pages
 app.get('/', (req, res) => {
-  res.send(`${htmlIntro}<body>Testing</body>${htmlOutro}`);
+  res.send(`${htmlIntro}<body>Testing testing just a basic page</body>${htmlOutro}`);
 });
 
 // Asset path pages


### PR DESCRIPTION
Fixes #169 

## What Changed

<!-- Insert a description below. -->
The names in pw/cy tests and describe blocks are used to generate the snapshot ID and stories file name, both of which are used to name files that are written to the file system. It's possible for those to be longer than the file system will allow for file names, resulting in test suite errors.

This fixes that by truncating the snapshot ID and stories file names such that they won't be too long for relevant file systems. If the values need to be truncated, an additional hash of 4 characters will be added to the values to try to avoid file system collisions that could be introduced by truncating values that have the same lengthly beginnings and only differ in the ending that's been removed. 

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
* See new tests with long names failing before the fix: https://github.com/chromaui/chromatic-e2e/actions/runs/9846109047
* See all tests pass after the fix
