### PR TITLE
[AP-6208] sanitize newlines from test names for snapshot filenames

### DIFF
--- a/.changeset/few-suns-work.md
+++ b/.changeset/few-suns-work.md
@@ -1,0 +1,7 @@
+---
+"@chromatic-com/playwright": patch
+"@chromatic-com/cypress": patch
+"@chromatic-com/shared-e2e": patch
+---
+
+Sanitize newlines in snapshot archive filenames

--- a/packages/cypress/tests/cypress/e2e/newline-test-names.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/newline-test-names.cy.ts
@@ -1,0 +1,9 @@
+describe(`
+Test
+name
+newlines
+`, () => {
+  it('Are\n\rRemoved\r\nFrom\nFile\rNames\n\n\r\r', () => {
+    cy.visit('/');
+  });
+});

--- a/packages/playwright/tests/newline-test-names.spec.ts
+++ b/packages/playwright/tests/newline-test-names.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '../src';
+
+test.describe(`
+Test
+name
+newlines
+`, () => {
+  test('Are\n\rRemoved\r\nFrom\nFile\rNames\n\n\r\r', async ({ page }) => {
+    await page.goto('/');
+  });
+});

--- a/packages/shared/src/write-archive/stories-files.test.ts
+++ b/packages/shared/src/write-archive/stories-files.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
 
 describe('storiesFileName', () => {
   it('sanitizes the file name', () => {
-    const fileName = storiesFiles.storiesFileName('a title *() with $%& chars');
+    const fileName = storiesFiles.storiesFileName('--a title *() with $%& chars---');
     expect(fileName).toEqual('a-title-with-chars.stories.json');
   });
 

--- a/packages/shared/src/write-archive/stories-files.test.ts
+++ b/packages/shared/src/write-archive/stories-files.test.ts
@@ -32,7 +32,7 @@ describe('storiesFileName', () => {
   });
 
   it('replaces newlines with -', () => {
-    const title = '\n\n\r\rThere\nShould\rBe\r\nNo\n\rNewlines\r\r\n\n'
+    const title = '\n\n\r\rThere\nShould\rBe\r\nNo\n\rNewlines\r\r\n\n';
 
     const filename = storiesFiles.storiesFileName(title);
     expect(filename).toEqual('there-should-be-no-newlines.stories.json');

--- a/packages/shared/src/write-archive/stories-files.test.ts
+++ b/packages/shared/src/write-archive/stories-files.test.ts
@@ -30,6 +30,13 @@ describe('storiesFileName', () => {
     expect(fileName.length).toEqual(230);
     expect(fileName).toMatch(new RegExp('^this-title-has-.*blah-bl[a-z0-9]{4}.stories.json$'));
   });
+
+  it('replaces newlines with -', () => {
+    const title = '\n\n\r\rThere\nShould\rBe\r\nNo\n\rNewlines\r\r\n\n'
+
+    const filename = storiesFiles.storiesFileName(title);
+    expect(filename).toEqual('there-should-be-no-newlines.stories.json');
+  });
 });
 
 describe('createStories', () => {

--- a/packages/shared/src/write-archive/storybook-sanitize.ts
+++ b/packages/shared/src/write-archive/storybook-sanitize.ts
@@ -1,10 +1,12 @@
-// @storybook/csf's sanitize function, we could import this
+// storybook's csf sanitize function, plus sanitization of newlines
+// https://github.com/storybookjs/storybook/blob/a0d1b3e62533fbf531b79ddfd1f5856fa5bf7384/code/core/src/csf/index.ts#L8-L16
 export const sanitize = (string: string) => {
   return (
     string
       .toLowerCase()
       // eslint-disable-next-line no-useless-escape
       .replace(/[ ’–—―′¿'`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '-')
+      .replace(/[\r\n]/g, '-')
       .replace(/-+/g, '-')
       .replace(/^-+/, '')
       .replace(/-+$/, '')


### PR DESCRIPTION
Issue: #

## What Changed

Added replacement of newlines with `-` to the `sanitize` function used when generating DOM snapshot filenames.

## How to test

On this branch, in this repository:

1. Run `yarn run build`,
2. Run `yarn test:cypress`, observe the `newline-test-names.cy.ts` spec includes a test with newlines in the name
3. Check that the corresponding `.snapshot.json` file in `packages/cypress/test-downloads/chromatic-archives/` does not include newlines and they have been replaced with `-`
4. Run `yarn test:playwright`, observe the `newline-test-names.spec.ts` spec includes a test with newlines in the name
5. Check the corresponding `.snapshot.json` file in `package/playwright/test-results/chromatic-archives/` does not include newlines and they have been replaced with `-`
6. Run `yarn build-archive-storybook:playwright`
7. Assure you can run a build via chromatic CLI, `CHROMATIC_INDEX_URL=[YOUR_INDEX_URL] npx chromatic -d storybook-static --project-token=[YOUR_PROJECT_TOKEN]`