### PR TITLE
PR template standardized

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,3 +23,14 @@ Check ☑️ the appropriate box once you've finished QA:
 
 - [ ] Author - QA OK
 - [ ] Reviewer - QA OK
+
+<!-- ignore-task-list-start -->
+
+<!--
+## Release checklist
+- [ ] https://github.com/chromaui/chromatic-e2e/blob/main/DEVELOPMENT.md#pr-workflow-with-changesets created in this PR
+
+
+-->
+
+<!-- ignore-task-list-end -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,12 +24,10 @@ Check ☑️ the appropriate box once you've finished QA:
 - [ ] Author - QA OK
 - [ ] Reviewer - QA OK
 
-<!-- ignore-task-list-start -->
+## Release checklist
 
 <!--
-## Release checklist
-- [ ] [Changeset](https://github.com/chromaui/chromatic-e2e/blob/main/DEVELOPMENT.md#pr-workflow-with-changesets) created in this PR
-
+  If you're not publishing the packages to NPM, delete this section.
 -->
 
-<!-- ignore-task-list-end -->
+- [ ] [Changeset](https://github.com/chromaui/chromatic-e2e/blob/main/DEVELOPMENT.md#pr-workflow-with-changesets) created in this PR

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ Check ☑️ the appropriate box once you've finished QA:
 
 <!--
 ## Release checklist
-- [ ] [Checklist](https://github.com/chromaui/chromatic-e2e/blob/main/DEVELOPMENT.md#pr-workflow-with-changesets) created in this PR
+- [ ] [Changeset](https://github.com/chromaui/chromatic-e2e/blob/main/DEVELOPMENT.md#pr-workflow-with-changesets) created in this PR
 
 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ Check ☑️ the appropriate box once you've finished QA:
 
 <!--
 ## Release checklist
-- [ ] https://github.com/chromaui/chromatic-e2e/blob/main/DEVELOPMENT.md#pr-workflow-with-changesets created in this PR
+- [ ] [Checklist](https://github.com/chromaui/chromatic-e2e/blob/main/DEVELOPMENT.md#pr-workflow-with-changesets) created in this PR
 
 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,25 @@
 Issue: #
 
-## What Changed
+## Summary
 
-<!-- Insert a description below. -->
+<!--
+  Describe the changes made.
+  What would someone unfamiliar with the project (but familiar with the codebase) need to understand what happened and why?
+-->
 
-## How to test
+## How to QA
 
-<!-- Add an explanation below for the reviewers to help them test your changes. -->
+<!--
+  Provide step-by-step instructions on how to verify the work.
+  Use the canary build of the e2e packages (created via the `release_canary` CI job with this PR)
+  If necessary, include details on how to test in production.
+
+  Don't forget to test related features!
+-->
+
+1.
+
+Check ☑️ the appropriate box once you've finished QA:
+
+- [ ] Author - QA OK
+- [ ] Reviewer - QA OK

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,6 @@ Check ☑️ the appropriate box once you've finished QA:
 ## Release checklist
 - [ ] [Changeset](https://github.com/chromaui/chromatic-e2e/blob/main/DEVELOPMENT.md#pr-workflow-with-changesets) created in this PR
 
-
 -->
 
 <!-- ignore-task-list-end -->

--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -1,0 +1,28 @@
+name: Checking PR checklist
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-pr-description:
+    runs-on: ubuntu-latest
+    steps:
+      - id: task-completed
+        uses: chromaui/task-completed-checker-action@main
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+        continue-on-error: true
+      - name: Update Check (failure)
+        if: steps.task-completed.outcome != 'success'
+        uses: ouzi-dev/commit-status-updater@v2
+        with:
+          name: PR Checklist
+          status: pending
+          description: Check off PR items to proceed
+      - name: Update Check (success)
+        if: steps.task-completed.outcome == 'success'
+        uses: ouzi-dev/commit-status-updater@v2
+        with:
+          name: PR Checklist
+          status: success
+          description: All tasks checked off!

--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -1,4 +1,5 @@
 name: Checking PR checklist
+permissions: read-all
 on:
   pull_request:
     types: [opened, edited, synchronize]


### PR DESCRIPTION
With [recent changes](https://github.com/chromaui/chromatic/pull/8947) to the Chromatic issue template, this PR brings this repo's PR template up to the same formatting. Minor differences occur where we need to be repo-specific or have different deploy steps.


## What Changed

<!-- Insert a description below. -->
The PR issue template includes checkboxes for QA and an optional release checklist
