### PR TITLE
Integrate forked @chromaui/rrweb-snapshot package 

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -72,13 +72,13 @@
     "access": "public"
   },
   "dependencies": {
+    "@chromaui/rrweb-snapshot": "2.0.0-alpha.17",
     "@segment/analytics-node": "^1.1.0",
     "@storybook/addon-essentials": "^8.1.5",
     "@storybook/csf": "^0.1.0",
     "@storybook/manager-api": "^8.1.5",
     "@storybook/server-webpack5": "^8.1.5",
     "chrome-remote-interface": "^0.33.0",
-    "rrweb-snapshot": "^2.0.0-alpha.11",
     "storybook": "^8.1.5"
   }
 }

--- a/packages/cypress/src/commands.ts
+++ b/packages/cypress/src/commands.ts
@@ -1,5 +1,5 @@
-import { snapshot } from 'rrweb-snapshot';
-import type { elementNode } from 'rrweb-snapshot';
+import { snapshot } from '@chromaui/rrweb-snapshot';
+import type { elementNode } from '@chromaui/rrweb-snapshot';
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -1,4 +1,4 @@
-import type { elementNode } from 'rrweb-snapshot';
+import type { elementNode } from '@chromaui/rrweb-snapshot';
 import CDP, { Version } from 'chrome-remote-interface';
 import {
   ResourceArchiver,

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -1,4 +1,4 @@
-import { snapshot } from 'rrweb-snapshot';
+import { snapshot } from '@chromaui/rrweb-snapshot';
 import './commands';
 
 // these client-side lifecycle hooks will be added to the user's Cypress suite

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -63,12 +63,12 @@
     "access": "public"
   },
   "dependencies": {
+    "@chromaui/rrweb-snapshot": "2.0.0-alpha.17",
     "@segment/analytics-node": "^1.1.0",
     "@storybook/addon-essentials": "^8.1.5",
     "@storybook/csf": "^0.1.0",
     "@storybook/manager-api": "^8.1.5",
     "@storybook/server-webpack5": "^8.1.5",
-    "rrweb-snapshot": "2.0.0-alpha.14",
     "storybook": "^8.1.5",
     "ts-dedent": "^2.2.0"
   },

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -1,10 +1,10 @@
 import type { Page, TestInfo } from '@playwright/test';
 import { readFileSync } from 'fs';
 import { dedent } from 'ts-dedent';
-import type { elementNode } from 'rrweb-snapshot';
+import type { elementNode } from '@chromaui/rrweb-snapshot';
 import { logger } from '@chromatic-com/shared-e2e';
 
-const rrweb = readFileSync(require.resolve('rrweb-snapshot/dist/rrweb-snapshot.js'), 'utf8');
+const rrweb = readFileSync(require.resolve('@chromaui/rrweb-snapshot'), 'utf8');
 
 // top-level key is the test ID, next level key is the name of the snapshot (which we expect to be unique)
 export const chromaticSnapshots: Map<string, Map<string, Buffer>> = new Map();

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -111,8 +111,8 @@
     "*.{ts,js,css,md}": "prettier --write"
   },
   "dependencies": {
+    "@chromaui/rrweb-snapshot": "2.0.0-alpha.17",
     "@segment/analytics-node": "^1.1.0",
-    "rrweb-snapshot": "^2.0.0-alpha.11",
     "storybook": "^8.1.5"
   }
 }

--- a/packages/shared/src/write-archive/dom-snapshot.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable no-param-reassign */
-import type { serializedNodeWithId } from 'rrweb-snapshot';
-import { NodeType } from 'rrweb-snapshot';
+import type { serializedNodeWithId } from '@chromaui/rrweb-snapshot';
+import { NodeType } from '@chromaui/rrweb-snapshot';
 import srcset from 'srcset';
 
 // Matches `url(...)` function in CSS text, excluding data URLs

