### PR TITLE
[AP-6453] update @segment/analytics-core to 2.1.3 for dset patch

### DIFF
--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@chromaui/rrweb-snapshot": "2.0.0-alpha.18-noAbsolute",
-    "@segment/analytics-node": "^1.1.0",
+    "@segment/analytics-node": "2.1.3",
     "@storybook/addon-essentials": "~8.5.8",
     "@storybook/csf": "^0.1.0",
     "@storybook/manager-api": "~8.5.8",

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@chromaui/rrweb-snapshot": "2.0.0-alpha.18-noAbsolute",
-    "@segment/analytics-node": "^1.1.0",
+    "@segment/analytics-node": "2.1.3",
     "@storybook/addon-essentials": "~8.5.8",
     "@storybook/csf": "^0.1.0",
     "@storybook/manager-api": "~8.5.8",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -112,7 +112,7 @@
   },
   "dependencies": {
     "@chromaui/rrweb-snapshot": "2.0.0-alpha.18-noAbsolute",
-    "@segment/analytics-node": "^1.1.0",
+    "@segment/analytics-node": "2.1.3",
     "storybook": "~8.5.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1849,7 +1849,7 @@ __metadata:
     "@chromatic-com/shared-e2e": "workspace:*"
     "@chromaui/rrweb-snapshot": "npm:2.0.0-alpha.18-noAbsolute"
     "@rrweb/types": "npm:^2.0.0-alpha.18"
-    "@segment/analytics-node": "npm:^1.1.0"
+    "@segment/analytics-node": "npm:2.1.3"
     "@storybook/addon-essentials": "npm:~8.5.8"
     "@storybook/csf": "npm:^0.1.0"
     "@storybook/manager-api": "npm:~8.5.8"
@@ -1873,7 +1873,7 @@ __metadata:
     "@chromaui/rrweb-snapshot": "npm:2.0.0-alpha.18-noAbsolute"
     "@playwright/test": "npm:^1.46.1"
     "@rrweb/types": "npm:^2.0.0-alpha.18"
-    "@segment/analytics-node": "npm:^1.1.0"
+    "@segment/analytics-node": "npm:2.1.3"
     "@storybook/addon-essentials": "npm:~8.5.8"
     "@storybook/csf": "npm:^0.1.0"
     "@storybook/manager-api": "npm:~8.5.8"
@@ -1903,7 +1903,7 @@ __metadata:
     "@jest/types": "npm:^27.0.6"
     "@playwright/test": "npm:^1.46.1"
     "@rrweb/types": "npm:^2.0.0-alpha.18"
-    "@segment/analytics-node": "npm:^1.1.0"
+    "@segment/analytics-node": "npm:2.1.3"
     "@storybook/addon-essentials": "npm:~8.5.8"
     "@storybook/eslint-config-storybook": "npm:^4.0.0"
     "@storybook/server-webpack5": "npm:~8.5.8"
@@ -3276,27 +3276,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@segment/analytics-core@npm:1.3.0":
-  version: 1.3.0
-  resolution: "@segment/analytics-core@npm:1.3.0"
+"@segment/analytics-core@npm:1.7.0":
+  version: 1.7.0
+  resolution: "@segment/analytics-core@npm:1.7.0"
   dependencies:
     "@lukeed/uuid": "npm:^2.0.0"
-    dset: "npm:^3.1.2"
+    "@segment/analytics-generic-utils": "npm:1.2.0"
+    dset: "npm:^3.1.4"
     tslib: "npm:^2.4.1"
-  checksum: 0b93b404f15de9939bd6d93d45556bdffed6c9b0abef0237a5277d01912cd5e37abc429710f481ba8b5b9b89e325dea00b801fbe97233fb5c4b7de333ee6465a
+  checksum: 5757daa2a16d2b457ce68c50139cccd71063fc75e0eb0e960a9ffbe865b158434301bf9a11658ad1fac5f53fc5fddad36924fea5a8ff787d583a11c521ea8982
   languageName: node
   linkType: hard
 
-"@segment/analytics-node@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@segment/analytics-node@npm:1.1.0"
+"@segment/analytics-generic-utils@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@segment/analytics-generic-utils@npm:1.2.0"
+  dependencies:
+    tslib: "npm:^2.4.1"
+  checksum: 2f9aebc1027ed2d1afcb02338ed4971f774ce25250c499cac6c1c0020a7376e05b56411d38d36ee1cf0cec49cfdb82e68cd3f5d868b47b9e61b3b668bd27e122
+  languageName: node
+  linkType: hard
+
+"@segment/analytics-node@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@segment/analytics-node@npm:2.1.3"
   dependencies:
     "@lukeed/uuid": "npm:^2.0.0"
-    "@segment/analytics-core": "npm:1.3.0"
+    "@segment/analytics-core": "npm:1.7.0"
+    "@segment/analytics-generic-utils": "npm:1.2.0"
     buffer: "npm:^6.0.3"
+    jose: "npm:^5.1.0"
     node-fetch: "npm:^2.6.7"
     tslib: "npm:^2.4.1"
-  checksum: 9913db24e66aca64f15fc5c3d1dc3d4a6960e7f1b60fefa0e9bb2c3ad3b3eeca4c22da740e41649591470d87bff9a85f2e81adfb63be02ce6365d8947765f786
+  checksum: 2b39ac7f6ee8eae99ea91b6d0c8632cd7d11e6c97f0127b48704acf5f9cc5bf9c99d8c2f5a2b7bfda6e755346d960afdaf8285a2d31326cc1735233b07f2fab4
   languageName: node
   linkType: hard
 
@@ -7415,10 +7427,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dset@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "dset@npm:3.1.2"
-  checksum: a10d5f214ccd53e7d2e79215473256b74cb98fd3f20ad4f4684ab575b19bac71e5dda524d6febcf42854062e3f575a2dbfca4d53d2ffb9ae238eecdcc97a095b
+"dset@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "dset@npm:3.1.4"
+  checksum: b67bbd28dd8a539e90c15ffb61100eb64ef995c5270a124d4f99bbb53f4d82f55a051b731ba81f3215dd9dce2b4c8d69927dc20b3be1c5fc88bab159467aa438
   languageName: node
   linkType: hard
 
@@ -11480,6 +11492,13 @@ __metadata:
     "@sideway/formula": "npm:^3.0.1"
     "@sideway/pinpoint": "npm:^2.0.0"
   checksum: c41c86fe772828b88fbdbcaef2e41235ccbb107c22523a377f9a2fd39829f203213f37a352589f49d9a9b38bf1c645846defede8b81d8c1f3123117c1a600010
+  languageName: node
+  linkType: hard
+
+"jose@npm:^5.1.0":
+  version: 5.10.0
+  resolution: "jose@npm:5.10.0"
+  checksum: e20d9fc58d7e402f2e5f04e824b8897d5579aae60e64cb88ebdea1395311c24537bf4892f7de413fab1acf11e922797fb1b42269bc8fc65089a3749265ccb7b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Issue: #AP-6453

## What Changed

<!-- Insert a description below. -->

`dset` under version `3.1.4` has a high severity vulnerability. The `@segment/analytics-core` package used an affected version of `dset` until version `2.1.3`. This PR updates the package so that it has the `dset` patch.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. Test against the published, canary versions of the packages (which are published along with this PR). -->

1. Run `yarn test:playwright` > ensure the tests pass
2. Run `yarn archive-storybook:playwright` > Inspect the hosted Storybook and ensure there are no issues
