### PR TITLE
ci: reduce warnings in `test` job by 50%

### DIFF
--- a/packages/cypress/src/bin/archive-storybook.ts
+++ b/packages/cypress/src/bin/archive-storybook.ts
@@ -13,6 +13,7 @@ try {
 } catch (err) {
   // Throwing the error results in a large output of minified code and a stacktrace that is
   // likely not helpful to users, so this should hide the noise.
+  // eslint-disable-next-line no-console
   console.error(err.message);
   process.exitCode = 1;
 }

--- a/packages/cypress/src/bin/build-archive-storybook.ts
+++ b/packages/cypress/src/bin/build-archive-storybook.ts
@@ -13,6 +13,7 @@ try {
 } catch (err) {
   // Throwing the error results in a large output of minified code and a stacktrace that is
   // likely not helpful to users, so this should hide the noise.
+  // eslint-disable-next-line no-console
   console.error(err.message);
   process.exitCode = 1;
 }

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -80,6 +80,7 @@ const setupNetworkListener = async ({
       await resourceArchiver.watch();
     }
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.log('err', err);
   }
 

--- a/packages/playwright/src/bin/archive-storybook.ts
+++ b/packages/playwright/src/bin/archive-storybook.ts
@@ -13,6 +13,7 @@ try {
 } catch (err) {
   // Throwing the error results in a large output of minified code and a stacktrace that is
   // likely not helpful to users, so this should hide the noise.
+  // eslint-disable-next-line no-console
   console.error(err.message);
   process.exitCode = 1;
 }

--- a/packages/playwright/src/bin/build-archive-storybook.ts
+++ b/packages/playwright/src/bin/build-archive-storybook.ts
@@ -13,6 +13,7 @@ try {
 } catch (err) {
   // Throwing the error results in a large output of minified code and a stacktrace that is
   // likely not helpful to users, so this should hide the noise.
+  // eslint-disable-next-line no-console
   console.error(err.message);
   process.exitCode = 1;
 }


### PR DESCRIPTION
Fixes: #246

Cherry picked from #247 opened by @hamirmahal 

## What Changed

This reduces warnings for workflows that run `eslint` in `packages/cypress` or `packages/playwright`, like [the `Test and Release Main` workflow run](https://github.com/chromaui/chromatic-e2e/actions/runs/14538039028).

<!-- Insert a description below. -->

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. Test against the published, canary versions of the packages (which are published along with this PR). -->
You can see the reduction in warnings when looking at the Summary for an action at URLs like https://github.com/chromaui/chromatic-e2e/actions/runs/14538039028, and comparing that to the summary for the actions on this pull request, once they run.
