### PR TITLE
vbabel/ap 5925 allow running multiple projects in playwright

### DIFF
--- a/.changeset/clean-numbers-build.md
+++ b/.changeset/clean-numbers-build.md
@@ -1,0 +1,6 @@
+---
+"@chromatic-com/playwright": minor
+"@chromatic-com/shared-e2e": minor
+---
+
+Add groupByProject option to group Playwright tests by project

--- a/packages/playwright/src/makeTest.ts
+++ b/packages/playwright/src/makeTest.ts
@@ -32,6 +32,7 @@ export const performChromaticSnapshot = async (
     assetDomains,
     cropToViewport,
     ignoreSelectors,
+    groupByProject,
   }: ChromaticConfig & { page: Page },
   use: () => Promise<void>,
   testInfo: TestInfo
@@ -77,11 +78,13 @@ export const performChromaticSnapshot = async (
       ...(ignoreSelectors && { ignoreSelectors }),
     };
 
+    const projectName = groupByProject ? testInfo.project.name : '';
+
     // TestInfo.outputDir gives us the test-specific subfolder (https://playwright.dev/docs/api/class-testconfig#test-config-output-dir);
     // we want to write one level above that
     const outputDir = join(testInfo.outputDir, '..');
     await writeTestResult(
-      { ...testInfo, outputDir, pageUrl: page.url(), viewport: page.viewportSize() },
+      { ...testInfo, outputDir, pageUrl: page.url(), viewport: page.viewportSize(), projectName },
       Object.fromEntries(snapshots),
       resourceArchive,
       chromaticStorybookParams
@@ -118,6 +121,7 @@ export const makeTest = (
     assetDomains: [[], { option: true }],
     cropToViewport: [undefined, { option: true }],
     ignoreSelectors: [undefined, { option: true }],
+    groupByProject: [false, { option: true }],
 
     chromaticSnapshot: [
       performChromaticSnapshot,

--- a/packages/playwright/tests/group-by-project.spec.ts
+++ b/packages/playwright/tests/group-by-project.spec.ts
@@ -1,0 +1,9 @@
+import { test } from '../src';
+
+test.describe(() => {
+  test.use({ groupByProject: true });
+
+  test('tests from different files end up in same project directory', async ({ page }) => {
+    await page.goto('/options/group-by-project');
+  });
+});

--- a/packages/playwright/tests/options.spec.ts
+++ b/packages/playwright/tests/options.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '../src';
+import { test, takeSnapshot } from '../src';
 
 test.describe(() => {
   test.use({ delay: 2500 });
@@ -50,4 +50,16 @@ test.describe(() => {
 
 test('does not crop to viewport by default', async ({ page }) => {
   await page.goto('/options/crop-to-viewport');
+});
+
+test.describe(() => {
+  test.use({ groupByProject: true });
+
+  test('groups test by project', async ({ page }, testInfo) => {
+    await page.goto('/options/group-by-project');
+
+    if (testInfo.project.name === 'Desktop') {
+      takeSnapshot(page, 'Extra Desktop Snapshot', testInfo);
+    }
+  });
 });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -34,6 +34,9 @@ export interface ChromaticConfig {
 
   // CSS selectors of elements to ignore when comparing snapshots.
   ignoreSelectors?: string[];
+
+  // Group stories by project, Playwright only
+  groupByProject?: boolean;
 }
 
 export type ChromaticStorybookParameters = Omit<ChromaticConfig, 'disableAutoSnapshot'>;

--- a/packages/shared/src/write-archive/index.ts
+++ b/packages/shared/src/write-archive/index.ts
@@ -19,6 +19,7 @@ interface E2ETestInfo {
   outputDir: string;
   pageUrl: string;
   viewport: Viewport;
+  projectName?: string;
 }
 
 export async function writeTestResult(
@@ -27,7 +28,8 @@ export async function writeTestResult(
   archive: ResourceArchive,
   chromaticStorybookParams: ChromaticStorybookParameters
 ) {
-  const { titlePath, outputDir, pageUrl, viewport } = e2eTestInfo;
+  const { titlePath, outputDir, pageUrl, projectName, viewport } = e2eTestInfo;
+
   // remove the test file extensions (.spec.ts|ts, .cy.ts|js), preserving other periods in directory, file name, or test titles
   const titlePathWithoutFileExtensions = titlePath.map((pathPart) =>
     // make sure we remove file extensions, even if the file name doesn't have .spec or .test or.cy
@@ -37,7 +39,9 @@ export async function writeTestResult(
     pathPart.replace(/\.(ts|js|mjs|cjs|tsx|jsx|cjsx|coffee)$/, '').replace(/\.(spec|test|cy)$/, '')
   );
   // in Storybook, `/` splits the title out into hierarchies (folders)
-  const title = titlePathWithoutFileExtensions.join('/');
+  const title = [projectName, titlePathWithoutFileExtensions.join('/')]
+    .filter((i) => !!i)
+    .join('/');
   const finalOutputDir = join(outputDir, 'chromatic-archives');
 
   const archiveDir = join(finalOutputDir, 'archive');
@@ -67,7 +71,7 @@ export async function writeTestResult(
   );
 
   await Promise.all(
-    await Object.entries(domSnapshots).map(async ([name, domSnapshot]) => {
+    Object.entries(domSnapshots).map(async ([name, domSnapshot]) => {
       // XXX_jwir3: We go through our stories here and map any instances that are found in
       //            the keys of the source map to their respective values.
       const snapshot = new DOMSnapshot(domSnapshot);

--- a/test-server/fixtures/options/group-by-project.html
+++ b/test-server/fixtures/options/group-by-project.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <h1>These tests should be in directories per each project in Playwright.</h1>
+  </body>
+</html>


### PR DESCRIPTION
Issue: #258 

## What Changed

This introduces a `groupByProject` option to `ChromaticConfig` to enable better support for multiple Playwright projects. 

When `groupByProject` is set to true, the project's name, via `testInfo.project.name` is prepended to the test `title` when determining the title of the corresponding Story. Ex: if the test title is `test-file-name/test title` and the project name is `Desktop`, the story title becomes `Desktop/test-file-name/test-title`. Thus, all tests within the same project will be grouped in a directory in the resulting storybook.

The default value of `groupByProject` is false to retain backwards compatibility and avoid changing every story/snapshot for users who upgrade.

## How to test

### In this repository:
1. Run the playwright tests: `yarn test:playwright`
2. Spin up the archive storybook: `yarn archive-storybook:playwright`
3. Observe the corresponding stories under "Mobile" and "Desktop"

#### To test w/ chromatic CLI:
1. Run the playwright tests: `yarn test:playwright`
2. Build the archive storybook: `yarn build-archive-storybook:playwright`
3. Run chromatic: `yarn dlx chromatic -d storybook-static --project-token=YOUR_TOKEN_HERE`

### With the canary versions:
1. Create an example project per #258, w/ git setup and at least one commit
3. Optionally add conditional snapshots per [options.spec.ts](https://github.com/chromaui/chromatic-e2e/blob/vbabel/ap-5925-allow-running-multiple-projects-in-playwright/packages/playwright/tests/options.spec.ts#L58-L65)
4. Run `playwright test`
5. Run chromatic: `yarn dlx chromatic --playwright --project-token=YOUR_TOKEN_HERE`
