### PR TITLE
Add second shadow DOM element to shadow DOM test pages

### DIFF
--- a/test-server/fixtures/constructable-stylesheets/shadow-dom.html
+++ b/test-server/fixtures/constructable-stylesheets/shadow-dom.html
@@ -6,6 +6,9 @@
       <h2>This section should have been generated using shadow DOM</h2>
     </div>
     <p>Paragraph outside the shadow DOM.</p>
+    <div id="shadowHost2">
+      <h2>This section should have been generated using shadow DOM</h2>
+    </div>
 
     <script type="text/javascript">
       const shadowElement = document.getElementById('shadowHost');
@@ -37,6 +40,38 @@
         }
       `);
       shadow.adoptedStyleSheets = [styles];
+    </script>
+
+    <script type="text/javascript">
+      const shadowElement2 = document.getElementById('shadowHost2');
+      const shadow2 = shadowElement2.attachShadow({ mode: 'open' });
+
+      const container2 = document.createElement('div');
+      shadow2.appendChild(container2);
+
+      const subHeading2 = document.createElement('h2');
+      subHeading2.innerHTML = 'This section is generated using shadow DOM (I should be red)';
+      container2.appendChild(subHeading2);
+
+      const paragraph2 = document.createElement('p');
+      paragraph2.innerHTML =
+        'This section is <strong>locally</strong> styled with constructable stylesheets created inside the shadow DOM. I should be <strong>purple</strong> and the section background should be <strong>yellow</strong>.';
+      container2.appendChild(paragraph2);
+
+      const styles2 = new CSSStyleSheet();
+      styles2.replaceSync(`
+        div {
+          background: yellow;
+          padding: 10px;
+        }            
+        h1, h2 {
+          color: red;
+        }
+        p {
+          color: purple;
+        }
+      `);
+      shadow2.adoptedStyleSheets = [styles2];
     </script>
   </body>
 </html>

--- a/test-server/fixtures/constructable-stylesheets/shadow-dom.html
+++ b/test-server/fixtures/constructable-stylesheets/shadow-dom.html
@@ -9,7 +9,6 @@
     <div id="shadowHost2">
       <h2>This section should have been generated using shadow DOM</h2>
     </div>
-    <div id="shadowHost3"></div>
 
     <script type="text/javascript">
       const attachShadowDomElement = (

--- a/test-server/fixtures/constructable-stylesheets/shadow-dom.html
+++ b/test-server/fixtures/constructable-stylesheets/shadow-dom.html
@@ -32,26 +32,26 @@
         paragraph.innerHTML = `This section is <strong>locally</strong> styled with constructable stylesheets created inside the shadow DOM. I should be <strong>${paragraphColor}</strong> and the section background should be <strong>${backgroundColor}</strong>.`;
         container.appendChild(paragraph);
 
-        const bodyStyle = new CSSStyleSheet();
-        bodyStyle.replaceSync(`
+        const bodyStyleSheet = new CSSStyleSheet();
+        bodyStyleSheet.replaceSync(`
           div {
             background: ${backgroundColor};
             padding: 10px;
           }            
         `);
-        const headerStyle = new CSSStyleSheet();
-        headerStyle.replaceSync(`
+        const headerStyleSheet = new CSSStyleSheet();
+        headerStyleSheet.replaceSync(`
           h1, h2 {
             color: ${headerColor};
           }
         `);
-        const paragraphStyle = new CSSStyleSheet();
-        paragraphStyle.replaceSync(`
+        const paragraphStyleSheet = new CSSStyleSheet();
+        paragraphStyleSheet.replaceSync(`
           p {
             color: ${paragraphColor};
           }
         `);
-        shadow.adoptedStyleSheets = [bodyStyle, headerStyle, paragraphStyle];
+        shadow.adoptedStyleSheets = [bodyStyleSheet, headerStyleSheet, paragraphStyleSheet];
       };
 
       attachShadowDomElement('shadowHost', 'cyan', 'blue', 'green');

--- a/test-server/fixtures/constructable-stylesheets/shadow-dom.html
+++ b/test-server/fixtures/constructable-stylesheets/shadow-dom.html
@@ -9,69 +9,53 @@
     <div id="shadowHost2">
       <h2>This section should have been generated using shadow DOM</h2>
     </div>
