### PR TITLE
Pin Storybook to 8.5.x

### DIFF
--- a/.changeset/young-bottles-draw.md
+++ b/.changeset/young-bottles-draw.md
@@ -1,0 +1,7 @@
+---
+'@chromatic-com/playwright': patch
+'@chromatic-com/cypress': patch
+'@chromatic-com/shared-e2e': patch
+---
+
+pin Storybook to 8.5.x to fix the error with the `server-webpack5` mismatch with version 8.6 and above

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -73,11 +73,11 @@
   "dependencies": {
     "@chromaui/rrweb-snapshot": "2.0.0-alpha.18-noAbsolute",
     "@segment/analytics-node": "^1.1.0",
-    "@storybook/addon-essentials": "^8.6.0",
+    "@storybook/addon-essentials": "~8.5.8",
     "@storybook/csf": "^0.1.0",
-    "@storybook/manager-api": "^8.6.0",
-    "@storybook/server-webpack5": "^8.6.0",
+    "@storybook/manager-api": "~8.5.8",
+    "@storybook/server-webpack5": "~8.5.8",
     "chrome-remote-interface": "^0.33.0",
-    "storybook": "^8.6.0"
+    "storybook": "~8.5.8"
   }
 }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -64,11 +64,11 @@
   "dependencies": {
     "@chromaui/rrweb-snapshot": "2.0.0-alpha.18-noAbsolute",
     "@segment/analytics-node": "^1.1.0",
-    "@storybook/addon-essentials": "^8.6.0",
+    "@storybook/addon-essentials": "~8.5.8",
     "@storybook/csf": "^0.1.0",
-    "@storybook/manager-api": "^8.6.0",
-    "@storybook/server-webpack5": "^8.6.0",
-    "storybook": "^8.6.0",
+    "@storybook/manager-api": "~8.5.8",
+    "@storybook/server-webpack5": "~8.5.8",
+    "storybook": "~8.5.8",
     "ts-dedent": "^2.2.0"
   },
   "peerDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -79,9 +79,9 @@
     "@jest/types": "^27.0.6",
     "@playwright/test": "^1.46.1",
     "@rrweb/types": "^2.0.0-alpha.18",
-    "@storybook/addon-essentials": "^8.6.0",
+    "@storybook/addon-essentials": "~8.5.8",
     "@storybook/eslint-config-storybook": "^4.0.0",
-    "@storybook/server-webpack5": "^8.6.0",
+    "@storybook/server-webpack5": "~8.5.8",
     "@testing-library/dom": "^8.1.0",
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.2.1",
@@ -102,7 +102,7 @@
     "prompts": "^2.4.2",
     "rimraf": "^3.0.2",
     "srcset": "^4.0.0",
-    "storybook": "^8.6.0",
+    "storybook": "~8.5.8",
     "ts-dedent": "^2.2.0",
     "ts-jest": "^27.0.4",
     "typescript": "^4.2.4"
