### PR TITLE
Picture elements are captured, including art direction

### DIFF
--- a/.changeset/eighty-bikes-peel.md
+++ b/.changeset/eighty-bikes-peel.md
@@ -1,0 +1,7 @@
+---
+'@chromatic-com/playwright': minor
+'@chromatic-com/cypress': minor
+'@chromatic-com/shared-e2e': minor
+---
+
+Picture tags are archived

--- a/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
@@ -43,7 +43,11 @@ it('picture is captured', () => {
   cy.visit('/asset-paths/picture');
 });
 
-it('picture captures fallback image', () => {
+// TODO: Unskip when we use one-archive-per-test in Cypress (like we do in Playwright)
+// currently, we use one archive for all the tests, but in this case it means we capture
+// the wrong image (since the unmatching images are already in the global archive, we
+// mistakenly assume they were "captured" by this test and use them instead of the fallback image)
+it.skip('picture captures fallback image', () => {
   cy.visit('/asset-paths/picture-no-matching-source');
 });
 

--- a/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
@@ -39,6 +39,10 @@ it('srcset is used to determine image asset URL', () => {
   cy.visit('/asset-paths/srcset');
 });
 
+it('picture is captured', () => {
+  cy.visit('/asset-paths/picture');
+});
+
 it('external CSS files are inlined', () => {
   cy.visit('/asset-paths/external-css-files');
 });

--- a/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
@@ -43,6 +43,10 @@ it('picture is captured', () => {
   cy.visit('/asset-paths/picture');
 });
 
+it('picture captures fallback image', () => {
+  cy.visit('/asset-paths/picture-no-matching-source');
+});
+
 it('external CSS files are inlined', () => {
   cy.visit('/asset-paths/external-css-files');
 });

--- a/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
@@ -39,7 +39,7 @@ it('srcset is used to determine image asset URL', () => {
   cy.visit('/asset-paths/srcset');
 });
 
-it('picture is captured', () => {
+it('picture source is captured, multiple source elements', () => {
   cy.visit('/asset-paths/picture');
 });
 
@@ -49,6 +49,10 @@ it('picture is captured', () => {
 // mistakenly assume they were "captured" by this test and use them instead of the fallback image)
 it.skip('picture captures fallback image', () => {
   cy.visit('/asset-paths/picture-no-matching-source');
+});
+
+it('picture source is captured, single source with srcset', () => {
+  cy.visit('/asset-paths/picture-multiple-srcset');
 });
 
 it('external CSS files are inlined', () => {

--- a/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
@@ -47,12 +47,32 @@ it('picture source is captured, multiple source elements', () => {
 // currently, we use one archive for all the tests, but in this case it means we capture
 // the wrong image (since the unmatching images are already in the global archive, we
 // mistakenly assume they were "captured" by this test and use them instead of the fallback image)
+context.skip('mobile', { viewportWidth: 500, viewportHeight: 500 }, () => {
+  it('picture source is captured, multiple source elements', () => {
+    cy.visit('/asset-paths/picture');
+  });
+});
+
+// TODO: Unskip when we use one-archive-per-test in Cypress (like we do in Playwright)
+// currently, we use one archive for all the tests, but in this case it means we capture
+// the wrong image (since the unmatching images are already in the global archive, we
+// mistakenly assume they were "captured" by this test and use them instead of the fallback image)
 it.skip('picture captures fallback image', () => {
   cy.visit('/asset-paths/picture-no-matching-source');
 });
 
 it('picture source is captured, single source with srcset', () => {
   cy.visit('/asset-paths/picture-multiple-srcset');
+});
+
+// TODO: Unskip when we use one-archive-per-test in Cypress (like we do in Playwright)
+// currently, we use one archive for all the tests, but in this case it means we capture
+// the wrong image (since the unmatching images are already in the global archive, we
+// mistakenly assume they were "captured" by this test and use them instead of the fallback image)
+context.skip('mobile', { viewportWidth: 500, viewportHeight: 500 }, () => {
+  it('picture source is captured, single source with srcset', () => {
+    cy.visit('/asset-paths/picture-multiple-srcset');
+  });
 });
 
 it('external CSS files are inlined', () => {

--- a/packages/playwright/tests/archiving-assets.spec.ts
+++ b/packages/playwright/tests/archiving-assets.spec.ts
@@ -53,6 +53,10 @@ test('picture is captured', async ({ page }) => {
   await page.goto('/asset-paths/picture');
 });
 
+test('picture captures fallback image', async ({ page }) => {
+  await page.goto('/asset-paths/picture-no-matching-source');
+});
+
 test('external CSS files are inlined', async ({ page }) => {
   await page.goto('/asset-paths/external-css-files');
 });

--- a/packages/playwright/tests/archiving-assets.spec.ts
+++ b/packages/playwright/tests/archiving-assets.spec.ts
@@ -49,6 +49,10 @@ test('srcset is used to determine image asset URL', async ({ page }) => {
   await page.goto('/asset-paths/srcset');
 });
 
+test('picture is captured', async ({ page }) => {
+  await page.goto('/asset-paths/picture');
+});
+
 test('external CSS files are inlined', async ({ page }) => {
   await page.goto('/asset-paths/external-css-files');
 });

--- a/packages/playwright/tests/archiving-assets.spec.ts
+++ b/packages/playwright/tests/archiving-assets.spec.ts
@@ -49,8 +49,12 @@ test('srcset is used to determine image asset URL', async ({ page }) => {
   await page.goto('/asset-paths/srcset');
 });
 
-test('picture is captured', async ({ page }) => {
+test('picture source is captured, multiple source elements', async ({ page }) => {
   await page.goto('/asset-paths/picture');
+});
+
+test('picture source is captured, single source with srcset', async ({ page }) => {
+  await page.goto('/asset-paths/picture-multiple-srcset');
 });
 
 test('picture captures fallback image', async ({ page }) => {

--- a/packages/shared/src/write-archive/dom-snapshot.test.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.test.ts
@@ -23,11 +23,7 @@ function createImgSrcsetSnapshot(backupUrl: string, smallUrl: string, largeUrl: 
   });
 }
 
-function createPictureSrcsetSnapshotSingleSource(
-  backupUrl: string,
-  smallUrl: string,
-  largeUrl: string
-) {
+function createPictureSrcsetSnapshotSingleSource(backupUrl: string, largeUrl: string) {
   return JSON.stringify({
     type: 2,
     tagName: 'picture',
@@ -58,7 +54,6 @@ function createPictureSrcsetSnapshotSingleSource(
 
 function createPictureSrcsetSnapshotSingleSourceImageHasAttributes(
   backupUrl: string,
-  smallUrl: string,
   largeUrl: string
 ) {
   return JSON.stringify({
@@ -201,6 +196,7 @@ const imageTag = {
   attributes: {
     src: queryUrlTransformed,
   },
+  // @ts-expect-error I don't want to deal with this right now
   childNodes: [],
   id: 61,
 };
@@ -266,7 +262,7 @@ describe('DOMSnapshot', () => {
 
     it('maps picture srcsets, single <source>', async () => {
       const domSnapshot = new DOMSnapshot(
-        createPictureSrcsetSnapshotSingleSource(relativeUrl, externalUrl, queryUrl)
+        createPictureSrcsetSnapshotSingleSource(relativeUrl, queryUrl)
       );
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
@@ -310,11 +306,7 @@ describe('DOMSnapshot', () => {
     // we don't want to get rid of any existing <img> attributes (like class for example)
     it('maps picture srcsets, preserves existing <img> attributes', async () => {
       const domSnapshot = new DOMSnapshot(
-        createPictureSrcsetSnapshotSingleSourceImageHasAttributes(
-          relativeUrl,
-          externalUrl,
-          queryUrl
-        )
+        createPictureSrcsetSnapshotSingleSourceImageHasAttributes(relativeUrl, queryUrl)
       );
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);

--- a/packages/shared/src/write-archive/dom-snapshot.test.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.test.ts
@@ -9,8 +9,18 @@ function createSnapshot(url1: string, url2: string, url3: string) {
   return `{"type":0,"childNodes":[{"type":1,"name":"html","publicId":"","systemId":"","id":2},{"type":2,"tagName":"html","attributes":{},"childNodes":[{"type":2,"tagName":"head","attributes":{},"childNodes":[{"type":3,"textContent":"    ","id":5},{"type":2,"tagName":"link","attributes":{"rel":"stylesheet","href":"/styles-test.css"},"childNodes":[],"id":6},{"type":3,"textContent":"    ","id":7},{"type":2,"tagName":"style","attributes":{},"childNodes":[{"type":3,"textContent":".test1 { background-image: url(\\"${url1}\\"); }.test2 { background-image: url(\\"${url2}\\"); }.test2 { background-image: url(\\"${url3}\\"); }","isStyle":true,"id":9}],"id":8},{"type":3,"textContent":"  ","id":10}],"id":4},{"type":3,"textContent":"  ","id":11},{"type":2,"tagName":"body","attributes":{},"childNodes":[{"type":3,"textContent":"    ","id":13},{"type":2,"tagName":"div","attributes":{"class":"image-container flex flex-wrap"},"childNodes":[{"type":3,"textContent":"      ","id":15},{"type":2,"tagName":"img","attributes":{"src":"${url1}"},"childNodes":[],"id":16},{"type":3,"textContent":"      ","id":17},{"type":2,"tagName":"img","attributes":{"src":"${url2}"},"childNodes":[],"id":18},{"type":3,"textContent":"      ","id":19},{"type":2,"tagName":"img","attributes":{"src":"${url3}"},"childNodes":[],"id":20},{"type":3,"textContent":"      ","id":21},{"type":2,"tagName":"div","attributes":{"style":"background: url('${url1}'); no-repeat center;"},"childNodes":[],"id":22},{"type":3,"textContent":"      ","id":23},{"type":2,"tagName":"div","attributes":{"style":"background: url('${url2}'); no-repeat center;"},"childNodes":[],"id":24},{"type":3,"textContent":"      ","id":25},{"type":2,"tagName":"div","attributes":{"style":"background: url('${url3}'); no-repeat center;"},"childNodes":[],"id":26},{"type":3,"textContent":"    ","id":27}],"id":14},{"type":3,"textContent":"  ","id":28}],"id":12}],"id":3}],"id":1}`;
 }
 
-function createSrcsetSnapshot(url1: string, url2: string, url3: string) {
-  return `{"type":2,"tagName":"img","attributes":{"srcset":"${url2} 384w, ${url3} 1920w","sizes":"(min-width: 768px) 768px, 192px","src":"${url1}"},"childNodes":[],"id":61}`;
+function createImgSrcsetSnapshot(backupUrl: string, smallUrl: string, largeUrl: string) {
+  return JSON.stringify({
+    type: 2,
+    tagName: 'img',
+    attributes: {
+      srcset: `${smallUrl} 384w, ${largeUrl} 1920w`,
+      sizes: '(min-width: 768px) 768px, 192px',
+      src: backupUrl,
+    },
+    childNodes: [],
+    id: 61,
+  });
 }
 
 const snapshot = createSnapshot(relativeUrl, externalUrl, queryUrl);
@@ -38,7 +48,9 @@ describe('DOMSnapshot', () => {
     });
 
     it('maps img srcsets', async () => {
-      const domSnapshot = new DOMSnapshot(createSrcsetSnapshot(relativeUrl, externalUrl, queryUrl));
+      const domSnapshot = new DOMSnapshot(
+        createImgSrcsetSnapshot(relativeUrl, externalUrl, queryUrl)
+      );
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
 
@@ -48,7 +60,7 @@ describe('DOMSnapshot', () => {
     });
 
     it('does not change img srcsets when no mapped asset found in source map', async () => {
-      const origSnapshot = createSrcsetSnapshot(relativeUrl, externalUrl, queryUrl);
+      const origSnapshot = createImgSrcsetSnapshot(relativeUrl, externalUrl, queryUrl);
       const domSnapshot = new DOMSnapshot(origSnapshot);
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(new Map<string, string>());

--- a/packages/shared/src/write-archive/dom-snapshot.test.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.test.ts
@@ -23,12 +23,92 @@ function createImgSrcsetSnapshot(backupUrl: string, smallUrl: string, largeUrl: 
   });
 }
 
-function createPictureSrcsetSnapshot(backupUrl: string, smallUrl: string, largeUrl: string) {
+function createPictureSrcsetSnapshotSingleSource(
+  backupUrl: string,
+  smallUrl: string,
+  largeUrl: string
+) {
   return JSON.stringify({
     type: 2,
     tagName: 'picture',
     attributes: {},
     childNodes: [
+      {
+        type: 2,
+        tagName: 'source',
+        attributes: {
+          srcset: largeUrl,
+        },
+        childNodes: [],
+        id: 63,
+      },
+      {
+        type: 2,
+        tagName: 'img',
+        attributes: {
+          src: backupUrl,
+        },
+        childNodes: [],
+        id: 61,
+      },
+    ],
+    id: 62,
+  });
+}
+
+function createPictureSrcsetSnapshotSingleSourceMultipleSrcsets(
+  backupUrl: string,
+  smallUrl: string,
+  largeUrl: string
+) {
+  return JSON.stringify({
+    type: 2,
+    tagName: 'picture',
+    attributes: {},
+    childNodes: [
+      {
+        type: 2,
+        tagName: 'source',
+        attributes: {
+          expectedMappedSnapshot,
+          srcset: `${smallUrl} 2000w, ${largeUrl} 900w`,
+        },
+        childNodes: [],
+        id: 63,
+      },
+      {
+        type: 2,
+        tagName: 'img',
+        attributes: {
+          src: backupUrl,
+        },
+        childNodes: [],
+        id: 61,
+      },
+    ],
+    id: 62,
+  });
+}
+
+function createPictureSrcsetSnapshotMultipleSources(
+  backupUrl: string,
+  smallUrl: string,
+  largeUrl: string
+) {
+  return JSON.stringify({
+    type: 2,
+    tagName: 'picture',
+    attributes: {},
+    childNodes: [
+      {
+        type: 2,
+        tagName: 'source',
+        attributes: {
+          srcset: smallUrl,
+        },
+        childNodes: [],
+        id: 64,
+      },
       {
         type: 2,
         tagName: 'source',
@@ -105,7 +185,59 @@ describe('DOMSnapshot', () => {
 
     it('maps picture srcsets, single <source>', async () => {
       const domSnapshot = new DOMSnapshot(
-        createPictureSrcsetSnapshot(relativeUrl, externalUrl, queryUrl)
+        createPictureSrcsetSnapshotSingleSource(relativeUrl, externalUrl, queryUrl)
+      );
+
+      const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
+
+      expect(JSON.parse(mappedSnapshot)).toEqual({
+        type: 2,
+        tagName: 'picture',
+        attributes: {},
+        childNodes: [
+          {
+            type: 2,
+            tagName: 'img',
+            attributes: {
+              src: queryUrlTransformed,
+            },
+            childNodes: [],
+            id: 61,
+          },
+        ],
+        id: 62,
+      });
+    });
+
+    it('maps picture srcsets, multiple <source>s', async () => {
+      const domSnapshot = new DOMSnapshot(
+        createPictureSrcsetSnapshotMultipleSources(relativeUrl, externalUrl, queryUrl)
+      );
+
+      const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
+
+      expect(JSON.parse(mappedSnapshot)).toEqual({
+        type: 2,
+        tagName: 'picture',
+        attributes: {},
+        childNodes: [
+          {
+            type: 2,
+            tagName: 'img',
+            attributes: {
+              src: queryUrlTransformed,
+            },
+            childNodes: [],
+            id: 61,
+          },
+        ],
+        id: 62,
+      });
+    });
+
+    it('maps picture srcsets, single <source> with multiple srcset values', async () => {
+      const domSnapshot = new DOMSnapshot(
+        createPictureSrcsetSnapshotSingleSourceMultipleSrcsets(relativeUrl, externalUrl, queryUrl)
       );
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);

--- a/packages/shared/src/write-archive/dom-snapshot.test.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.test.ts
@@ -83,9 +83,15 @@ describe('DOMSnapshot', () => {
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
 
-      expect(mappedSnapshot).toEqual(
-        `{"type":2,"tagName":"img","attributes":{"src":"${queryUrlTransformed}"},"childNodes":[],"id":61}`
-      );
+      expect(JSON.parse(mappedSnapshot)).toEqual({
+        type: 2,
+        tagName: 'img',
+        attributes: {
+          src: `${queryUrlTransformed}`,
+        },
+        childNodes: [],
+        id: 61,
+      });
     });
 
     it('does not change img srcsets when no mapped asset found in source map', async () => {

--- a/packages/shared/src/write-archive/dom-snapshot.test.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.test.ts
@@ -9,7 +9,15 @@ function createSnapshot(url1: string, url2: string, url3: string) {
   return `{"type":0,"childNodes":[{"type":1,"name":"html","publicId":"","systemId":"","id":2},{"type":2,"tagName":"html","attributes":{},"childNodes":[{"type":2,"tagName":"head","attributes":{},"childNodes":[{"type":3,"textContent":"    ","id":5},{"type":2,"tagName":"link","attributes":{"rel":"stylesheet","href":"/styles-test.css"},"childNodes":[],"id":6},{"type":3,"textContent":"    ","id":7},{"type":2,"tagName":"style","attributes":{},"childNodes":[{"type":3,"textContent":".test1 { background-image: url(\\"${url1}\\"); }.test2 { background-image: url(\\"${url2}\\"); }.test2 { background-image: url(\\"${url3}\\"); }","isStyle":true,"id":9}],"id":8},{"type":3,"textContent":"  ","id":10}],"id":4},{"type":3,"textContent":"  ","id":11},{"type":2,"tagName":"body","attributes":{},"childNodes":[{"type":3,"textContent":"    ","id":13},{"type":2,"tagName":"div","attributes":{"class":"image-container flex flex-wrap"},"childNodes":[{"type":3,"textContent":"      ","id":15},{"type":2,"tagName":"img","attributes":{"src":"${url1}"},"childNodes":[],"id":16},{"type":3,"textContent":"      ","id":17},{"type":2,"tagName":"img","attributes":{"src":"${url2}"},"childNodes":[],"id":18},{"type":3,"textContent":"      ","id":19},{"type":2,"tagName":"img","attributes":{"src":"${url3}"},"childNodes":[],"id":20},{"type":3,"textContent":"      ","id":21},{"type":2,"tagName":"div","attributes":{"style":"background: url('${url1}'); no-repeat center;"},"childNodes":[],"id":22},{"type":3,"textContent":"      ","id":23},{"type":2,"tagName":"div","attributes":{"style":"background: url('${url2}'); no-repeat center;"},"childNodes":[],"id":24},{"type":3,"textContent":"      ","id":25},{"type":2,"tagName":"div","attributes":{"style":"background: url('${url3}'); no-repeat center;"},"childNodes":[],"id":26},{"type":3,"textContent":"    ","id":27}],"id":14},{"type":3,"textContent":"  ","id":28}],"id":12}],"id":3}],"id":1}`;
 }
 
-function createImgSrcsetSnapshot(backupUrl: string, smallUrl: string, largeUrl: string) {
+function createImgSrcsetSnapshot({
+  backupUrl,
+  smallUrl,
+  largeUrl,
+}: {
+  backupUrl: string;
+  smallUrl: string;
+  largeUrl: string;
+}) {
   return JSON.stringify({
     type: 2,
     tagName: 'img',
@@ -23,7 +31,13 @@ function createImgSrcsetSnapshot(backupUrl: string, smallUrl: string, largeUrl: 
   });
 }
 
-function createPictureSrcsetSnapshotSingleSource(backupUrl: string, largeUrl: string) {
+function createPictureSrcsetSnapshotSingleSource({
+  backupUrl,
+  matchingUrl,
+}: {
+  backupUrl: string;
+  matchingUrl: string;
+}) {
   return JSON.stringify({
     type: 2,
     tagName: 'picture',
@@ -33,7 +47,7 @@ function createPictureSrcsetSnapshotSingleSource(backupUrl: string, largeUrl: st
         type: 2,
         tagName: 'source',
         attributes: {
-          srcset: largeUrl,
+          srcset: matchingUrl,
         },
         childNodes: [],
         id: 63,
@@ -52,10 +66,13 @@ function createPictureSrcsetSnapshotSingleSource(backupUrl: string, largeUrl: st
   });
 }
 
-function createPictureSrcsetSnapshotSingleSourceImageHasAttributes(
-  backupUrl: string,
-  largeUrl: string
-) {
+function createPictureSrcsetSnapshotSingleSourceImageHasAttributes({
+  backupUrl,
+  matchingUrl,
+}: {
+  backupUrl: string;
+  matchingUrl: string;
+}) {
   return JSON.stringify({
     type: 2,
     tagName: 'picture',
@@ -65,7 +82,7 @@ function createPictureSrcsetSnapshotSingleSourceImageHasAttributes(
         type: 2,
         tagName: 'source',
         attributes: {
-          srcset: largeUrl,
+          srcset: matchingUrl,
         },
         childNodes: [],
         id: 63,
@@ -85,11 +102,15 @@ function createPictureSrcsetSnapshotSingleSourceImageHasAttributes(
   });
 }
 
-function createPictureSrcsetSnapshotSingleSourceMultipleSrcsets(
-  backupUrl: string,
-  smallUrl: string,
-  largeUrl: string
-) {
+function createPictureSrcsetSnapshotSingleSourceMultipleSrcsets({
+  backupUrl,
+  wrongUrl,
+  matchingUrl,
+}: {
+  backupUrl: string;
+  wrongUrl: string;
+  matchingUrl: string;
+}) {
   return JSON.stringify({
     type: 2,
     tagName: 'picture',
@@ -100,7 +121,7 @@ function createPictureSrcsetSnapshotSingleSourceMultipleSrcsets(
         tagName: 'source',
         attributes: {
           expectedMappedSnapshot,
-          srcset: `${smallUrl} 2000w, ${largeUrl} 900w`,
+          srcset: `${wrongUrl} 2000w, ${matchingUrl} 900w`,
         },
         childNodes: [],
         id: 63,
@@ -119,11 +140,15 @@ function createPictureSrcsetSnapshotSingleSourceMultipleSrcsets(
   });
 }
 
-function createPictureSrcsetSnapshotMultipleSources(
-  backupUrl: string,
-  smallUrl: string,
-  largeUrl: string
-) {
+function createPictureSrcsetSnapshotMultipleSources({
+  backupUrl,
+  wrongUrl,
+  matchingUrl,
+}: {
+  backupUrl: string;
+  wrongUrl: string;
+  matchingUrl: string;
+}) {
   return JSON.stringify({
     type: 2,
     tagName: 'picture',
@@ -133,7 +158,7 @@ function createPictureSrcsetSnapshotMultipleSources(
         type: 2,
         tagName: 'source',
         attributes: {
-          srcset: smallUrl,
+          srcset: wrongUrl,
         },
         childNodes: [],
         id: 64,
@@ -142,7 +167,7 @@ function createPictureSrcsetSnapshotMultipleSources(
         type: 2,
         tagName: 'source',
         attributes: {
-          srcset: largeUrl,
+          srcset: matchingUrl,
         },
         childNodes: [],
         id: 63,
@@ -161,7 +186,13 @@ function createPictureSrcsetSnapshotMultipleSources(
   });
 }
 
-function createPictureSrcsetNoUrlMatches(wrongUrl: string, alsoWrongUrl: string) {
+function createPictureSrcsetNoUrlMatches({
+  wrongUrl,
+  alsoWrongUrl,
+}: {
+  wrongUrl: string;
+  alsoWrongUrl: string;
+}) {
   return JSON.stringify({
     type: 2,
     tagName: 'picture',
@@ -235,7 +266,11 @@ describe('DOMSnapshot', () => {
 
     it('maps img srcsets', async () => {
       const domSnapshot = new DOMSnapshot(
-        createImgSrcsetSnapshot(relativeUrl, externalUrl, queryUrl)
+        createImgSrcsetSnapshot({
+          backupUrl: relativeUrl,
+          smallUrl: externalUrl,
+          largeUrl: queryUrl,
+        })
       );
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
@@ -252,7 +287,11 @@ describe('DOMSnapshot', () => {
     });
 
     it('does not change img srcsets when no mapped asset found in source map', async () => {
-      const originalSnapshot = createImgSrcsetSnapshot(relativeUrl, externalUrl, queryUrl);
+      const originalSnapshot = createImgSrcsetSnapshot({
+        backupUrl: relativeUrl,
+        smallUrl: externalUrl,
+        largeUrl: queryUrl,
+      });
       const domSnapshot = new DOMSnapshot(originalSnapshot);
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(new Map<string, string>());
@@ -262,7 +301,7 @@ describe('DOMSnapshot', () => {
 
     it('maps picture srcsets, single <source>', async () => {
       const domSnapshot = new DOMSnapshot(
-        createPictureSrcsetSnapshotSingleSource(relativeUrl, queryUrl)
+        createPictureSrcsetSnapshotSingleSource({ backupUrl: relativeUrl, matchingUrl: queryUrl })
       );
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
@@ -272,7 +311,11 @@ describe('DOMSnapshot', () => {
 
     it('maps picture srcsets, multiple <source>s', async () => {
       const domSnapshot = new DOMSnapshot(
-        createPictureSrcsetSnapshotMultipleSources(relativeUrl, externalUrl, queryUrl)
+        createPictureSrcsetSnapshotMultipleSources({
+          backupUrl: relativeUrl,
+          wrongUrl: externalUrl,
+          matchingUrl: queryUrl,
+        })
       );
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
@@ -282,7 +325,11 @@ describe('DOMSnapshot', () => {
 
     it('maps picture srcsets, single <source> with multiple srcset values', async () => {
       const domSnapshot = new DOMSnapshot(
-        createPictureSrcsetSnapshotSingleSourceMultipleSrcsets(relativeUrl, externalUrl, queryUrl)
+        createPictureSrcsetSnapshotSingleSourceMultipleSrcsets({
+          backupUrl: relativeUrl,
+          wrongUrl: externalUrl,
+          matchingUrl: queryUrl,
+        })
       );
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
@@ -291,10 +338,10 @@ describe('DOMSnapshot', () => {
     });
 
     it('maps picture srcsets, <picture> and children left untouched if there is no URL match', async () => {
-      const originalSnapshot = createPictureSrcsetNoUrlMatches(
-        '/totally-bogus-url.png',
-        'https://another-totally-bogus.com/url.png'
-      );
+      const originalSnapshot = createPictureSrcsetNoUrlMatches({
+        wrongUrl: '/totally-bogus-url.png',
+        alsoWrongUrl: 'https://another-totally-bogus.com/url.png',
+      });
       const domSnapshot = new DOMSnapshot(originalSnapshot);
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
@@ -306,7 +353,10 @@ describe('DOMSnapshot', () => {
     // we don't want to get rid of any existing <img> attributes (like class for example)
     it('maps picture srcsets, preserves existing <img> attributes', async () => {
       const domSnapshot = new DOMSnapshot(
-        createPictureSrcsetSnapshotSingleSourceImageHasAttributes(relativeUrl, queryUrl)
+        createPictureSrcsetSnapshotSingleSourceImageHasAttributes({
+          backupUrl: relativeUrl,
+          matchingUrl: queryUrl,
+        })
       );
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);

--- a/packages/shared/src/write-archive/dom-snapshot.test.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.test.ts
@@ -1,3 +1,4 @@
+import { serializedNodeWithId } from '@chromaui/rrweb-snapshot';
 import { DOMSnapshot } from './dom-snapshot';
 
 const relativeUrl = '/images/image.png';
@@ -227,8 +228,7 @@ const imageTag = {
   attributes: {
     src: queryUrlTransformed,
   },
-  // @ts-expect-error I don't want to deal with this right now
-  childNodes: [],
+  childNodes: [] as serializedNodeWithId[],
   id: 61,
 };
 

--- a/packages/shared/src/write-archive/dom-snapshot.test.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.test.ts
@@ -23,6 +23,35 @@ function createImgSrcsetSnapshot(backupUrl: string, smallUrl: string, largeUrl: 
   });
 }
 
+function createPictureSrcsetSnapshot(backupUrl: string, smallUrl: string, largeUrl: string) {
+  return JSON.stringify({
+    type: 2,
+    tagName: 'picture',
+    attributes: {},
+    childNodes: [
+      {
+        type: 2,
+        tagName: 'source',
+        attributes: {
+          srcset: largeUrl,
+        },
+        childNodes: [],
+        id: 63,
+      },
+      {
+        type: 2,
+        tagName: 'img',
+        attributes: {
+          src: backupUrl,
+        },
+        childNodes: [],
+        id: 61,
+      },
+    ],
+    id: 62,
+  });
+}
+
 const snapshot = createSnapshot(relativeUrl, externalUrl, queryUrl);
 const expectedMappedSnapshot = createSnapshot(relativeUrl, externalUrl, queryUrlTransformed);
 
@@ -66,6 +95,32 @@ describe('DOMSnapshot', () => {
       const mappedSnapshot = await domSnapshot.mapAssetPaths(new Map<string, string>());
 
       expect(mappedSnapshot).toEqual(origSnapshot);
+    });
+
+    it('maps picture srcsets, single <source>', async () => {
+      const domSnapshot = new DOMSnapshot(
+        createPictureSrcsetSnapshot(relativeUrl, externalUrl, queryUrl)
+      );
+
+      const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
+
+      expect(JSON.parse(mappedSnapshot)).toEqual({
+        type: 2,
+        tagName: 'picture',
+        attributes: {},
+        childNodes: [
+          {
+            type: 2,
+            tagName: 'img',
+            attributes: {
+              src: queryUrlTransformed,
+            },
+            childNodes: [],
+            id: 61,
+          },
+        ],
+        id: 62,
+      });
     });
   });
 });

--- a/packages/shared/src/write-archive/dom-snapshot.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.ts
@@ -104,10 +104,11 @@ export class DOMSnapshot {
   private mapPictureElement(node: serializedElementNodeWithId, sourceMap: Map<string, string>) {
     const allSourceUrls: string[] = node.childNodes
       .filter(this.isSourceElement)
-      .map((childNode) => {
+      .map((childNode: serializedElementNodeWithId) => {
         // there can be multiple values in a single srcset, extract all of them
-        // @ts-expect-error attributes does exist on source
-        const sourceSetValues = srcset.parse(childNode.attributes.srcset);
+        const sourceSetValues = srcset.parse(
+          (childNode.attributes?.srcset as string | undefined) ?? ''
+        );
         return sourceSetValues.map((srcSetValue) => srcSetValue.url);
       })
       // since srcsets can have multiple values, we will have a nested array here
@@ -127,9 +128,8 @@ export class DOMSnapshot {
       // replace the <img> tag's `src` with this asset-mapped URL
       const imageElement = node.childNodes.find(
         (childNode) => childNode.type === NodeType.Element && childNode.tagName === 'img'
-      );
-      if (imageElement) {
-        // @ts-expect-error attributes does exist on img
+      ) as serializedElementNodeWithId;
+      if (imageElement && imageElement.attributes) {
         imageElement.attributes.src = sourceMap.get(matchingUrl);
       }
     }

--- a/packages/shared/src/write-archive/dom-snapshot.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.ts
@@ -93,21 +93,19 @@ export class DOMSnapshot {
         }
       }
 
-      /*
-        CONSIDER:
-        can source srcsets have more than one item, or have complex item (url 2x stuff)?
-        If so, parse those out
-
-        If matchingUrl AND imageElement don't exist, don't blow all the source tags away
-      */
-
       if (node.tagName === 'picture') {
-        const allSourceUrls = node.childNodes
+        const allSourceUrls: string[] = node.childNodes
           .filter(
             (childNode) => childNode.type === NodeType.Element && childNode.tagName === 'source'
           )
-          // @ts-expect-error attributes does exist on source
-          .map((childNode) => childNode.attributes.srcset);
+          .map((childNode) => {
+            // there can be multiple values in a single srcset, extract all of them
+            // @ts-expect-error attributes does exist on source
+            const sourceSetValues = srcset.parse(childNode.attributes.srcset);
+            return sourceSetValues.map((srcSetValue) => srcSetValue.url);
+          })
+          // since srcsets can have multiple values, we will have a nested array here
+          .flat();
 
         // we have all of the raw URLs.
         const matchingUrl = allSourceUrls.find((sourceUrl) => {

--- a/packages/shared/src/write-archive/dom-snapshot.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.ts
@@ -130,6 +130,9 @@ export class DOMSnapshot {
         (childNode) => childNode.type === NodeType.Element && childNode.tagName === 'img'
       ) as serializedElementNodeWithId;
       if (imageElement && imageElement.attributes) {
+        // we're assuming that whatever was archived is an image URL
+        // this should be the case (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source#srcset),
+        // but noting it here as it'a an assumption
         imageElement.attributes.src = sourceMap.get(matchingUrl);
       }
     }

--- a/packages/shared/src/write-archive/dom-snapshot.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.ts
@@ -107,6 +107,7 @@ export class DOMSnapshot {
           .filter(
             (childNode) => childNode.type === NodeType.Element && childNode.tagName === 'source'
           )
+          // @ts-expect-error attributes does exist on source
           .map((childNode) => childNode.attributes.srcset);
         console.log('uruls', allSourceUrls);
         // we have all of the raw URLs.
@@ -127,6 +128,7 @@ export class DOMSnapshot {
             (childNode) => childNode.type === NodeType.Element && childNode.tagName === 'img'
           );
           if (imageElement) {
+            // @ts-expect-error attributes does exist on img
             imageElement.attributes.src = sourceMap.get(matchingUrl);
           }
         }

--- a/packages/shared/src/write-archive/dom-snapshot.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.ts
@@ -102,20 +102,19 @@ export class DOMSnapshot {
       */
 
       if (node.tagName === 'picture') {
-        console.log('SOURCE', node);
         const allSourceUrls = node.childNodes
           .filter(
             (childNode) => childNode.type === NodeType.Element && childNode.tagName === 'source'
           )
           // @ts-expect-error attributes does exist on source
           .map((childNode) => childNode.attributes.srcset);
-        console.log('uruls', allSourceUrls);
+
         // we have all of the raw URLs.
         const matchingUrl = allSourceUrls.find((sourceUrl) => {
           // find a url in the asset map... by which we mean in the sourceMap
           return sourceMap.has(sourceUrl);
         });
-        console.log('matching url', matchingUrl);
+
         // do any of my children match what is in there?
         if (matchingUrl) {
           // if so, blow away all <source> tags

--- a/test-server/fixtures/asset-paths/picture-multiple-srcset.html
+++ b/test-server/fixtures/asset-paths/picture-multiple-srcset.html
@@ -1,9 +1,13 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <!-- Crucial to make sure we factor out DPI when choosing an image -->
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
   <body>
     <picture>
       <!-- Instead of having multiple <source> elements, we have 1 that suggests (NOT specifies) which image should be used -->
-      <source srcset="/img?url=fixtures/pink.png 1500w, /img?url=fixtures/blue.png 600w" />
+      <source srcset="/img?url=fixtures/pink.png 2000w, /img?url=fixtures/blue.png 900w" />
       <img src="/img?url=fixtures/purple.png" />
     </picture>
     <p class="text-sm">blue < 768px <= pink</p>

--- a/test-server/fixtures/asset-paths/picture-multiple-srcset.html
+++ b/test-server/fixtures/asset-paths/picture-multiple-srcset.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <picture>
+      <!-- Instead of having multiple <source> elements, we have 1 that suggests (NOT specifies) which image should be used -->
+      <source srcset="/img?url=fixtures/pink.png 1500w, /img?url=fixtures/blue.png 600w" />
+      <img src="/img?url=fixtures/purple.png" />
+    </picture>
+    <p class="text-sm">blue < 768px <= pink</p>
+  </body>
+</html>

--- a/test-server/fixtures/asset-paths/picture-no-matching-source.html
+++ b/test-server/fixtures/asset-paths/picture-no-matching-source.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <picture>
+      <!-- both <source>s have media stipulations that should "never" be true -->
+      <source srcset="/img?url=fixtures/pink.png" media="(min-width: 7068px)" />
+      <source srcset="/img?url=fixtures/blue.png" media="(max-width: 20px)" />
+      <!-- We should, then, "always" be rendering this purple image as it is the fallback -->
+      <img src="/img?url=fixtures/purple.png" />
+    </picture>
+    <p class="text-sm">Should show purple as it's the only compatible image</p>
+  </body>
+</html>

--- a/test-server/fixtures/asset-paths/picture.html
+++ b/test-server/fixtures/asset-paths/picture.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <picture>
+      <source srcset="/img?url=fixtures/pink.png" media="(min-width: 768px)" />
+      <source srcset="/img?url=fixtures/blue.png" />
+      <img src="/img?url=fixtures/purple.png" />
+    </picture>
+    <p class="text-sm">blue < 768px <= pink</p>
+  </body>
+</html>

--- a/test-server/fixtures/asset-paths/picture.html
+++ b/test-server/fixtures/asset-paths/picture.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
   <body>
     <picture>
       <source srcset="/img?url=fixtures/pink.png" media="(min-width: 768px)" />


### PR DESCRIPTION
Issue: #AP-3783

## What Changed

<!-- Insert a description below. -->
We now properly snapshot `<picture>` elements.

## Background
A `<picture>` element can have multiple <source> child elements, but has to have exactly one `<img>` element (the img is used as a fallback in case none of the sources are supported or match the media queries/pixel densities provided).

## Our solution

Similar to @tevanoff's [img srcset fix](https://github.com/chromaui/chromatic-e2e/pull/40), we'll see if any of the `<picture>`'s `<source>` or `<img>` tags' srcset or src properties match an an item in our asset map. If so, we'll blow away all the `<source>`s of the `<picture>` tag and modify the existing `<img>` tag with the src set to the archived resource.

We take care not to modify _other_ attributes of the `<img>` tag, (like `class`), as we don't want to affect the original styling of the picture.


## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->

We only need to manually test Cypress for mobile screens:
1. Create a new (or use an existing) Cypress Chromatic project
2. Create a page-under-test that renders a `<picture>` element with multiple `<source>`s that have differing image URLs -- one for desktop, one for mobile ([see here](https://github.com/chromaui/chromatic-e2e/blob/bfed37f1b1b54b027a413f8e063ff7b0b2afd9db/test-server/fixtures/asset-paths/picture.html) for example HTML, but better if you write your own)
3. Create a Cypress test that tests this page in mobile-sized view ([see here](https://github.com/chromaui/chromatic-e2e/blob/bfed37f1b1b54b027a413f8e063ff7b0b2afd9db/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts#L72-L76) for example)
4. Create a Cypress test that tests this page in desk-top sized view (can just omit the viewport options)
5. Run Cypress and Chromatic
4. In the small-test Chromatic snapshot, verify that the small-sized image is captured
4. In the large-test Chromatic snapshot, verify that the large-sized image is captured

The automated tests cover the rest:
* Unit tests assure the nuts-and-bolts of picture-source-finding work
* UI Tests assure that we 1) capture `<picture>` elements', well, pictures, as well as get the right one in the right circumstance

- [x] Author QA
- [x] Reviewer QA