+    <div id="shadowHost3"></div>
 
     <script type="text/javascript">
-      const shadowElement = document.getElementById('shadowHost');
-      const shadow = shadowElement.attachShadow({ mode: 'open' });
+      const attachShadowDomElement = (
+        shadowHostId,
+        backgroundColor,
+        headerColor,
+        paragraphColor
+      ) => {
+        const shadowElement = document.getElementById(shadowHostId);
+        const shadow = shadowElement.attachShadow({ mode: 'open' });
 
-      const container = document.createElement('div');
-      shadow.appendChild(container);
+        const container = document.createElement('div');
+        shadow.appendChild(container);
 
-      const subHeading = document.createElement('h2');
-      subHeading.innerHTML = 'This section is generated using shadow DOM (I should be blue)';
-      container.appendChild(subHeading);
+        const subHeading = document.createElement('h2');
+        subHeading.innerHTML = `This section is generated using shadow DOM (I should be ${headerColor})`;
+        container.appendChild(subHeading);
 
-      const paragraph = document.createElement('p');
-      paragraph.innerHTML =
-        'This section is <strong>locally</strong> styled with constructable stylesheets created inside the shadow DOM. I should be <strong>green</strong> and the section background should be <strong>cyan</strong>.';
-      container.appendChild(paragraph);
+        const paragraph = document.createElement('p');
+        paragraph.innerHTML = `This section is <strong>locally</strong> styled with constructable stylesheets created inside the shadow DOM. I should be <strong>${paragraphColor}</strong> and the section background should be <strong>${backgroundColor}</strong>.`;
+        container.appendChild(paragraph);
 
-      const styles = new CSSStyleSheet();
-      styles.replaceSync(`
-        div {
-          background: cyan;
-          padding: 10px;
-        }            
-        h1, h2 {
-          color: blue;
-        }
-        p {
-          color: green;
-        }
-      `);
-      shadow.adoptedStyleSheets = [styles];
-    </script>
+        const bodyStyle = new CSSStyleSheet();
+        bodyStyle.replaceSync(`
+          div {
+            background: ${backgroundColor};
+            padding: 10px;
+          }            
+        `);
+        const headerStyle = new CSSStyleSheet();
+        headerStyle.replaceSync(`
+          h1, h2 {
+            color: ${headerColor};
+          }
+        `);
+        const paragraphStyle = new CSSStyleSheet();
+        paragraphStyle.replaceSync(`
+          p {
+            color: ${paragraphColor};
+          }
+        `);
+        shadow.adoptedStyleSheets = [bodyStyle, headerStyle, paragraphStyle];
+      };
 
-    <script type="text/javascript">
-      const shadowElement2 = document.getElementById('shadowHost2');
-      const shadow2 = shadowElement2.attachShadow({ mode: 'open' });
-
-      const container2 = document.createElement('div');
-      shadow2.appendChild(container2);
-
-      const subHeading2 = document.createElement('h2');
-      subHeading2.innerHTML = 'This section is generated using shadow DOM (I should be red)';
-      container2.appendChild(subHeading2);
-
-      const paragraph2 = document.createElement('p');
-      paragraph2.innerHTML =
-        'This section is <strong>locally</strong> styled with constructable stylesheets created inside the shadow DOM. I should be <strong>purple</strong> and the section background should be <strong>yellow</strong>.';
-      container2.appendChild(paragraph2);
-
-      const styles2 = new CSSStyleSheet();
-      styles2.replaceSync(`
-        div {
-          background: yellow;
-          padding: 10px;
-        }            
-        h1, h2 {
-          color: red;
-        }
-        p {
-          color: purple;
-        }
-      `);
-      shadow2.adoptedStyleSheets = [styles2];
+      attachShadowDomElement('shadowHost', 'cyan', 'blue', 'green');
+      attachShadowDomElement('shadowHost2', 'yellow', 'red', 'purple');
     </script>
   </body>
 </html>

