### PR TITLE
Remove unused NPM commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "build": "yarn workspaces foreach --all --topological-dev --parallel run build",
     "test:unit": "yarn workspaces foreach --all run test:unit",
     "dev:server": "node test-server/server",
-    "dev:storybook": "cd test-storybook && yarn storybook",
-    "start": "yarn build:watch",
     "lint": "yarn workspaces foreach --all --parallel run lint",
     "prettier": "prettier",
     "prepare": "husky install",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -51,11 +51,9 @@
     "clean": "rimraf ./dist",
     "prebuild": "yarn clean",
     "build": "yarn prebuild && tsup",
-    "build:watch": "yarn build --watch",
     "test:cypress": "start-server-and-test 'yarn run dev:server' 3000 'yarn run test:do-cypress'",
     "test:do-cypress": "ELECTRON_EXTRA_LAUNCH_ARGS=--remote-debugging-port=8192 cypress run --project tests",
     "test:unit": "jest --passWithNoTests --coverage",
-    "start": "yarn build:watch",
     "lint": "eslint src/*",
     "prettier": "prettier"
   },

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -41,10 +41,8 @@
     "clean": "rimraf ./dist",
     "prebuild": "yarn clean",
     "build": "yarn prebuild && tsup",
-    "build:watch": "yarn build --watch",
     "test:unit": "jest --passWithNoTests --coverage",
     "test:playwright": "playwright test",
-    "start": "yarn build:watch",
     "lint": "eslint src/*",
     "prettier": "prettier"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -68,7 +68,6 @@
     "clean": "rimraf ./dist",
     "prebuild": "yarn clean",
     "build": "yarn prebuild && tsup",
-    "build:watch": "yarn build --watch",
     "test:unit": "jest --coverage",
     "lint": "eslint src/*",
     "prettier": "prettier"


### PR DESCRIPTION
## What Changed

<!-- Insert a description below. -->

Removes unused NPM scripts (noticed during onboarding @ax-vasquez that we have scripts like `yarn start` in here that we never use).

Commands removed at all levels:
`yarn start`
`yarn build:watch`

Commands removed at root level:
`yarn dev:storybook`

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. -->
Make sure all the CI checks pass!