### PR TITLE
Fix archive storybook build for storybook8.2

### DIFF
--- a/packages/shared/src/archive-storybook/index.ts
+++ b/packages/shared/src/archive-storybook/index.ts
@@ -10,8 +10,7 @@ export function archiveStorybook(
 ) {
   checkArchivesDirExists(defaultOutputDir);
   addViewportsToStoriesFiles(defaultOutputDir).then(() => {
-    const binPath = resolve(dirname(require.resolve('storybook/package.json')), './index.js');
-    execFileSync('node', [binPath, 'dev', ...processArgs, '-c', configDir], { stdio: 'inherit' });
+    execFileSync('node', [binPath(), 'dev', ...processArgs, '-c', configDir], { stdio: 'inherit' });
   });
 }
 
@@ -22,7 +21,14 @@ export function buildArchiveStorybook(
 ) {
   checkArchivesDirExists(defaultOutputDir);
   addViewportsToStoriesFiles(defaultOutputDir).then(() => {
-    const binPath = resolve(dirname(require.resolve('storybook/package.json')), './index.js');
-    execFileSync('node', [binPath, 'build', ...processArgs, '-c', configDir], { stdio: 'inherit' });
+    execFileSync('node', [binPath(), 'build', ...processArgs, '-c', configDir], {
+      stdio: 'inherit',
+    });
   });
+}
+
+function binPath() {
+  // eslint-disable-next-line global-require
+  const packageJson = require('storybook/package.json');
+  return resolve(dirname(require.resolve('storybook/package.json')), packageJson.bin.storybook);
 }


### PR DESCRIPTION
Issue: https://github.com/chromaui/chromatic-e2e/issues/180

## What Changed

In `storybook@8.2` the path to the bin changed, this PR uses the `bin` field of the package.json to determine the path.

Alternatively one could pin the storybook dependency 

## How to test

Running:
```js
const { resolve, dirname } = require('path');
const packageJson = require('storybook/package.json');
console.log(resolve(dirname(require.resolve('storybook/package.json')), packageJson.bin.storybook));
```

Results in:
- `storybook@8.1`: `/workspace/node_modules/storybook/index.js`
- `storybook@8.2`: `/workspace/node_modules/storybook/bin/index.cjs`
