### PR TITLE
Rename Chromatic `ignore` parameter to `ignoreSelectors`

### DIFF
--- a/.changeset/unlucky-houses-melt.md
+++ b/.changeset/unlucky-houses-melt.md
@@ -3,4 +3,4 @@
 '@chromatic-com/cypress': minor
 ---
 
-Rename Chromatic ignore parameter to ignoreSelectors
+Rename Chromatic `ignore` parameter to `ignoreSelectors`

--- a/.changeset/unlucky-houses-melt.md
+++ b/.changeset/unlucky-houses-melt.md
@@ -1,0 +1,6 @@
+---
+'@chromatic-com/playwright': minor
+'@chromatic-com/cypress': minor
+---
+
+Rename Chromatic ignore parameter to ignoreSelectors

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -54,7 +54,9 @@ afterEach(() => {
               ...(Cypress.env('cropToViewport') && {
                 cropToViewport: Cypress.env('cropToViewport'),
               }),
-              ...(Cypress.env('ignore') && { ignore: Cypress.env('ignore') }),
+              ...(Cypress.env('ignoreSelectors') && {
+                ignoreSelectors: Cypress.env('ignoreSelectors'),
+              }),
             },
             pageUrl: url,
             viewport: {

--- a/packages/cypress/tests/cypress/e2e/ignored-regions.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/ignored-regions.cy.ts
@@ -1,6 +1,6 @@
 // NOTE: This is a test that is meant to be run through Chromatic, so it doesn't actually work
 //       with the automated test suite.
-it('ignored regions work with chromatic', { env: { ignore: ['.custom-ignore'] } }, () => {
+it('ignored regions work with chromatic', { env: { ignoreSelectors: ['.custom-ignore'] } }, () => {
   cy.visit('/ignore');
   cy.wait(1000);
 });

--- a/packages/playwright/src/makeTest.ts
+++ b/packages/playwright/src/makeTest.ts
@@ -31,7 +31,7 @@ export const performChromaticSnapshot = async (
     resourceArchiveTimeout,
     assetDomains,
     cropToViewport,
-    ignore,
+    ignoreSelectors,
   }: ChromaticConfig & { page: Page },
   use: () => Promise<void>,
   testInfo: TestInfo
@@ -74,7 +74,7 @@ export const performChromaticSnapshot = async (
       ...(pauseAnimationAtEnd && { pauseAnimationAtEnd }),
       ...(prefersReducedMotion && { prefersReducedMotion }),
       ...(cropToViewport && { cropToViewport }),
-      ...(ignore && { ignore }),
+      ...(ignoreSelectors && { ignoreSelectors }),
     };
 
     // TestInfo.outputDir gives us the test-specific subfolder (https://playwright.dev/docs/api/class-testconfig#test-config-output-dir);
@@ -117,7 +117,7 @@ export const makeTest = (
     resourceArchiveTimeout: [DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS, { option: true }],
     assetDomains: [[], { option: true }],
     cropToViewport: [undefined, { option: true }],
-    ignore: [undefined, { option: true }],
+    ignoreSelectors: [undefined, { option: true }],
 
     chromaticSnapshot: [
       performChromaticSnapshot,

--- a/packages/playwright/tests/ignored-regions.spec.ts
+++ b/packages/playwright/tests/ignored-regions.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '../src';
 
 // NOTE: This is a test that is meant to be run through Chromatic, so it doesn't actually work
 //       with the automated test suite.
-test.describe('ignore regions', () => {
-  test.use({ ignore: ['.custom-ignore'] });
+test.describe(() => {
+  test.use({ ignoreSelectors: ['.custom-ignore'] });
   test('ignored regions work with chromatic', async ({ page }) => {
     test.setTimeout(2000);
     await page.goto('/ignore');

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -33,7 +33,7 @@ export interface ChromaticConfig {
   cropToViewport?: boolean;
 
   // CSS selectors of elements to ignore when comparing snapshots.
-  ignore?: string[];
+  ignoreSelectors?: string[];
 }
 
 export type ChromaticStorybookParameters = Omit<ChromaticConfig, 'disableAutoSnapshot'>;


### PR DESCRIPTION
Issue: #CAP-2256

## What Changed

<!-- Insert a description below. -->

We are renaming `ignore` to `ignoreSelectors`

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->

- Add a custom ignore element to a test page.
- Configure playwright/cypress to use that selector for ignore.
- Run Chromatic and ensure that the element is ignored.