--- a/test-server/fixtures/constructable-stylesheets/web-components-shadow-dom.html
+++ b/test-server/fixtures/constructable-stylesheets/web-components-shadow-dom.html
@@ -2,11 +2,33 @@
 <html>
   <body>
     <h1>Constructable Stylesheets in Web Components in Shadow DOM</h1>
-    <styled-component></styled-component>
+    <styled-component
+      background-color="cyan"
+      header-color="blue"
+      paragraph-color="green"
+    ></styled-component>
     <p>Paragraph outside the Web Component.</p>
+    <styled-component
+      background-color="yellow"
+      header-color="red"
+      paragraph-color="purple"
+    ></styled-component>
 
     <script type="text/javascript">
       class StyledComponent extends HTMLElement {
+        constructor() {
+          super();
+        }
+
+        static get observedAttributes() {
+          return ['background-color', 'header-color', 'paragraph-color'];
+        }
+
+        attributeChangedCallback(property, oldValue, newValue) {
+          if (oldValue === newValue) return;
+          this[property] = newValue;
+        }
+
         connectedCallback() {
           const shadow = this.attachShadow({ mode: 'open' });
 
@@ -18,24 +40,29 @@
           container.appendChild(h2);
 
           const p = document.createElement('p');
-          p.innerHTML =
-            'This section is <strong>locally</strong> styled with constructable stylesheets created inside the Web Component using shadow DOM. I should be <strong>green</strong> and the section background should be <strong>cyan</strong>.';
+          p.innerHTML = `This section is <strong>locally</strong> styled with constructable stylesheets created inside the Web Component using shadow DOM. I should be <strong>green</strong> and the section background should be <strong>${this['background-color']}</strong>.`;
           container.appendChild(p);
 
-          const stylesheet = new CSSStyleSheet();
-          stylesheet.replaceSync(`
+          const bodyStyleSheet = new CSSStyleSheet();
+          bodyStyleSheet.replaceSync(`
             div {
-              background: cyan;
+              background: ${this['background-color']};
               padding: 10px;
             }            
+          `);
+          const headerStylesheet = new CSSStyleSheet();
+          headerStylesheet.replaceSync(`
             h1, h2 {
-              color: blue;
-            }
-            p {
-              color: green;
+              color: ${this['header-color']};
             }
           `);
-          shadow.adoptedStyleSheets = [stylesheet];
+          const paragraphStylesheet = new CSSStyleSheet();
+          paragraphStylesheet.replaceSync(`
+            p {
+              color: ${this['paragraph-color']};
+            }
+          `);
+          shadow.adoptedStyleSheets = [bodyStyleSheet, headerStylesheet, paragraphStylesheet];
         }
       }
       customElements.define('styled-component', StyledComponent);

--- a/test-server/fixtures/constructable-stylesheets/web-components-shadow-dom.html
+++ b/test-server/fixtures/constructable-stylesheets/web-components-shadow-dom.html
@@ -36,11 +36,11 @@
           shadow.appendChild(container);
 
           const h2 = document.createElement('h2');
-          h2.innerHTML = 'This section is generated using a Web Component (I should be blue)';
+          h2.innerHTML = `This section is generated using a Web Component (I should be ${this['header-color']})`;
           container.appendChild(h2);
 
           const p = document.createElement('p');
-          p.innerHTML = `This section is <strong>locally</strong> styled with constructable stylesheets created inside the Web Component using shadow DOM. I should be <strong>green</strong> and the section background should be <strong>${this['background-color']}</strong>.`;
+          p.innerHTML = `This section is <strong>locally</strong> styled with constructable stylesheets created inside the Web Component using shadow DOM. I should be <strong>${this['paragraph-color']}</strong> and the section background should be <strong>${this['background-color']}</strong>.`;
           container.appendChild(p);
 
           const bodyStyleSheet = new CSSStyleSheet();


### PR DESCRIPTION
Issue: #AP-4984

## What Changed

This just adds a second instance of shadow DOM elements to a couple test pages, while also using multiple constructed stylesheets per element.

## How to test

For both Cypress and Playwright, look at the constructible-stylesheets `styles render in shadow DOM elements` and `styles render in web components in shadow DOM` stories to verify that they contain two instances of a block with a header and paragraph, instead of just one instance.