### PR TITLE
Better QA guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,4 @@ Issue: #
 
 ## How to test
 
-<!-- Add an explanation below for the reviewers to help them test your changes. -->
+<!-- Add an explanation below for the reviewers to help them test your changes. Test against the published, canary versions of the packages (which are published along with this PR). -->


### PR DESCRIPTION
## What Changed

<!-- Insert a description below. -->
Piggybacking off of #229, this updates our PR template to be clear that we should QA against published package versions (not just using CI's tests), as publishing the package can cause changes (with bundling perhaps) that aren't caught when using the package internally.

## How to test
1. Create a new PR
2. Verify that you see the new instructions
