### PR TITLE
Properly load rrweb-snapshot on AMD-based web pages

### DIFF
--- a/.changeset/little-donuts-push.md
+++ b/.changeset/little-donuts-push.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/playwright': patch
+---
+
+Add support for AMD module-based web pages

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -35,6 +35,9 @@ async function takeSnapshot(
   // Serialize and capture the DOM
   const domSnapshot: elementNode = await page.evaluate(dedent`
     ${rrweb};
+    // page.evaluate returns the value of the function being evaluated. In this case, it means that
+    // it is returning either the resolved value of the Promise or the return value of the call to
+    // the snapshot function. See https://playwright.dev/docs/api/class-page#page-evaluate.
     if (typeof define === "function" && define.amd) {
       // AMD support is detected, so we need to load rrwebSnapshot asynchronously
       new Promise((resolve) => {

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -36,6 +36,7 @@ async function takeSnapshot(
   const domSnapshot: elementNode = await page.evaluate(dedent`
     ${rrweb};
     if (typeof define === "function" && define.amd) {
+      // AMD support is detected, so we need to load rrwebSnapshot asynchronously
       new Promise((resolve) => {
         require(['rrwebSnapshot'], (rrwebSnapshot) => {
           resolve(rrwebSnapshot.snapshot(document));

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -35,7 +35,15 @@ async function takeSnapshot(
   // Serialize and capture the DOM
   const domSnapshot: elementNode = await page.evaluate(dedent`
     ${rrweb};
-    rrwebSnapshot.snapshot(document);
+    if (typeof define === "function" && define.amd) {
+      new Promise((resolve) => {
+        require(['rrwebSnapshot'], (rrwebSnapshot) => {
+          resolve(rrwebSnapshot.snapshot(document));
+        });
+      });
+    } else {
+      rrwebSnapshot.snapshot(document);
+    }
   `);
 
   const bufferedSnapshot = Buffer.from(JSON.stringify(domSnapshot));

--- a/packages/playwright/tests/amd.spec.ts
+++ b/packages/playwright/tests/amd.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '../src';
+
+test('pages with AMD modules are archived', async ({ page }) => {
+  await page.goto('/amd');
+  await expect(page.getByText('Sum of')).toBeVisible();
+});

--- a/test-server/fixtures/amd.html
+++ b/test-server/fixtures/amd.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>AMD Example</title>
+    <script
+      data-main="scripts/amd"
+      src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"
+    ></script>
+  </head>
+  <body>
+    This is a basic page with some math content below that is loaded from an AMD module:
+    <div id="output"></div>
+  </body>
+</html>

--- a/test-server/fixtures/assets/scripts/amd.js
+++ b/test-server/fixtures/assets/scripts/amd.js
@@ -1,0 +1,12 @@
+requirejs.config({
+  basePath: 'fixtures/amd',
+  paths: {
+    lodash: 'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min',
+  },
+});
+
+require(['lodash'], function (_) {
+  const numbers = [1, 2, 3, 4, 5];
+  const sum = _.sum(numbers);
+  document.getElementById('output').textContent = `Sum of ${numbers.join('+')} = ${sum}`;
+});

--- a/test-server/server.js
+++ b/test-server/server.js
@@ -132,6 +132,10 @@ app.get('/constructable-stylesheets/:page', (req, res) => {
   res.sendFile(path.join(__dirname, `fixtures/constructable-stylesheets/${page}.html`));
 });
 
+app.get('/amd', (req, res) => {
+  res.sendFile(path.join(__dirname, 'fixtures/amd.html'));
+});
+
 app.listen(port, () => {
   console.log(`Example app listening on port ${port}`);
 });


### PR DESCRIPTION
Issue: #AP-5218

## What Changed

<!-- Insert a description below. -->

Any tests using `@chromatic-com/playwright` error _if_ the page being tested loads modules using the AMD API (requirejs) _and_ is running in Chrome. This change detects AMD and properly loads our fork of `rrweb-snapshot` so that we can take a snapshot of the page.

As part of this PR, I first added a new AMD-based page and then created a Playwright test to take a snapshot of that page. Before implementing the fix, the test failed in exactly the same way that the customer's tests are failing.

### Background

We currently use `rrweb-snapshot` v2.0.0-alpha.17. They made some big changes from v2.0.0-alpha.14 and v2.0.0-alpha.15. Among those changes was how modules were being exported. Something about the older way they did this worked fine, but the newer version does not. This issue _might_ be related: https://github.com/rrweb-io/rrweb/issues/1592.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->

1. Run the tests
2. Extra credit: Create a new Playwright project with a test that points to `http://cookbook.tools.bbc.co.uk/` and verify that it is captured correctly