### PR TITLE
Upgrade rrweb-snapshot to support shadow DOM constructed stylesheets

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -72,7 +72,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@chromaui/rrweb-snapshot": "2.0.0-alpha.17",
+    "@chromaui/rrweb-snapshot": "2.0.0-alpha.17-noAbsolute",
     "@segment/analytics-node": "^1.1.0",
     "@storybook/addon-essentials": "^8.1.5",
     "@storybook/csf": "^0.1.0",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -63,7 +63,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@chromaui/rrweb-snapshot": "2.0.0-alpha.17",
+    "@chromaui/rrweb-snapshot": "2.0.0-alpha.17-noAbsolute",
     "@segment/analytics-node": "^1.1.0",
     "@storybook/addon-essentials": "^8.1.5",
     "@storybook/csf": "^0.1.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -111,7 +111,7 @@
     "*.{ts,js,css,md}": "prettier --write"
   },
   "dependencies": {
-    "@chromaui/rrweb-snapshot": "2.0.0-alpha.17",
+    "@chromaui/rrweb-snapshot": "2.0.0-alpha.17-noAbsolute",
     "@segment/analytics-node": "^1.1.0",
     "storybook": "^8.1.5"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3572,7 +3572,7 @@ __metadata:
   resolution: "@chromatic-com/cypress@workspace:packages/cypress"
   dependencies:
     "@chromatic-com/shared-e2e": "workspace:*"
-    "@chromaui/rrweb-snapshot": "npm:2.0.0-alpha.17"
+    "@chromaui/rrweb-snapshot": "npm:2.0.0-alpha.17-noAbsolute"
     "@segment/analytics-node": "npm:^1.1.0"
     "@storybook/addon-essentials": "npm:^8.1.5"
     "@storybook/csf": "npm:^0.1.0"
@@ -3594,7 +3594,7 @@ __metadata:
   resolution: "@chromatic-com/playwright@workspace:packages/playwright"
   dependencies:
     "@chromatic-com/shared-e2e": "workspace:*"
-    "@chromaui/rrweb-snapshot": "npm:2.0.0-alpha.17"
+    "@chromaui/rrweb-snapshot": "npm:2.0.0-alpha.17-noAbsolute"
     "@playwright/test": "npm:^1.46.1"
     "@segment/analytics-node": "npm:^1.1.0"
     "@storybook/addon-essentials": "npm:^8.1.5"
@@ -3622,7 +3622,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.21.4"
     "@babel/preset-react": "npm:^7.18.6"
     "@babel/preset-typescript": "npm:^7.21.4"
-    "@chromaui/rrweb-snapshot": "npm:2.0.0-alpha.17"
+    "@chromaui/rrweb-snapshot": "npm:2.0.0-alpha.17-noAbsolute"
     "@jest/types": "npm:^27.0.6"
     "@playwright/test": "npm:^1.46.1"
     "@segment/analytics-node": "npm:^1.1.0"
@@ -3700,12 +3700,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@chromaui/rrweb-snapshot@npm:2.0.0-alpha.17":
-  version: 2.0.0-alpha.17
-  resolution: "@chromaui/rrweb-snapshot@npm:2.0.0-alpha.17"
+"@chromaui/rrweb-snapshot@npm:2.0.0-alpha.17-noAbsolute":
+  version: 2.0.0-alpha.17-noAbsolute
+  resolution: "@chromaui/rrweb-snapshot@npm:2.0.0-alpha.17-noAbsolute"
   dependencies:
     postcss: "npm:^8.4.38"
-  checksum: cff6946425c2d8b4cf846d498f932ad985987491b91fb3ed43ed05c69444e7b29a690b350135d2086585e7ab37c09289a424888a6b82f76a5928f64a1270f2b6
+  checksum: 983b4a704145da353b73d6fb09675117466e833486ad2efc3033433655a9b12f4e00b05e884a9d4ca85947f01e60f57c14a3d8e809656e470a44bdcb082f9f85
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: #AP-5027

## What Changed

Just what the title says. Constructable stylesheets in shadow DOM elements will now be displayed in our captures.

## How to test

1. Run `yarn test:cypress && yarn archive-storybook:cypress`
2. View the `styles render in shadow dom elements` and `styles render in web components in shadow dom` stories in the `constructable-stylesheets` folder
3. Verify that the sections are styled with the colors described in the text on those story pages
4. Run `yarn test:playwright && yarn archive-storybook:playwright`
5. Repeats steps 2-3
6. OPTIONAL: Create your own Cypress or Playwright project that uses constructed stylesheets in shadow DOM elements and verify that they render as expected in the archived Storybook