@@ -113,6 +113,6 @@
   "dependencies": {
     "@chromaui/rrweb-snapshot": "2.0.0-alpha.18-noAbsolute",
     "@segment/analytics-node": "^1.1.0",
-    "storybook": "^8.6.0"
+    "storybook": "~8.5.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,15 +1850,15 @@ __metadata:
     "@chromaui/rrweb-snapshot": "npm:2.0.0-alpha.18-noAbsolute"
     "@rrweb/types": "npm:^2.0.0-alpha.18"
     "@segment/analytics-node": "npm:^1.1.0"
-    "@storybook/addon-essentials": "npm:^8.6.0"
+    "@storybook/addon-essentials": "npm:~8.5.8"
     "@storybook/csf": "npm:^0.1.0"
-    "@storybook/manager-api": "npm:^8.6.0"
-    "@storybook/server-webpack5": "npm:^8.6.0"
+    "@storybook/manager-api": "npm:~8.5.8"
+    "@storybook/server-webpack5": "npm:~8.5.8"
     "@storybook/types": "npm:^8.1.5"
     chrome-remote-interface: "npm:^0.33.0"
     cypress: "npm:^13.4.0"
     start-server-and-test: "npm:^2.0.3"
-    storybook: "npm:^8.6.0"
+    storybook: "npm:~8.5.8"
   bin:
     archive-storybook: dist/bin/archive-storybook.js
     build-archive-storybook: dist/bin/build-archive-storybook.js
@@ -1874,15 +1874,15 @@ __metadata:
     "@playwright/test": "npm:^1.46.1"
     "@rrweb/types": "npm:^2.0.0-alpha.18"
     "@segment/analytics-node": "npm:^1.1.0"
-    "@storybook/addon-essentials": "npm:^8.6.0"
+    "@storybook/addon-essentials": "npm:~8.5.8"
     "@storybook/csf": "npm:^0.1.0"
-    "@storybook/manager-api": "npm:^8.6.0"
-    "@storybook/server-webpack5": "npm:^8.6.0"
+    "@storybook/manager-api": "npm:~8.5.8"
+    "@storybook/server-webpack5": "npm:~8.5.8"
     "@storybook/types": "npm:^8.1.5"
     express: "npm:^4.18.2"
     playwright: "npm:^1.46.1"
     playwright-core: "npm:^1.46.1"
-    storybook: "npm:^8.6.0"
+    storybook: "npm:~8.5.8"
     ts-dedent: "npm:^2.2.0"
   peerDependencies:
     "@playwright/test": ^1.0.0
@@ -1904,9 +1904,9 @@ __metadata:
     "@playwright/test": "npm:^1.46.1"
     "@rrweb/types": "npm:^2.0.0-alpha.18"
     "@segment/analytics-node": "npm:^1.1.0"
-    "@storybook/addon-essentials": "npm:^8.6.0"
+    "@storybook/addon-essentials": "npm:~8.5.8"
     "@storybook/eslint-config-storybook": "npm:^4.0.0"
-    "@storybook/server-webpack5": "npm:^8.6.0"
+    "@storybook/server-webpack5": "npm:~8.5.8"
     "@testing-library/dom": "npm:^8.1.0"
     "@testing-library/react": "npm:^12.0.0"
     "@testing-library/user-event": "npm:^13.2.1"
@@ -1927,7 +1927,7 @@ __metadata:
     prompts: "npm:^2.4.2"
     rimraf: "npm:^3.0.2"
     srcset: "npm:^4.0.0"
-    storybook: "npm:^8.6.0"
+    storybook: "npm:~8.5.8"
     ts-dedent: "npm:^2.2.0"
     ts-jest: "npm:^27.0.4"
     typescript: "npm:^4.2.4"
@@ -3341,9 +3341,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-actions@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/addon-actions@npm:8.6.0"
+"@storybook/addon-actions@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/addon-actions@npm:8.5.8"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     "@types/uuid": "npm:^9.0.1"
@@ -3351,153 +3351,154 @@ __metadata:
     polished: "npm:^4.2.2"
     uuid: "npm:^9.0.0"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: c8cc348463462fcbebff45c388935701ae90661695250caadcaa7634e035ff8c611c3c41c111a8116caf49a386505beee98e6b4cb1a49160355321bddb1477a2
+    storybook: ^8.5.8
+  checksum: 6d83052e7746b79efb72593c29b61d18def896216d0d4559038c7d18cd46403a88bcdd41dfa14405671203a626d37221fd91f8a45316fa6c2073e5e1de9ca9d5
   languageName: node
   linkType: hard
 
-"@storybook/addon-backgrounds@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/addon-backgrounds@npm:8.6.0"
+"@storybook/addon-backgrounds@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/addon-backgrounds@npm:8.5.8"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     memoizerific: "npm:^1.11.3"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: 73397df7ba7d1979b22ad2f4989a454ec4186d0469cf51bc815f5a0b5651f4d4296a822af2e601c5b0c503ec845cb541861da30f8ce76787df10c73299556539
+    storybook: ^8.5.8
+  checksum: 7f852c73a4116755097a0fefd848a74d9907c4ce88bbcf18c1db8aed0254943c028626c440c75353f3102931f6f34795615a2eda3f5fd1a2bb620a7cff9fb035
   languageName: node
   linkType: hard
 
-"@storybook/addon-controls@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/addon-controls@npm:8.6.0"
+"@storybook/addon-controls@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/addon-controls@npm:8.5.8"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     dequal: "npm:^2.0.2"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: ab752ad4fe8915aabe637c7be40dcd7bfc6a7cc93f29c574bc245a93e8bae00f8d057b4713ac26bca9d01bc6483c40ac1cc5480156bf2de0596fa200a11c98b0
+    storybook: ^8.5.8
+  checksum: 0d6a61148067d5015029322cb2beedc635cf9e1342357e1eda6b1b44abb9af44709772e29d144e280f7f91d3251c53abe43af711f552a08e52d2a47c9f8f2aea
   languageName: node
   linkType: hard
 
-"@storybook/addon-docs@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/addon-docs@npm:8.6.0"
+"@storybook/addon-docs@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/addon-docs@npm:8.5.8"
   dependencies:
     "@mdx-js/react": "npm:^3.0.0"
-    "@storybook/blocks": "npm:8.6.0"
-    "@storybook/csf-plugin": "npm:8.6.0"
-    "@storybook/react-dom-shim": "npm:8.6.0"
+    "@storybook/blocks": "npm:8.5.8"
+    "@storybook/csf-plugin": "npm:8.5.8"
+    "@storybook/react-dom-shim": "npm:8.5.8"
     react: "npm:^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
     react-dom: "npm:^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: 9a5315806d7518a3cee4ad12dedc77a871c5bdc116dc1d449d6da9096ac770ebf93675d401cb9d62398a28d300605c5301ecd7c9815cb4b000acf743ca67645b
+    storybook: ^8.5.8
+  checksum: f480e265a450f2de6e379c480e1f470bcdd17869721d57b3e96843b365f40b9ef2e38d7c6103ce976e575bb34a5400d39758b4a2ed5846a779f2a53bdd9184ea
   languageName: node
   linkType: hard
 
-"@storybook/addon-essentials@npm:^8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/addon-essentials@npm:8.6.0"
+"@storybook/addon-essentials@npm:~8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/addon-essentials@npm:8.5.8"
   dependencies:
-    "@storybook/addon-actions": "npm:8.6.0"
-    "@storybook/addon-backgrounds": "npm:8.6.0"
-    "@storybook/addon-controls": "npm:8.6.0"
-    "@storybook/addon-docs": "npm:8.6.0"
-    "@storybook/addon-highlight": "npm:8.6.0"
-    "@storybook/addon-measure": "npm:8.6.0"
-    "@storybook/addon-outline": "npm:8.6.0"
-    "@storybook/addon-toolbars": "npm:8.6.0"
-    "@storybook/addon-viewport": "npm:8.6.0"
+    "@storybook/addon-actions": "npm:8.5.8"
+    "@storybook/addon-backgrounds": "npm:8.5.8"
+    "@storybook/addon-controls": "npm:8.5.8"
+    "@storybook/addon-docs": "npm:8.5.8"
+    "@storybook/addon-highlight": "npm:8.5.8"
+    "@storybook/addon-measure": "npm:8.5.8"
+    "@storybook/addon-outline": "npm:8.5.8"
+    "@storybook/addon-toolbars": "npm:8.5.8"
+    "@storybook/addon-viewport": "npm:8.5.8"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: a62e36b6e40a58af8a2d617d80189c86e081d6fd421814ecb5b5a1d57c2efd5c8aa86d2e7393b3c696eb524fdd26822053b847d4ffc8024efc8f88f793b79a45
+    storybook: ^8.5.8
+  checksum: 9dd3a3d79cce807a615a238e45f62f1519308a777730f199468b859337763502a442c555234d6c54535d8aea4aee8f4561840338bd310384f3340d8499592a5d
   languageName: node
   linkType: hard
 
-"@storybook/addon-highlight@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/addon-highlight@npm:8.6.0"
+"@storybook/addon-highlight@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/addon-highlight@npm:8.5.8"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: 8d79691c49eb45da71838b5fe98cf595a64c40d5e0d9daf11311138f21c26ecb10cc1107d58cd02a3d055273f56df6d8d20cdca70d954ef93a5aaa9aedabc37a
+    storybook: ^8.5.8
+  checksum: 80c4fd899cf0c11e75994617713cc69e156db64d46ea61b855356b7a2766925d2a8db470e27544664932ce96875c85e84f52d7b9e5f3d6a3e8e4c8cdb6ba393b
   languageName: node
   linkType: hard
 
-"@storybook/addon-measure@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/addon-measure@npm:8.6.0"
+"@storybook/addon-measure@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/addon-measure@npm:8.5.8"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     tiny-invariant: "npm:^1.3.1"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: 4a72cb9d0a02e381b3bde60b48298fa26f73ae59b9197520153d416964c91d68032fd7ff853a1cf597624f60d0a1af5859ed87cb3747e822cc4a09fef0e84b1c
+    storybook: ^8.5.8
+  checksum: 1de801b44b09402249dea38f463bc6a3ee49aeaaa1329ea2581da175b9a961316f3e01ce70311d277c99975ffe2aa19fbd39ab1565564e6569ac156542aab08f
   languageName: node
   linkType: hard
 
-"@storybook/addon-outline@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/addon-outline@npm:8.6.0"
+"@storybook/addon-outline@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/addon-outline@npm:8.5.8"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: 3a482815661eb6ebc17d26fb4d6694cda353567856e2e8cf8d5b03e7cad04f7ee6a2329b130550748a8a5c7f4fd52e3f9b950db5a0dbe7893354ee8ef7210392
+    storybook: ^8.5.8
+  checksum: 15b0251ad2ca46437a52d7ace4bdcaae068c40d3f3f56046637bb106336a64635eb59883c7561f71465f7ece5b8061f0a5ae22904324e55a6f0e65596220c659
   languageName: node
   linkType: hard
 
-"@storybook/addon-toolbars@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/addon-toolbars@npm:8.6.0"
+"@storybook/addon-toolbars@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/addon-toolbars@npm:8.5.8"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: 085115be28f61e019780adb6158a0b9848a4775234cda16b91535412ba695fa30c2ae6e8bfc6ee14e9062ba4af2fca5f022bf54920acda843992d3f70e185651
+    storybook: ^8.5.8
+  checksum: 961a2bf7c415b91dc0aa1703369d6350481ecc249a972a20282d275466ed92af29615516e198dd8ef001833febe36991640659cc6d852f25cf4e31fb955aac1d
   languageName: node
   linkType: hard
 
-"@storybook/addon-viewport@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/addon-viewport@npm:8.6.0"
+"@storybook/addon-viewport@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/addon-viewport@npm:8.5.8"
   dependencies:
     memoizerific: "npm:^1.11.3"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: 624327b1db671a960acd52cedcdc46777d810480910510e08b36667d9a39c2f92678141ed81a651bc81e621a2e314c4a3be61fccf30d7c433e3a82988e30644d
+    storybook: ^8.5.8
+  checksum: 9c9fa6332e81a6e83e75468d5365b8cd5fcd9e40abeca138f8c0e3abefc1a56addc92f97bd79e317b366db0d87d80c29c775a05fc810f7fa7b387044784b4737
   languageName: node
   linkType: hard
 
-"@storybook/blocks@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/blocks@npm:8.6.0"
+"@storybook/blocks@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/blocks@npm:8.5.8"
   dependencies:
+    "@storybook/csf": "npm:0.1.12"
     "@storybook/icons": "npm:^1.2.12"
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    storybook: ^8.6.0
+    storybook: ^8.5.8
   peerDependenciesMeta:
     react:
       optional: true
     react-dom:
       optional: true
-  checksum: ab3611550afc26cc6abd96be63e6c4d0a5dda6edc337972949fbc773db343c1096dc7657ce3bd75ae5dbbf681f88a7fbcbaa4715c096b1a911edb6ce13f6d2a1
+  checksum: 842c8d239c34dfee2d9e6fd7eb68a9b1fb7e5656617271e1fef17064973416b13d870636bc11a0516dae490dd91774ca15043bd66740d5fb9886b9efb01b8043
   languageName: node
   linkType: hard
 
-"@storybook/builder-webpack5@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/builder-webpack5@npm:8.6.0"
+"@storybook/builder-webpack5@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/builder-webpack5@npm:8.5.8"
   dependencies:
-    "@storybook/core-webpack": "npm:8.6.0"
+    "@storybook/core-webpack": "npm:8.5.8"
     "@types/semver": "npm:^7.3.4"
     browser-assert: "npm:^1.2.1"
     case-sensitive-paths-webpack-plugin: "npm:^2.4.0"
@@ -3522,11 +3523,11 @@ __metadata:
     webpack-hot-middleware: "npm:^2.25.1"
     webpack-virtual-modules: "npm:^0.6.0"
   peerDependencies:
-    storybook: ^8.6.0
+    storybook: ^8.5.8
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 40a5794b95105218b0752f071929af055432585e1e0ee08c823e606d908070e17e3ea8a97132ccf77b6f97082fd696715ebbc70189da19fad4525420910f2a26
+  checksum: 8c013e9f62409f169c212cca69bc0193a636a22a5280f6d30751b5561ec726c1ee7521245693f5e6ceeec16f31794560fc4cbefef33c227fce112187d4d489c6
   languageName: node
   linkType: hard
 
@@ -3552,12 +3553,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/components@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/components@npm:8.6.0"
+"@storybook/components@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/components@npm:8.5.8"
   peerDependencies:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-  checksum: 4b5670aadb82a9bc687e5d4317d4f03bbb95adbc706b37a0e2e96077a0890b6e0406812a32389d6e438d20c193619b4e2f95f033642784d0935a9eae175d2dc0
+  checksum: dde5ac41f60a4561095a15fb8de99344b26f8887a93fd4947ea7f378c2be71cc0421a9a46be57c9521e5e2fc6c42d222e8138ca2b3390a4eb7c1b7fa299fd0d6
   languageName: node
   linkType: hard
 
@@ -3571,22 +3572,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/core-webpack@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/core-webpack@npm:8.6.0"
+"@storybook/core-webpack@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/core-webpack@npm:8.5.8"
   dependencies:
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: 0f2e5b465c1b3e21bdd927130054589edb8c6a0b729b6c9c16737787caffb32df8eb24d88ef3a1f485182413a5bcdeccaed7c40cb57efdec9ef8ea01488f65ef
+    storybook: ^8.5.8
+  checksum: 9fdecb169595f125ab797ea8638c077e10e7514d6afaafc2de1c5d2e3520b42e21beb6830af0cc612dfc44d2be9afd4c497e8863cf5b09d41a371d9978a3fcea
   languageName: node
   linkType: hard
 
-"@storybook/core@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/core@npm:8.6.0"
+"@storybook/core@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/core@npm:8.5.8"
   dependencies:
-    "@storybook/theming": "npm:8.6.0"
+    "@storybook/csf": "npm:0.1.12"
     better-opn: "npm:^3.0.2"
     browser-assert: "npm:^1.2.1"
     esbuild: "npm:^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0"
@@ -3602,18 +3603,27 @@ __metadata:
   peerDependenciesMeta:
     prettier:
       optional: true
-  checksum: 1f3dc0693dc3ffdaffe16b2bf3e77d8a21dd2c331ce1ee79971e0236cb56cb7619400f4a489b8b82312967aa9009a8b74400dc3152826f891d76f5101744f09a
+  checksum: bf883e32827668e50dd90bb52ee8f2b419b1beaba3213695ec21afe39f6b880feb107c96768021388222519c4bab8870bba5971415f68a426912a3cb7f5e3d80
   languageName: node
   linkType: hard
 
-"@storybook/csf-plugin@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/csf-plugin@npm:8.6.0"
+"@storybook/csf-plugin@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/csf-plugin@npm:8.5.8"
   dependencies:
     unplugin: "npm:^1.3.1"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: ff37386b10d2884cc912aaf24c13547bb38a0fe8820958cd3d915049a5ef902897927120ce61e78e5564d71f369127c6139ada25bb5cd5f10c2c1f5e1cdfc0d6
+    storybook: ^8.5.8
+  checksum: 27d51f0ba97971826bbf3276e568427a1c39c8a7b6ea308ac833e797c1e39a6b3171231513c6ff9880c4677197cb2b18b33e69fce0cfcf294e74e5b1bee6d7c3
+  languageName: node
+  linkType: hard
+
+"@storybook/csf@npm:0.1.12":
+  version: 0.1.12
+  resolution: "@storybook/csf@npm:0.1.12"
+  dependencies:
+    type-fest: "npm:^2.19.0"
+  checksum: 3d96a976ada67eb683279338d1eb6aa730b228107d4c4f6616ea7b94061899c1fdc11957a756e7bc0708d18cb39af0010c865d124efd84559cd82dcb2d8bc959
   languageName: node
   linkType: hard
 
@@ -3688,87 +3698,88 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/manager-api@npm:8.6.0, @storybook/manager-api@npm:^8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/manager-api@npm:8.6.0"
+"@storybook/manager-api@npm:8.5.8, @storybook/manager-api@npm:~8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/manager-api@npm:8.5.8"
   peerDependencies:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-  checksum: 560dad38af5f3434efe48b3ab03b25b196b11236df2dffee9cf13083a9ad45c67dd2e66b689e1cf3978e16f5c93b89807ca1073b8e8808f45796df88a71edbe4
+  checksum: 4045257c2169cef88508cef8087d177faea481fa6bf403ea92d531f6c27291c06107d786bf0bd7bb380631f86a2d87819e60f84598bd7eefdc6c12c85e97b4ab
   languageName: node
   linkType: hard
 
-"@storybook/preset-server-webpack@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/preset-server-webpack@npm:8.6.0"
+"@storybook/preset-server-webpack@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/preset-server-webpack@npm:8.5.8"
   dependencies:
-    "@storybook/core-webpack": "npm:8.6.0"
+    "@storybook/core-webpack": "npm:8.5.8"
     "@storybook/global": "npm:^5.0.0"
-    "@storybook/server": "npm:8.6.0"
+    "@storybook/server": "npm:8.5.8"
     safe-identifier: "npm:^0.4.1"
     ts-dedent: "npm:^2.0.0"
     yaml-loader: "npm:^0.8.0"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: 886be074fd6ca25aaa4985bbf0dd1a1e8d15b207fcce66a8f7582f56b95477d834c6c8c2e377a618a05704af5b2737ac04c3f70f82f1f527e148a6f46784abc2
+    storybook: ^8.5.8
+  checksum: b44683d167dfead5e583746ae802ce94b6b72b1ed133ad63035231885f5457de91f5a85158fc349e25d74f2cf610a8c491b23e49a5b8e8e95e4ef57fa474f14d
   languageName: node
   linkType: hard
 
-"@storybook/preview-api@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/preview-api@npm:8.6.0"
+"@storybook/preview-api@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/preview-api@npm:8.5.8"
   peerDependencies:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-  checksum: 095bd66d3363ef707aa25f3cfabe2fc6a966090837fff943e5e8b5dbd6cc17d8754df09ea03e616c7d3fb00feb63ef0886051a14add087fca533d26d2f8ce8c2
+  checksum: 278dff2940ba93c366a2a83a347f8e17dc80d087e0aa44eb868e4fe95f76a23e12d740867f3fd8e65142c47a73e5a66a628847179ce10b5ae22c4b1645910c2c
   languageName: node
   linkType: hard
 
-"@storybook/react-dom-shim@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/react-dom-shim@npm:8.6.0"
+"@storybook/react-dom-shim@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/react-dom-shim@npm:8.5.8"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-    storybook: ^8.6.0
-  checksum: e0ab0b5c660b291aa94523045a49a75c0da6c05618cfe63608d6cd50b4aafc7cafe8236d9994f334a074bc305be57d7578bcad3cd441514fcb9732c81431df25
+    storybook: ^8.5.8
+  checksum: 0d6a7f24bb0ae168dfb7f984e2defd16e15d65dd07b1f9c4251c23e1abe88c11fa58d716125c536199e689266eca371cd054f5514c952ab76863946406fbeedd
   languageName: node
   linkType: hard
 
-"@storybook/server-webpack5@npm:^8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/server-webpack5@npm:8.6.0"
+"@storybook/server-webpack5@npm:~8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/server-webpack5@npm:8.5.8"
   dependencies:
-    "@storybook/builder-webpack5": "npm:8.6.0"
-    "@storybook/preset-server-webpack": "npm:8.6.0"
-    "@storybook/server": "npm:8.6.0"
+    "@storybook/builder-webpack5": "npm:8.5.8"
+    "@storybook/preset-server-webpack": "npm:8.5.8"
+    "@storybook/server": "npm:8.5.8"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: 87e284fa8c712ecbd2906f07377edaf5e3d75df03fc282b0148e8582413155c443fea415a7e9eeec5a04e019508c04ed1af28faaa988b995346e6ac21f5b735e
+    storybook: ^8.5.8
+  checksum: c0414165812234fa5f5c847f6c6a759412b75c5fbb12eaeb3351fea14e15e2bbf1e2620ca1bb85baa2b2afadd83c42af68b9f10224bbfa2359781c9b93b2340c
   languageName: node
   linkType: hard
 
-"@storybook/server@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/server@npm:8.6.0"
+"@storybook/server@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/server@npm:8.5.8"
   dependencies:
-    "@storybook/components": "npm:8.6.0"
+    "@storybook/components": "npm:8.5.8"
+    "@storybook/csf": "npm:0.1.12"
     "@storybook/global": "npm:^5.0.0"
-    "@storybook/manager-api": "npm:8.6.0"
-    "@storybook/preview-api": "npm:8.6.0"
-    "@storybook/theming": "npm:8.6.0"
+    "@storybook/manager-api": "npm:8.5.8"
+    "@storybook/preview-api": "npm:8.5.8"
+    "@storybook/theming": "npm:8.5.8"
     ts-dedent: "npm:^2.0.0"
     yaml: "npm:^2.3.1"
   peerDependencies:
-    storybook: ^8.6.0
-  checksum: 950e1f77ca89b2c1c9aa2e84b6230c825cf85b972d30a9e73761666917513f1c4020739e527cb319b72d11d3c11ddd73ddec6d5e16659ec876de2b9095e6fe61
+    storybook: ^8.5.8
+  checksum: 7f5ebbc0c557f36a925ee82e453c8af7fd9acaf09ccec86b464ebacad76176bf863e7eab5bc76dc4c1152bcfa42920573b8ee24c9a30973db59d04d4ada15512
   languageName: node
   linkType: hard
 
-"@storybook/theming@npm:8.6.0":
-  version: 8.6.0
-  resolution: "@storybook/theming@npm:8.6.0"
+"@storybook/theming@npm:8.5.8":
+  version: 8.5.8
+  resolution: "@storybook/theming@npm:8.5.8"
   peerDependencies:
     storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-  checksum: 15ce90333e0c38ad2381991bb6184d7b8d1bd7351af0aa0514978b4c58e905ac4133e17676337312ce60836c796da7bb6cbefad59beee5afc8f48f5b51e920d7
+  checksum: 6a3083fb2f3166a86fd177a24974149cea71d31e44cac1730c5c17b04f22cb17de41f65ead2984adb26a272fdf7bcab6d6ebda791c2ce5a21671e90a07a7d8a9
   languageName: node
   linkType: hard
 
@@ -16325,11 +16336,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"storybook@npm:^8.6.0":
-  version: 8.6.0
-  resolution: "storybook@npm:8.6.0"
+"storybook@npm:~8.5.8":
+  version: 8.5.8
+  resolution: "storybook@npm:8.5.8"
   dependencies:
-    "@storybook/core": "npm:8.6.0"
+    "@storybook/core": "npm:8.5.8"
   peerDependencies:
     prettier: ^2 || ^3
   peerDependenciesMeta:
@@ -16339,7 +16350,7 @@ __metadata:
     getstorybook: ./bin/index.cjs
     sb: ./bin/index.cjs
     storybook: ./bin/index.cjs
-  checksum: d19e09dea7d8c57f949fcd92351e199d8389e39c16afacd19caf4a3ab26793c771f2e62af871bf5c8bcbedaf221059ac285c69668d0511cd4d805f21a55aec32
+  checksum: a02ccf3132c05341139deb23dd7731191b4542b80d0d4ed772d06f483373be5713e3db1003fddb8823da417c5c9353273032d30d61cfa6084a04b9b33dc764cc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: #

## What Changed

<!-- Insert a description below. -->
There's currently an error with a `server-webpack5` mismatch when these E2E packages use Storybook 8.6 when the consuming project also has its own dependency on SB 8.5 or below. Pinning E2E to 8.5 seems to work when the project has a dependency a dependency on any 8.x version of SB.


## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. Test against the published, canary versions of the packages (which are published along with this PR). -->
* Chromatic tests pass
* Run a Chromatic E2E build using the canary version of E2E on a test project that has its own Storybook dep on 8.5.x
