### PR TITLE
Use url path for snapshot src attribute

### DIFF
--- a/packages/shared/src/write-archive/index.ts
+++ b/packages/shared/src/write-archive/index.ts
@@ -58,8 +58,12 @@ export async function writeTestResult(
       const origSrcPath = archiveFile.originalSrc();
       const fileSystemPath = archiveFile.toFileSystemPath();
 
+      // we write the archive files to the file system using the file system path (this could be a windows path)
+      // and we update the source map with a url path for the resource -> this will be used to update the src attribute in the DOM snapshot
+      // if the file system path is a windows path, we convert it to a url path by replacing the backslashes with forward slashes
       if (origSrcPath !== fileSystemPath) {
-        sourceMap.set(origSrcPath, fileSystemPath);
+        const mappedSrcUrl = fileSystemPath.replace(/\\/g, '/');
+        sourceMap.set(origSrcPath, mappedSrcUrl);
       }
 
       await outputFile(join(archiveDir, fileSystemPath), response.body);


### PR DESCRIPTION
Issue:

## Problem
When running Cypress with Chromatic on Windows machines, the [sourceMap](https://github.com/chromaui/chromatic-e2e/blob/87c85abe5b050a539fed4758cd3e10fc7d3ddefa/packages/shared/src/write-archive/index.ts#L51) object was storing Windows file system paths (containing backslashes) as values, which were then used to update the `src` attributes in the DOM snapshots.

While the Windows file system path may work for an image url (browser normalize it automatically), but urls used in CSS properties could be broken and caused resource not found since backslashes are used for css escape. For example, this code:

```css
.btn {background: url('assets\images\icon.png')}
```
can be interpreted as this:
```css
.btn {background-image: url('assetsmagescon.png')}
```

## What this PR does
Separate the concerns of file system operations and URL generation:
- Continue using the original fileSystemPath for writing files to archive
- Convert backslashes to forward slashes before storing in sourceMap for URL replacement.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. Test against the published, canary versions of the packages (which are published along with this PR). -->
