### PR TITLE
Add extra Basic Authentication tests in E2E

### DIFF
--- a/packages/cypress/tests/cypress/e2e/auth.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/auth.cy.ts
@@ -1,0 +1,9 @@
+it('can succeed with basic authentication using locally defined credentials', () => {
+  cy.visit('/protected', {
+    auth: {
+      username: 'user',
+      password: 'secret',
+    },
+  });
+  cy.contains('I AM PROTECTED!!!').should('be.visible');
+});

--- a/packages/playwright/playwright.config.ts
+++ b/packages/playwright/playwright.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
   use: {
     baseURL: 'http://localhost:3000',
     httpCredentials: {
-      username: 'admin',
-      password: 'supersecret',
+      username: 'user',
+      password: 'secret',
     },
   },
   projects: [

--- a/packages/playwright/tests/auth.spec.ts
+++ b/packages/playwright/tests/auth.spec.ts
@@ -1,8 +1,26 @@
 import { test, expect } from '../src';
 
 test.describe(() => {
-  test('can login', async ({ page }) => {
-    await page.goto('/auth');
+  test('can succeed with basic authentication using globally-defined credentials', async ({
+    page,
+  }) => {
+    await page.goto('/protected');
+
+    await expect(page.getByText('I AM PROTECTED!!!')).toBeVisible();
+  });
+});
+
+test.describe(() => {
+  test.use({
+    extraHTTPHeaders: {
+      Authorization: `Basic ${btoa('admin:supersecret')}`,
+    },
+  });
+
+  test('can succeed with basic authentication using a locally-defined header that overrides globally-defined credentials', async ({
+    page,
+  }) => {
+    await page.goto('/admin');
 
     await expect(page.getByText('I AM PROTECTED!!!')).toBeVisible();
   });

--- a/test-server/server.js
+++ b/test-server/server.js
@@ -10,7 +10,15 @@ const htmlIntro = `<!doctype html><html>`;
 const htmlOutro = `</html>`;
 
 app.use(
-  '/auth',
+  '/protected',
+  basicAuth({
+    users: { user: 'secret' },
+    challenge: true,
+  })
+);
+
+app.use(
+  '/admin',
   basicAuth({
     users: { admin: 'supersecret' },
     challenge: true,
@@ -36,7 +44,11 @@ app.get('/img', (req, res) => {
   }
 });
 
-app.get('/auth', (req, res) => {
+app.get('/protected', (req, res) => {
+  res.sendFile(path.join(__dirname, 'fixtures/auth/index.html'));
+});
+
+app.get('/admin', (req, res) => {
   res.sendFile(path.join(__dirname, 'fixtures/auth/index.html'));
 });
 


### PR DESCRIPTION
Issue: #AP-4963

## What Changed

<!-- Insert a description below. -->

There are now two resources that require authentication: `/protected` and `/admin`. These resources use different sets of credentials to access them. This ensures that credentials set in a specific test will override global credentials, as supported in Playwright.

There is also a new Cypress test to validate that tests can set credentials to access these protected resources.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->

See the Cypress and Playwright `auth` tests.