### PR TITLE
add tests for long multibyte test/story names

### DIFF
--- a/.changeset/tall-kings-happen.md
+++ b/.changeset/tall-kings-happen.md
@@ -1,0 +1,7 @@
+---
+'@chromatic-com/playwright': patch
+'@chromatic-com/cypress': patch
+'@chromatic-com/shared-e2e': patch
+---
+
+Fix to truncate filename based on byte size

--- a/packages/cypress/tests/cypress/e2e/long-test-names.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/long-test-names.cy.ts
@@ -6,4 +6,8 @@ describe('this is a very long story name it just keeps going and going and it ca
   it('and this is also an incredibly long test name because there are just a bunch of random chars at the end like this ldlk elke lekj felk felkf lkf lsf lkef lse flskef ls fls eflsj flksef 2', () => {
     cy.visit('/');
   });
+
+  it('multi-byte characters test case: ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ', () => {
+    cy.visit('/');
+  });
 });

--- a/packages/playwright/tests/long-test-names.spec.ts
+++ b/packages/playwright/tests/long-test-names.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../src';
+import { test } from '../src';
 
 test.describe('this is a very long story name it just keeps going and going and it cannot stop and it will not stop ba bada da da dum dum dum', () => {
   test('and this is also an incredibly long test name because there are just a bunch of random chars at the end like this ldlk elke lekj felk felkf lkf lsf lkef lse flskef ls fls eflsj flksef', async ({
@@ -8,6 +8,12 @@ test.describe('this is a very long story name it just keeps going and going and 
   });
 
   test('and this is also an incredibly long test name because there are just a bunch of random chars at the end like this ldlk elke lekj felk felkf lkf lsf lkef lse flskef ls fls eflsj flksef 2', async ({
+    page,
+  }) => {
+    await page.goto('/');
+  });
+
+  test('multi-byte characters test case: ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ、ああだこうだ', async ({
     page,
   }) => {
     await page.goto('/');

--- a/packages/shared/src/write-archive/snapshot-files.ts
+++ b/packages/shared/src/write-archive/snapshot-files.ts
@@ -1,7 +1,7 @@
 import { readdir } from 'fs/promises';
 import { Viewport, parseViewport, viewportToString } from '../utils/viewport';
 import { sanitize } from './storybook-sanitize';
-import { MAX_FILE_NAME_LENGTH, truncateFileName } from '../utils/filePaths';
+import { MAX_FILE_NAME_BYTE_LENGTH, truncateFileName } from '../utils/filePaths';
 
 const SNAPSHOT_FILE_EXT = 'snapshot.json';
 
@@ -9,8 +9,8 @@ export function snapshotId(testTitle: string, snapshotName: string) {
   const fullSnapshotId = `${sanitize(testTitle)}-${sanitize(snapshotName)}`;
   // Leave room for the viewport and extension that will be added when using this
   // to create a full file path
-  const maxLength = MAX_FILE_NAME_LENGTH - 25;
-  return truncateFileName(fullSnapshotId, maxLength);
+  const maxByteLength = MAX_FILE_NAME_BYTE_LENGTH - 25;
+  return truncateFileName(fullSnapshotId, maxByteLength);
 }
 
 // NOTE: This is duplicated in the shared storybook preview.ts

--- a/packages/shared/src/write-archive/stories-files.ts
+++ b/packages/shared/src/write-archive/stories-files.ts
@@ -3,7 +3,7 @@ import { ChromaticStorybookParameters } from '../types';
 import { snapshotId } from './snapshot-files';
 import { sanitize } from './storybook-sanitize';
 import { Viewport, viewportToString } from '../utils/viewport';
-import { MAX_FILE_NAME_LENGTH, truncateFileName } from '../utils/filePaths';
+import { MAX_FILE_NAME_BYTE_LENGTH, truncateFileName } from '../utils/filePaths';
 
 const STORIES_FILE_EXT = 'stories.json';
 
@@ -11,8 +11,8 @@ const STORIES_FILE_EXT = 'stories.json';
 export function storiesFileName(testTitle: string) {
   const fileName = [sanitize(testTitle), STORIES_FILE_EXT].join('.');
   // Leave room for built storybook extensions that may be added (like `-stories.iframe.bundle.js`)
-  const maxLength = MAX_FILE_NAME_LENGTH - 25;
-  return truncateFileName(fileName, maxLength);
+  const maxByteLength = MAX_FILE_NAME_BYTE_LENGTH - 25;
+  return truncateFileName(fileName, maxByteLength);
 }
 
 // Converts the DOM snapshots into a JSON stories file.


### PR DESCRIPTION
Issue: #195
Brought over from #218 from @nakker1218, thanks for contributing!

## What Changed
(From #218)
> 
> In test cases containing multi-byte characters, "name too long" errors were occurring even when the file name was under 255 characters.
> This issue arises because, on most platforms, the file name size is determined by the number of bytes rather than the number of characters.
> 
> To address this, the logic for truncating snapshot IDs and story file names has been updated to use byte size instead of character count.
> This change ensures that test cases with multi-byte characters will no longer trigger "name too long" errors as described above.

## How to test
- Verify the Playwright and Cypress tests pass without erroring
- Verify the story name in the published storybooks (the one linked to in the Storybook Publish GitHub PR checks, for both Playwright and Cypress) is truncated correctly
<!-- Add an explanation below for the reviewers to help them test your changes. -->