--- a/packages/shared/src/write-archive/index.test.ts
+++ b/packages/shared/src/write-archive/index.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'path';
-import { NodeType } from 'rrweb-snapshot';
+import { NodeType } from '@chromaui/rrweb-snapshot';
 import * as filePaths from '../utils/filePaths';
 import { writeTestResult } from '.';
 

--- a/packages/shared/storybook-config/preview.ts
+++ b/packages/shared/storybook-config/preview.ts
@@ -1,6 +1,6 @@
 import type { RenderContext, RenderToCanvas, WebRenderer } from '@storybook/types';
-import type { serializedNodeWithId } from 'rrweb-snapshot';
-import { NodeType, rebuild } from 'rrweb-snapshot';
+import type { serializedNodeWithId } from '@chromaui/rrweb-snapshot';
+import { NodeType, rebuild } from '@chromaui/rrweb-snapshot';
 
 const pageUrl = new URL(window.location.href);
 pageUrl.pathname = '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3572,6 +3572,7 @@ __metadata:
   resolution: "@chromatic-com/cypress@workspace:packages/cypress"
   dependencies:
     "@chromatic-com/shared-e2e": "workspace:*"
+    "@chromaui/rrweb-snapshot": "npm:2.0.0-alpha.17"
     "@segment/analytics-node": "npm:^1.1.0"
     "@storybook/addon-essentials": "npm:^8.1.5"
     "@storybook/csf": "npm:^0.1.0"
@@ -3580,7 +3581,6 @@ __metadata:
     "@storybook/types": "npm:^8.1.5"
     chrome-remote-interface: "npm:^0.33.0"
     cypress: "npm:^13.4.0"
-    rrweb-snapshot: "npm:^2.0.0-alpha.11"
     start-server-and-test: "npm:^2.0.3"
     storybook: "npm:^8.1.5"
   bin:
@@ -3594,6 +3594,7 @@ __metadata:
   resolution: "@chromatic-com/playwright@workspace:packages/playwright"
   dependencies:
     "@chromatic-com/shared-e2e": "workspace:*"
+    "@chromaui/rrweb-snapshot": "npm:2.0.0-alpha.17"
     "@playwright/test": "npm:^1.46.1"
     "@segment/analytics-node": "npm:^1.1.0"
     "@storybook/addon-essentials": "npm:^8.1.5"
@@ -3604,7 +3605,6 @@ __metadata:
     express: "npm:^4.18.2"
     playwright: "npm:^1.46.1"
     playwright-core: "npm:^1.46.1"
-    rrweb-snapshot: "npm:2.0.0-alpha.14"
     storybook: "npm:^8.1.5"
     ts-dedent: "npm:^2.2.0"
   peerDependencies:
@@ -3622,6 +3622,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.21.4"
     "@babel/preset-react": "npm:^7.18.6"
     "@babel/preset-typescript": "npm:^7.21.4"
+    "@chromaui/rrweb-snapshot": "npm:2.0.0-alpha.17"
     "@jest/types": "npm:^27.0.6"
     "@playwright/test": "npm:^1.46.1"
     "@segment/analytics-node": "npm:^1.1.0"
@@ -3647,7 +3648,6 @@ __metadata:
     prettier: "npm:^2.3.1"
     prompts: "npm:^2.4.2"
     rimraf: "npm:^3.0.2"
-    rrweb-snapshot: "npm:^2.0.0-alpha.11"
     srcset: "npm:^4.0.0"
     storybook: "npm:^8.1.5"
     ts-dedent: "npm:^2.2.0"
@@ -3699,6 +3699,15 @@ __metadata:
     typescript: "npm:^4.2.4"
   languageName: unknown
   linkType: soft
+
+"@chromaui/rrweb-snapshot@npm:2.0.0-alpha.17":
+  version: 2.0.0-alpha.17
+  resolution: "@chromaui/rrweb-snapshot@npm:2.0.0-alpha.17"
+  dependencies:
+    postcss: "npm:^8.4.38"
+  checksum: cff6946425c2d8b4cf846d498f932ad985987491b91fb3ed43ed05c69444e7b29a690b350135d2086585e7ab37c09289a424888a6b82f76a5928f64a1270f2b6
+  languageName: node
+  linkType: hard
 
 "@colors/colors@npm:1.5.0":
   version: 1.5.0
