### PR TITLE
exclude overlapping system path segments from fileSystemPath

### DIFF
--- a/.changeset/lucky-penguins-sin.md
+++ b/.changeset/lucky-penguins-sin.md
@@ -1,0 +1,7 @@
+---
+"@chromatic-com/playwright": patch
+"@chromatic-com/cypress": patch
+"@chromatic-com/shared-e2e": patch
+---
+
+Improvements to windows compatibility in archive creation

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ packages/playwright/test-results/
 packages/cypress/tests/cypress/downloads/
 packages/cypress/tests/cypress/test-downloads/
 packages/*/coverage/
+packages/chromatic-archives/

--- a/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/archiving-assets.cy.ts
@@ -28,6 +28,7 @@ it.skip('external asset is archived', () => {
 
 it('assets from css urls are archived', () => {
   cy.visit('/asset-paths/css-urls');
+  cy.get('.with-background-img').should('be.visible');
 });
 
 it('assets from relative css urls with base tag are archived', () => {
@@ -41,6 +42,10 @@ it('assets from data urls are archived', () => {
 // TODO: Unskip when Cypress support achieves parity with Playwright
 it.skip('percents in URLs are handled', () => {
   cy.visit('/asset-paths/percents');
+});
+
+it('colons in URLs are handled', () => {
+  cy.visit('/asset-paths/colons');
 });
 
 it('srcset is used to determine image asset URL', () => {

--- a/packages/playwright/tests/archiving-assets.spec.ts
+++ b/packages/playwright/tests/archiving-assets.spec.ts
@@ -49,6 +49,10 @@ test('percents in URLs are handled', async ({ page }) => {
   await page.goto('/asset-paths/percents');
 });
 
+test('colons in URLs are handled', async ({ page }) => {
+  await page.goto('/asset-paths/colons');
+});
+
 test('srcset is used to determine image asset URL', async ({ page }) => {
   await page.goto('/asset-paths/srcset');
 });

--- a/packages/shared/src/write-archive/archive-file.ts
+++ b/packages/shared/src/write-archive/archive-file.ts
@@ -100,7 +100,7 @@ export class ArchiveFile {
 
   private removeSpecialChars(pathname: string) {
     // The storybook server seems to have a problem with percents in file names
-    return pathname.replace(/[%]/g, '');
+    return pathname.replace(/[%:@]/g, '');
   }
 
   private addExtension(pathname: string) {

--- a/packages/shared/src/write-archive/index.test.ts
+++ b/packages/shared/src/write-archive/index.test.ts
@@ -149,6 +149,35 @@ describe('writeTestResult', () => {
     );
   });
 
+  describe('archive file system path windows', () => {
+    it('handles system paths', async () => {
+      await writeTestResult(
+        {
+          titlePath: ['file.spec.ts', 'Test Story'],
+          // simulates a system path (for windows)
+          outputDir:
+            'C:/Users/testuser/dev/test-results/dist/.playwright/apps/web-react-demo/test-output/',
+          pageUrl: 'http://localhost:3000/',
+          viewport: { height: 800, width: 800 },
+        },
+        { home: Buffer.from(JSON.stringify(snapshotJson)) },
+        {
+          'http://localhost:3000/@fs/C:/Users/testuser/dev/test-results/node_modules/vite/dist/client/index.html':
+            {
+              statusCode: 200,
+              body: Buffer.from('Chromatic'),
+            },
+        },
+        {}
+      );
+
+      expect(filePaths.outputFile).toHaveBeenCalledWith(
+        'C:/Users/testuser/dev/test-results/dist/.playwright/apps/web-react-demo/test-output/chromatic-archives/archive/fs/C/Users/testuser/dev/test-results/node_modules/vite/dist/client/index.html',
+        Buffer.from('Chromatic')
+      );
+    });
+  });
+
   describe('smart story naming', () => {
     it('derives story title from test info, using all of the title path', async () => {
       // @ts-expect-error Jest mock

--- a/test-server/fixtures/asset-paths/colons.html
+++ b/test-server/fixtures/asset-paths/colons.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html>
+  <body>
+    <img src="@fs/C:/img/another:Cwith:colons/image.png" />
+  </body>
+</html>

--- a/test-server/server.js
+++ b/test-server/server.js
@@ -70,6 +70,10 @@ app.get('/img/another%Cwith%Cpercents', (req, res) => {
   res.sendFile(path.join(__dirname, 'fixtures/pink.png'));
 });
 
+app.get('/asset-paths/@fs/C:/img/another:Cwith:colons/image.png', (req, res) => {
+  res.sendFile(path.join(__dirname, 'fixtures/blue.png'));
+});
+
 app.get('/asset-paths/relative/purple.png', (req, res) => {
   res.sendFile(path.join(__dirname, 'fixtures/purple.png'));
 });


### PR DESCRIPTION
It's been reported that sometimes on Windows systems, if the file system path somehow includes the absolute path including the drive (`C:`), this can throw an error on attempting to create the directories to store the archive files. We believe this is because it's trying to create a directory that uses a reserved directory.

## What Changed
Users running Chromatic's Playwright integration on Windows systems can now create archive directories.
We'll now detect when the `fileSystemPath` indicates a local absolute file, and will detect and remove the repeated path segment before creating directories.

We'll also remove `:` characters from these paths regardless.

