### PR TITLE
Pin storybook dependency to <8.2

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -79,6 +79,6 @@
     "@storybook/server-webpack5": "^8.1.5",
     "chrome-remote-interface": "^0.33.0",
     "rrweb-snapshot": "^2.0.0-alpha.11",
-    "storybook": "^8.1.5"
+    "storybook": "~8.1.5"
   }
 }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -69,7 +69,7 @@
     "@storybook/manager-api": "^8.1.5",
     "@storybook/server-webpack5": "^8.1.5",
     "rrweb-snapshot": "2.0.0-alpha.14",
-    "storybook": "^8.1.5",
+    "storybook": "~8.1.5",
     "ts-dedent": "^2.2.0"
   },
   "peerDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -102,7 +102,7 @@
     "prompts": "^2.4.2",
     "rimraf": "^3.0.2",
     "srcset": "^4.0.0",
-    "storybook": "^8.1.5",
+    "storybook": "~8.1.5",
     "ts-dedent": "^2.2.0",
     "ts-jest": "^27.0.4",
     "typescript": "^4.2.4"
@@ -113,6 +113,6 @@
   "dependencies": {
     "@segment/analytics-node": "^1.1.0",
     "rrweb-snapshot": "^2.0.0-alpha.11",
-    "storybook": "^8.1.5"
+    "storybook": "~8.1.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3582,7 +3582,7 @@ __metadata:
     cypress: "npm:^13.4.0"
     rrweb-snapshot: "npm:^2.0.0-alpha.11"
     start-server-and-test: "npm:^2.0.3"
-    storybook: "npm:^8.1.5"
+    storybook: "npm:~8.1.5"
   bin:
     archive-storybook: dist/bin/archive-storybook.js
     build-archive-storybook: dist/bin/build-archive-storybook.js
@@ -3605,7 +3605,7 @@ __metadata:
     playwright: "npm:^1.32.2"
     playwright-core: "npm:^1.32.2"
     rrweb-snapshot: "npm:2.0.0-alpha.14"
-    storybook: "npm:^8.1.5"
+    storybook: "npm:~8.1.5"
     ts-dedent: "npm:^2.2.0"
   peerDependencies:
     "@playwright/test": ^1.0.0
@@ -3649,7 +3649,7 @@ __metadata:
     rimraf: "npm:^3.0.2"
     rrweb-snapshot: "npm:^2.0.0-alpha.11"
     srcset: "npm:^4.0.0"
-    storybook: "npm:^8.1.5"
+    storybook: "npm:~8.1.5"
     ts-dedent: "npm:^2.2.0"
     ts-jest: "npm:^27.0.4"
     typescript: "npm:^4.2.4"
@@ -5439,6 +5439,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/builder-manager@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/builder-manager@npm:8.1.11"
+  dependencies:
+    "@fal-works/esbuild-plugin-global-externals": "npm:^2.1.2"
+    "@storybook/core-common": "npm:8.1.11"
+    "@storybook/manager": "npm:8.1.11"
+    "@storybook/node-logger": "npm:8.1.11"
+    "@types/ejs": "npm:^3.1.1"
+    "@yarnpkg/esbuild-plugin-pnp": "npm:^3.0.0-rc.10"
+    browser-assert: "npm:^1.2.1"
+    ejs: "npm:^3.1.10"
+    esbuild: "npm:^0.18.0 || ^0.19.0 || ^0.20.0"
+    esbuild-plugin-alias: "npm:^0.2.1"
+    express: "npm:^4.17.3"
+    fs-extra: "npm:^11.1.0"
+    process: "npm:^0.11.10"
+    util: "npm:^0.12.4"
+  checksum: 5ffbd3122ef58e6d8a3a8bc0511ce30ce1c1521dee2871a54d59767ce0879ea3aa80542ba2aaa463468e1f7050467a4b56531870596e2c763d1434ba71940d92
+  languageName: node
+  linkType: hard
+
 "@storybook/builder-manager@npm:8.1.5":
   version: 8.1.5
   resolution: "@storybook/builder-manager@npm:8.1.5"
@@ -5506,6 +5528,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/channels@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/channels@npm:8.1.11"
+  dependencies:
+    "@storybook/client-logger": "npm:8.1.11"
+    "@storybook/core-events": "npm:8.1.11"
+    "@storybook/global": "npm:^5.0.0"
+    telejson: "npm:^7.2.0"
+    tiny-invariant: "npm:^1.3.1"
+  checksum: 203b1ef9f1d1e74d6f6c302af24d8662277a65ad5cb8c61f5db191d08a3d0d045094030d71777a2f4d7bba085b86bec10c68c0341a555896455656dc91aabb86
+  languageName: node
+  linkType: hard
+
 "@storybook/channels@npm:8.1.5":
   version: 8.1.5
   resolution: "@storybook/channels@npm:8.1.5"
@@ -5519,21 +5554,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/cli@npm:8.1.5":
-  version: 8.1.5
-  resolution: "@storybook/cli@npm:8.1.5"
+"@storybook/cli@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/cli@npm:8.1.11"
   dependencies:
     "@babel/core": "npm:^7.24.4"
     "@babel/types": "npm:^7.24.0"
     "@ndelangen/get-tarball": "npm:^3.0.7"
-    "@storybook/codemod": "npm:8.1.5"
-    "@storybook/core-common": "npm:8.1.5"
-    "@storybook/core-events": "npm:8.1.5"
-    "@storybook/core-server": "npm:8.1.5"
-    "@storybook/csf-tools": "npm:8.1.5"
-    "@storybook/node-logger": "npm:8.1.5"
-    "@storybook/telemetry": "npm:8.1.5"
-    "@storybook/types": "npm:8.1.5"
+    "@storybook/codemod": "npm:8.1.11"
+    "@storybook/core-common": "npm:8.1.11"
+    "@storybook/core-events": "npm:8.1.11"
+    "@storybook/core-server": "npm:8.1.11"
+    "@storybook/csf-tools": "npm:8.1.11"
+    "@storybook/node-logger": "npm:8.1.11"
+    "@storybook/telemetry": "npm:8.1.11"
+    "@storybook/types": "npm:8.1.11"
     "@types/semver": "npm:^7.3.4"
     "@yarnpkg/fslib": "npm:2.10.3"
     "@yarnpkg/libzip": "npm:2.3.0"
@@ -5562,7 +5597,16 @@ __metadata:
   bin:
     getstorybook: ./bin/index.js
     sb: ./bin/index.js
-  checksum: 9d274d4ec7fa0cf897a2a194718db5ac7a53e29d36f4a2aeef498b0fa7c8a6f9a75ef644299bcc570130b51a6e74b4b0dadecaaf6064d00da88ebb932197ac9c
+  checksum: 7b130cc73ce37e521b8a638db62b24337a19fc2f4b652367c826a943fe0611acb94de7e69450f6a8e1c44cc0055204c535cade01c72b765582d63eb7aa32951f
+  languageName: node
+  linkType: hard
+
+"@storybook/client-logger@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/client-logger@npm:8.1.11"
+  dependencies:
+    "@storybook/global": "npm:^5.0.0"
+  checksum: fbcc3a05c07baf3dac8b57980eebd4176e3c75dd065c5abefe1799d43bc03fe0738efa2fa70e9f2e2b6581414182156c99f37c21dda24410b214673643cc9515
   languageName: node
   linkType: hard
 
@@ -5575,17 +5619,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/codemod@npm:8.1.5":
-  version: 8.1.5
-  resolution: "@storybook/codemod@npm:8.1.5"
+"@storybook/codemod@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/codemod@npm:8.1.11"
   dependencies:
     "@babel/core": "npm:^7.24.4"
     "@babel/preset-env": "npm:^7.24.4"
     "@babel/types": "npm:^7.24.0"
     "@storybook/csf": "npm:^0.1.7"
-    "@storybook/csf-tools": "npm:8.1.5"
-    "@storybook/node-logger": "npm:8.1.5"
-    "@storybook/types": "npm:8.1.5"
+    "@storybook/csf-tools": "npm:8.1.11"
+    "@storybook/node-logger": "npm:8.1.11"
+    "@storybook/types": "npm:8.1.11"
     "@types/cross-spawn": "npm:^6.0.2"
     cross-spawn: "npm:^7.0.3"
     globby: "npm:^14.0.1"
@@ -5594,7 +5638,7 @@ __metadata:
     prettier: "npm:^3.1.1"
     recast: "npm:^0.23.5"
     tiny-invariant: "npm:^1.3.1"
-  checksum: c9d7b0f529a454a4f94d018012643b147f118a0592a0185b510d78e56491d2004ea2708c0e652073f47cfd860ed0e02e5e9e164a09e63149bcd59a03f0664f00
+  checksum: b8987e3fa9e392c1ad1d0d0ad6c244d5f69bbecb8db583091b2a91bc9d488d58deb204cdbd85f70f567a0a18ff294934a16f7cd3a31fcc21976e77911f3613ff
   languageName: node
   linkType: hard
 
@@ -5616,6 +5660,48 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
   checksum: 05c7913d529d9b80d840e90fd5d6e3503d11acc90044aec5275340725b7ca127b80ffcfa0bc7581d4a342a4f1b66c744764e97f187efae8db564b198a57335fa
+  languageName: node
+  linkType: hard
+
+"@storybook/core-common@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/core-common@npm:8.1.11"
+  dependencies:
+    "@storybook/core-events": "npm:8.1.11"
+    "@storybook/csf-tools": "npm:8.1.11"
+    "@storybook/node-logger": "npm:8.1.11"
+    "@storybook/types": "npm:8.1.11"
+    "@yarnpkg/fslib": "npm:2.10.3"
+    "@yarnpkg/libzip": "npm:2.3.0"
+    chalk: "npm:^4.1.0"
+    cross-spawn: "npm:^7.0.3"
+    esbuild: "npm:^0.18.0 || ^0.19.0 || ^0.20.0"
+    esbuild-register: "npm:^3.5.0"
+    execa: "npm:^5.0.0"
+    file-system-cache: "npm:2.3.0"
+    find-cache-dir: "npm:^3.0.0"
+    find-up: "npm:^5.0.0"
+    fs-extra: "npm:^11.1.0"
+    glob: "npm:^10.0.0"
+    handlebars: "npm:^4.7.7"
+    lazy-universal-dotenv: "npm:^4.0.0"
+    node-fetch: "npm:^2.0.0"
+    picomatch: "npm:^2.3.0"
+    pkg-dir: "npm:^5.0.0"
+    prettier-fallback: "npm:prettier@^3"
+    pretty-hrtime: "npm:^1.0.3"
+    resolve-from: "npm:^5.0.0"
+    semver: "npm:^7.3.7"
+    tempy: "npm:^3.1.0"
+    tiny-invariant: "npm:^1.3.1"
+    ts-dedent: "npm:^2.0.0"
+    util: "npm:^0.12.4"
+  peerDependencies:
+    prettier: ^2 || ^3
+  peerDependenciesMeta:
+    prettier:
+      optional: true
+  checksum: 149e4277ad4b0ddc07046228cc8386c670f046166967bb03c939d76e9557d661fbaf8736b9c33068997d2a27856237eaca57e9b3d884c30644f6c1d9075ab4ca
   languageName: node
   linkType: hard
 
@@ -5661,6 +5747,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/core-events@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/core-events@npm:8.1.11"
+  dependencies:
+    "@storybook/csf": "npm:^0.1.7"
+    ts-dedent: "npm:^2.0.0"
+  checksum: 219d6bff5118f3283dbc9963dd6bf5dfe7c199c7f51a0f5cc985b567e3b66d4d5d3475ac9d00d68ccf5c105afa012f830ec5d00d11de813a589cc4e172c35380
+  languageName: node
+  linkType: hard
+
 "@storybook/core-events@npm:8.1.5":
   version: 8.1.5
   resolution: "@storybook/core-events@npm:8.1.5"
@@ -5668,6 +5764,59 @@ __metadata:
     "@storybook/csf": "npm:^0.1.7"
     ts-dedent: "npm:^2.0.0"
   checksum: 04c993d42ac840c3f3c5d6cad060ca5adef12b48a10d090b90c55e63c2966e4724d18a236c67d9847a4600036a5b67f1a527300473035a4508b340fa2e50966f
+  languageName: node
+  linkType: hard
+
+"@storybook/core-server@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/core-server@npm:8.1.11"
+  dependencies:
+    "@aw-web-design/x-default-browser": "npm:1.4.126"
+    "@babel/core": "npm:^7.24.4"
+    "@babel/parser": "npm:^7.24.4"
+    "@discoveryjs/json-ext": "npm:^0.5.3"
+    "@storybook/builder-manager": "npm:8.1.11"
+    "@storybook/channels": "npm:8.1.11"
+    "@storybook/core-common": "npm:8.1.11"
+    "@storybook/core-events": "npm:8.1.11"
+    "@storybook/csf": "npm:^0.1.7"
+    "@storybook/csf-tools": "npm:8.1.11"
+    "@storybook/docs-mdx": "npm:3.1.0-next.0"
+    "@storybook/global": "npm:^5.0.0"
+    "@storybook/manager": "npm:8.1.11"
+    "@storybook/manager-api": "npm:8.1.11"
+    "@storybook/node-logger": "npm:8.1.11"
+    "@storybook/preview-api": "npm:8.1.11"
+    "@storybook/telemetry": "npm:8.1.11"
+    "@storybook/types": "npm:8.1.11"
+    "@types/detect-port": "npm:^1.3.0"
+    "@types/diff": "npm:^5.0.9"
+    "@types/node": "npm:^18.0.0"
+    "@types/pretty-hrtime": "npm:^1.0.0"
+    "@types/semver": "npm:^7.3.4"
+    better-opn: "npm:^3.0.2"
+    chalk: "npm:^4.1.0"
+    cli-table3: "npm:^0.6.1"
+    compression: "npm:^1.7.4"
+    detect-port: "npm:^1.3.0"
+    diff: "npm:^5.2.0"
+    express: "npm:^4.17.3"
+    fs-extra: "npm:^11.1.0"
+    globby: "npm:^14.0.1"
+    lodash: "npm:^4.17.21"
+    open: "npm:^8.4.0"
+    pretty-hrtime: "npm:^1.0.3"
+    prompts: "npm:^2.4.0"
+    read-pkg-up: "npm:^7.0.1"
+    semver: "npm:^7.3.7"
+    telejson: "npm:^7.2.0"
+    tiny-invariant: "npm:^1.3.1"
+    ts-dedent: "npm:^2.0.0"
+    util: "npm:^0.12.4"
+    util-deprecate: "npm:^1.0.2"
+    watchpack: "npm:^2.2.0"
+    ws: "npm:^8.2.3"
+  checksum: 31ce886df5fca817ae6309234fdc73d1fd8bf01cd31af00f42e5ea68632f0def9f3094ab815cc09b2ac096770b2d20a56a368b81122d355cd30409bcd03c14de
   languageName: node
   linkType: hard
 
@@ -5745,6 +5894,23 @@ __metadata:
     "@storybook/csf-tools": "npm:8.1.5"
     unplugin: "npm:^1.3.1"
   checksum: 7a369f91839021e9bb6ece326aaa6c0fe31b69683251476289cbe82decd1baadf44c1becb0db7c71fea13fe17de6769bca23cd192ba5350e3678d789bbfe5c1d
+  languageName: node
+  linkType: hard
+
+"@storybook/csf-tools@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/csf-tools@npm:8.1.11"
+  dependencies:
+    "@babel/generator": "npm:^7.24.4"
+    "@babel/parser": "npm:^7.24.4"
+    "@babel/traverse": "npm:^7.24.1"
+    "@babel/types": "npm:^7.24.0"
+    "@storybook/csf": "npm:^0.1.7"
+    "@storybook/types": "npm:8.1.11"
+    fs-extra: "npm:^11.1.0"
+    recast: "npm:^0.23.5"
+    ts-dedent: "npm:^2.0.0"
+  checksum: c61f66919178923ddc6f77c87e0ef8e47a8703e909701b11137327b7f963474edd595a4303ee7ddc22661cb788ed3a74a54ef98ed7908e89cb2145ddd58ee595
   languageName: node
   linkType: hard
 
@@ -5859,6 +6025,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/manager-api@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/manager-api@npm:8.1.11"
+  dependencies:
+    "@storybook/channels": "npm:8.1.11"
+    "@storybook/client-logger": "npm:8.1.11"
+    "@storybook/core-events": "npm:8.1.11"
+    "@storybook/csf": "npm:^0.1.7"
+    "@storybook/global": "npm:^5.0.0"
+    "@storybook/icons": "npm:^1.2.5"
+    "@storybook/router": "npm:8.1.11"
+    "@storybook/theming": "npm:8.1.11"
+    "@storybook/types": "npm:8.1.11"
+    dequal: "npm:^2.0.2"
+    lodash: "npm:^4.17.21"
+    memoizerific: "npm:^1.11.3"
+    store2: "npm:^2.14.2"
+    telejson: "npm:^7.2.0"
+    ts-dedent: "npm:^2.0.0"
+  checksum: 6fbd5c878dea80d7a3b4ee7d2b244c321c4893efa59e9de2257d4c74c688968b70e9008d2694af08c2a5cfaf373a69aea21c7fca096c43aa1962b77b9a2008b3
+  languageName: node
+  linkType: hard
+
 "@storybook/manager-api@npm:8.1.5, @storybook/manager-api@npm:^8.1.5":
   version: 8.1.5
   resolution: "@storybook/manager-api@npm:8.1.5"
@@ -5882,10 +6071,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/manager@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/manager@npm:8.1.11"
+  checksum: 82ef44adfb4ac7fcb02ab87880b715d6ab17ec335319da5fcb78abd903ab9a60b34fcb3bafc47f5d2e70701d8be1d574e48142d9def2d69297b0e32b9926e58e
+  languageName: node
+  linkType: hard
+
 "@storybook/manager@npm:8.1.5":
   version: 8.1.5
   resolution: "@storybook/manager@npm:8.1.5"
   checksum: 59e686b9bd67cd22a38665ce19f61ec8289faa3e6ee8454f5d6ca1efdb1d44236b8bafc6b742230279f9cf84a08286392ee92b6d3ca9159a75bb8fda59de7e2b
+  languageName: node
+  linkType: hard
+
+"@storybook/node-logger@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/node-logger@npm:8.1.11"
+  checksum: d2197269fac17bead36b639cd7dd97a76e6a2091a748f8578f2ab76c884d142d0e3ca8d4143b5c41fe9923218cc03700be87876a128cccfbd265abb3913b8ad0
   languageName: node
   linkType: hard
 
@@ -5909,6 +6112,28 @@ __metadata:
     ts-dedent: "npm:^2.0.0"
     yaml-loader: "npm:^0.8.0"
   checksum: cb597d28f88bdf79372501d7bc10cc629214bd822837b270bd23852586ea1fff9101de0156c3a69176c0480441aed766d98b1a75e350bd1d5e244f6154ee3fbc
+  languageName: node
+  linkType: hard
+
+"@storybook/preview-api@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/preview-api@npm:8.1.11"
+  dependencies:
+    "@storybook/channels": "npm:8.1.11"
+    "@storybook/client-logger": "npm:8.1.11"
+    "@storybook/core-events": "npm:8.1.11"
+    "@storybook/csf": "npm:^0.1.7"
+    "@storybook/global": "npm:^5.0.0"
+    "@storybook/types": "npm:8.1.11"
+    "@types/qs": "npm:^6.9.5"
+    dequal: "npm:^2.0.2"
+    lodash: "npm:^4.17.21"
+    memoizerific: "npm:^1.11.3"
+    qs: "npm:^6.10.0"
+    tiny-invariant: "npm:^1.3.1"
+    ts-dedent: "npm:^2.0.0"
+    util-deprecate: "npm:^1.0.2"
+  checksum: 4987b4ffb51993ef50f343b6fd7be2ecd4abd9757a5ec2b2b1c009b3013088d2ca456b596bde13f01d8c1fccae036ba66f006c2b0705232fdb11ee39047468f3
   languageName: node
   linkType: hard
 
@@ -5948,6 +6173,17 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
   checksum: 083209d731f686a56b386ababde1065ec9946f5f8b655cd07248a12c6773012835b2f9eab17c447da4aed5bc902d4aa6309e69eef2bf149f375aa5b6bebd448a
+  languageName: node
+  linkType: hard
+
+"@storybook/router@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/router@npm:8.1.11"
+  dependencies:
+    "@storybook/client-logger": "npm:8.1.11"
+    memoizerific: "npm:^1.11.3"
+    qs: "npm:^6.10.0"
+  checksum: 0d59c54604ba2810372ad18af741bf77f246603276e62068e73d291ba9e641b55997063bff1e6f97090e034ef36dd5c5761f4ebf462affa093aaefed3f32f079
   languageName: node
   linkType: hard
 
@@ -5993,6 +6229,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@storybook/telemetry@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/telemetry@npm:8.1.11"
+  dependencies:
+    "@storybook/client-logger": "npm:8.1.11"
+    "@storybook/core-common": "npm:8.1.11"
+    "@storybook/csf-tools": "npm:8.1.11"
+    chalk: "npm:^4.1.0"
+    detect-package-manager: "npm:^2.0.1"
+    fetch-retry: "npm:^5.0.2"
+    fs-extra: "npm:^11.1.0"
+    read-pkg-up: "npm:^7.0.1"
+  checksum: 300cdeca1bded6322efd9ce6233ae7b706a73d66b57ad060fd64bb2c08b00d5fbd27441d989a607d40932bba30e5bdffbba61175d48178a31c87959ad28032a5
+  languageName: node
+  linkType: hard
+
 "@storybook/telemetry@npm:8.1.5":
   version: 8.1.5
   resolution: "@storybook/telemetry@npm:8.1.5"
@@ -6006,6 +6258,26 @@ __metadata:
     fs-extra: "npm:^11.1.0"
     read-pkg-up: "npm:^7.0.1"
   checksum: 689fd124f7b094853042490724cd1dc5e3257e876ac8a1623a30e50be8ded6d5ba3ae4793f2fd7d00f0836bdf2340aa7f77f3ce1f7c20c57e0f18e7dbf75ee9c
+  languageName: node
+  linkType: hard
+
+"@storybook/theming@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/theming@npm:8.1.11"
+  dependencies:
+    "@emotion/use-insertion-effect-with-fallbacks": "npm:^1.0.1"
+    "@storybook/client-logger": "npm:8.1.11"
+    "@storybook/global": "npm:^5.0.0"
+    memoizerific: "npm:^1.11.3"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 67246798c0c19d50f82e035fede067c1ef6a01529a283939ebd284c451073d3e2442483ae8524ff8102aad9d3994f6b5ee621347cf344e7f4bbd5d0d05eb4ff8
   languageName: node
   linkType: hard
 
@@ -6026,6 +6298,17 @@ __metadata:
     react-dom:
       optional: true
   checksum: 082ac91e1a3c404a70bc99b44e251c4f12ccbca614d9ed582ddadea966fdb782349bc6cc6012678cd01017fcc683cd7df3b5d3dac7078edd8d4f4e635eea089c
+  languageName: node
+  linkType: hard
+
+"@storybook/types@npm:8.1.11":
+  version: 8.1.11
+  resolution: "@storybook/types@npm:8.1.11"
+  dependencies:
+    "@storybook/channels": "npm:8.1.11"
+    "@types/express": "npm:^4.7.0"
+    file-system-cache: "npm:2.3.0"
+  checksum: 5ebb60ed5b868769025c1252ce309472a36eb496b1e53e02b1f05d923fd59aafd452c4463664538cba59fe79118fa7e7f51c30346d8894f6f3a0723030838037
   languageName: node
   linkType: hard
 
@@ -17987,15 +18270,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"storybook@npm:^8.1.5":
-  version: 8.1.5
-  resolution: "storybook@npm:8.1.5"
+"storybook@npm:~8.1.5":
+  version: 8.1.11
+  resolution: "storybook@npm:8.1.11"
   dependencies:
-    "@storybook/cli": "npm:8.1.5"
+    "@storybook/cli": "npm:8.1.11"
   bin:
     sb: ./index.js
     storybook: ./index.js
-  checksum: 543566a5a13d639ca590c7b53f8cb3804c0d05cd847a131247be58166496dfa8607706125b567ddfe3952c54f221a93a3fabdaaac867ae67eda005ce1422ea4f
+  checksum: 51568831ce33a2c011db0edbcf2bfbe15a96678fae5db7d9790910c57524044f30b8dc4a0296ed09106fb733b371542a8a1002e33d4849e62b6cb66aac2abbbe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Quickfix for https://github.com/chromaui/chromatic-e2e/issues/180

The `build-archive-storybook` CLI does not work with `storybook@8.2`.
This is because it assumes there is a top-level `index.js` file:
https://github.com/chromaui/chromatic-e2e/blob/85a3d3ceb24bb7cb10fb8015072041186e116e96/packages/shared/src/archive-storybook/index.ts#L25

However, in storybook 8.2, I think the new path would be `bin/index.cjs`, see https://www.npmjs.com/package/storybook/v/8.2.0?activeTab=code

This PR ensures that only versions `8.1.0` < `8.2.0` will be used as a quick fix.