@@ -14943,6 +14952,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.7":
+  version: 3.3.7
+  resolution: "nanoid@npm:3.3.7"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: e3fb661aa083454f40500473bb69eedb85dc160e763150b9a2c567c7e9ff560ce028a9f833123b618a6ea742e311138b591910e795614a629029e86e180660f3
+  languageName: node
+  linkType: hard
+
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -15761,6 +15779,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picocolors@npm:^1.0.1":
+  version: 1.1.0
+  resolution: "picocolors@npm:1.1.0"
+  checksum: 86946f6032148801ef09c051c6fb13b5cf942eaf147e30ea79edb91dd32d700934edebe782a1078ff859fb2b816792e97ef4dab03d7f0b804f6b01a0df35e023
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^2.0.4, picomatch@npm:^2.2.1, picomatch@npm:^2.2.3, picomatch@npm:^2.3.0, picomatch@npm:^2.3.1":
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
@@ -15976,6 +16001,17 @@ __metadata:
     picocolors: "npm:^1.0.0"
     source-map-js: "npm:^1.0.2"
   checksum: 748b82e6e5fc34034dcf2ae88ea3d11fd09f69b6c50ecdd3b4a875cfc7cdca435c958b211e2cb52355422ab6fccb7d8f2f2923161d7a1b281029e4a913d59acf
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.38":
+  version: 8.4.45
+  resolution: "postcss@npm:8.4.45"
+  dependencies:
+    nanoid: "npm:^3.3.7"
+    picocolors: "npm:^1.0.1"
+    source-map-js: "npm:^1.2.0"
+  checksum: ad6f8b9b1157d678560373696109745ab97a947d449f8a997acac41c7f1e4c0f3ca4b092d6df1387f430f2c9a319987b1780dbdc27e35800a88cde9b606c1e8f
   languageName: node
   linkType: hard
 
@@ -17304,20 +17340,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rrweb-snapshot@npm:2.0.0-alpha.14":
-  version: 2.0.0-alpha.14
-  resolution: "rrweb-snapshot@npm:2.0.0-alpha.14"
-  checksum: 977a87df4ba00f1a5cd1f13cca61532dd5a9c9baeb21715f8394a6aaa1daf9d47f27280f86915e7cc312eb7a0b92cc25d5eb4d6ccf9dc4fdd5de35347aafdaac
-  languageName: node
-  linkType: hard
-
-"rrweb-snapshot@npm:^2.0.0-alpha.11":
-  version: 2.0.0-alpha.11
-  resolution: "rrweb-snapshot@npm:2.0.0-alpha.11"
-  checksum: 8b1c957877af546e89fb5428f5bcfda2a240d3cee9c770a63f897150dd5524e16048b6390a5d44e6d7ff4d1f7f3db63c816685e89ce4791e5645b6b5940378a7
-  languageName: node
-  linkType: hard
-
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -17798,6 +17820,13 @@ __metadata:
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
   checksum: 32f2dfd1e9b7168f9a9715eb1b4e21905850f3b50cf02cf476e47e4eebe8e6b762b63a64357896aa29b37e24922b4282df0f492e0d2ace572b43d15525976ff8
+  languageName: node
+  linkType: hard
+
+"source-map-js@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: #AP-4983

## What Changed

<!-- Insert a description below. -->
Use our re-forked `@chromaui/rrweb-snapshot` [package](https://www.npmjs.com/package/@chromaui/rrweb-snapshot?activeTab=versions) instead of `rrweb-snapshot` itself. This is so we can make changes to support constructed stylesheets without having to wait for rrweb to integrate them back in.

It also upgrades which version of rrweb-snapshot we're using (within our forked package). Previously we were using version `2.0.0-alpha.7`, now it's `2.0.0-alpha.17`.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
* Make sure none of the unit tests fail
* Make sure no Chromatic screenshots have changed
