### PR TITLE
Fix errors creating snapshot and stories files due to multi-bytes test names

### DIFF
--- a/packages/cypress/tests/cypress/e2e/long-test-names.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/long-test-names.cy.ts
@@ -6,4 +6,8 @@ describe('this is a very long story name it just keeps going and going and it ca
   it('and this is also an incredibly long test name because there are just a bunch of random chars at the end like this ldlk elke lekj felk felkf lkf lsf lkef lse flskef ls fls eflsj flksef 2', () => {
     cy.visit('/');
   });
+
+  it('multi-byte characters test case: ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ', () => {
+    cy.visit('/');
+  });
 });

--- a/packages/playwright/tests/long-test-names.spec.ts
+++ b/packages/playwright/tests/long-test-names.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../src';
+import { test } from '../src';
 
 test.describe('this is a very long story name it just keeps going and going and it cannot stop and it will not stop ba bada da da dum dum dum', () => {
   test('and this is also an incredibly long test name because there are just a bunch of random chars at the end like this ldlk elke lekj felk felkf lkf lsf lkef lse flskef ls fls eflsj flksef', async ({
@@ -8,6 +8,12 @@ test.describe('this is a very long story name it just keeps going and going and 
   });
 
   test('and this is also an incredibly long test name because there are just a bunch of random chars at the end like this ldlk elke lekj felk felkf lkf lsf lkef lse flskef ls fls eflsj flksef 2', async ({
+    page,
+  }) => {
+    await page.goto('/');
+  });
+
+  test('multi-byte characters test case: ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ', async ({
     page,
   }) => {
     await page.goto('/');


### PR DESCRIPTION
Issue: #195 

## What Changed

<!-- Insert a description below. -->
In test cases containing multi-byte characters, "name too long" errors were occurring even when the file name was under 255 characters.
This issue arises because, on most platforms, the file name size is determined by the number of bytes rather than the number of characters.

To address this, the logic for truncating snapshot IDs and story file names has been updated to use byte size instead of character count.
This change ensures that test cases with multi-byte characters will no longer trigger "name too long" errors as described above.

Related PR: #175

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
- See new tests with multi-bytes names failing before the fix:  
  - TODO: 7b6bfb16cc513e6df6c5633e48a64c2960bd7a22 actions result
- See all tests pass after the fix