### PR TITLE
Archive `use` tags to support SVGs

### DIFF
--- a/.changeset/fuzzy-readers-own.md
+++ b/.changeset/fuzzy-readers-own.md
@@ -1,0 +1,7 @@
+---
+'@chromatic-com/playwright': patch
+'@chromatic-com/cypress': patch
+'@chromatic-com/shared-e2e': patch
+---
+
+Archive `use` tags to support SVGs

--- a/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
@@ -90,3 +90,7 @@ it('video poster image is rendered', () => {
 it('link tags for fonts preloads and other things are handled', () => {
   cy.visit('/asset-paths/link-tags');
 });
+
+it('use tags for sprites are archived', () => {
+  cy.visit('/asset-paths/sprites');
+});

--- a/packages/playwright/tests/archiving-assets.spec.ts
+++ b/packages/playwright/tests/archiving-assets.spec.ts
@@ -76,3 +76,7 @@ test('video poster image is rendered', async ({ page }) => {
 test('link tags for fonts preloads and other things are handled', async ({ page }) => {
   await page.goto('/asset-paths/link-tags');
 });
+
+test('use tags for sprites are archived', async ({ page }) => {
+  await page.goto('/asset-paths/sprites');
+});

--- a/packages/shared/src/write-archive/dom-snapshot.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.ts
@@ -65,10 +65,17 @@ export class DOMSnapshot {
         node.attributes._cssText = mappedCssText;
       }
 
-      if (node.tagName === 'link' && node.attributes.href) {
+      if (['link', 'use'].includes(node.tagName) && node.attributes.href) {
         const hrefVal = node.attributes.href as string;
-        if (sourceMap.has(hrefVal)) {
-          node.attributes.href = sourceMap.get(hrefVal);
+
+        // SVGs and other href values can have an anchor which will not be included
+        // in the source map lookup. We'll remove it to do the lookup and add it back
+        // onto the found value.
+        const hrefValAndAnchor = hrefVal.split('#');
+        const hrefValWithoutAnchor = hrefValAndAnchor[0];
+        if (sourceMap.has(hrefValWithoutAnchor)) {
+          hrefValAndAnchor[0] = sourceMap.get(hrefValWithoutAnchor);
+          node.attributes.href = hrefValAndAnchor.join('#');
         }
       }
 

--- a/test-server/fixtures/asset-paths/sprites.html
+++ b/test-server/fixtures/asset-paths/sprites.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <body>
+    <svg stroke="#2C2C2C " width="1.5rem" height="1.5rem" class="sc-aXZVg jVhcVc" style="min-width: 1.5rem;">
+      <use href="/images/sprite-map.svg?#sun"></use>
+    </svg>
+
+    <svg stroke="#2C2C2C " width="1.5rem" height="1.5rem" class="sc-aXZVg jVhcVc" style="min-width: 1.5rem;">
+      <use href="/images/sprite-map.svg#cart"></use>
+    </svg>
+  </body>
+</html>

--- a/test-server/fixtures/assets/images/sprite-map.svg
+++ b/test-server/fixtures/assets/images/sprite-map.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+  <symbol id="arrow-right" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="5" y1="12" x2="19" y2="12"></line>
+    <polyline points="12 5 19 12 12 19"></polyline>
+  </symbol>
+
+  <symbol id="arrow-left" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="19" y1="12" x2="5" y2="12"></line>
+    <polyline points="12 19 5 12 12 5"></polyline>
+  </symbol>
+
+  <symbol id="cross" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="18" y1="6" x2="6" y2="18"></line>
+    <line x1="6" y1="6" x2="18" y2="18"></line>
+  </symbol>
+
+  <symbol id="cart" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="9" cy="21" r="1"></circle>
+    <circle cx="20" cy="21" r="1"></circle>
+    <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"></path>
+  </symbol>
+
+  <symbol id="minus" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="5" y1="12" x2="19" y2="12"></line>
+  </symbol>
+  
+  <symbol id="plus" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="12" y1="5" x2="12" y2="19"></line>
+    <line x1="5" y1="12" x2="19" y2="12"></line>
+  </symbol>
+
+  <symbol id="moon" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </symbol>
+
+  <symbol id="sun" viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="12" r="5"></circle>
+    <line x1="12" y1="1" x2="12" y2="3"></line>
+    <line x1="12" y1="21" x2="12" y2="23"></line>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+    <line x1="1" y1="12" x2="3" y2="12"></line>
+    <line x1="21" y1="12" x2="23" y2="12"></line>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </symbol>
+
+  <symbol id="star" viewBox="0 0 20 20" fill="none">
+    <path d="M19.947 7.179C19.818 6.801 19.477 6.534 19.079 6.503L13.378 6.05L10.911 0.589C10.75 0.23 10.393 0 9.99998 0C9.60698 0 9.24998 0.23 9.08898 0.588L6.62198 6.05L0.920979 6.503C0.529979 6.534 0.192979 6.791 0.0599788 7.16C-0.0730212 7.529 0.0209789 7.942 0.301979 8.216L4.51498 12.323L3.02498 18.775C2.93298 19.174 3.09398 19.589 3.43098 19.822C3.60298 19.94 3.80098 20 3.99998 20C4.19298 20 4.38698 19.944 4.55498 19.832L9.99998 16.202L15.445 19.832C15.793 20.064 16.25 20.055 16.59 19.808C16.928 19.561 17.077 19.128 16.962 18.726L15.133 12.326L19.669 8.244C19.966 7.976 20.075 7.558 19.947 7.179Z" fill="#6A8589"/>
+  </symbol>
+
+</svg>


### PR DESCRIPTION
Issue: #

## What Changed

<!-- Insert a description below. -->
Archive images in `use` tags to support SVGs.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. Test against the published, canary versions of the packages (which are published along with this PR). -->
* See Chromatic tests with SVG sprites properly archived
