### PR TITLE
feat: add empty `@chromatic-com/vitest` package

### DIFF
--- a/.changeset/smooth-walls-mate.md
+++ b/.changeset/smooth-walls-mate.md
@@ -1,0 +1,5 @@
+---
+"@chromatic-com/vitest": patch
+---
+
+Adds initial empty package

--- a/packages/vitest/index.js
+++ b/packages/vitest/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.log('@chromatic-com/vitest');

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@chromatic-com/vitest",
+  "version": "0.0.1",
+  "description": "Chromatic Visual Regression Testing for Vitest",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chromaui/chromatic-e2e.git",
+    "directory": "packages/vitest"
+  },
+  "author": "Chromatic <tom@chromatic.com>",
+  "license": "MIT",
+  "type": "module",
+  "module": "index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "default": "./index.js"
+      }
+    }
+  },
+  "files": [
+    "index.js"
+  ],
+  "scripts": {
+    "build": "echo skipped"
+  },
+  "lint-staged": {
+    "*.{ts,js,css,md}": "prettier --write"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -582,6 +582,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@chromatic-com/vitest@workspace:packages/vitest":
+  version: 0.0.0-use.local
+  resolution: "@chromatic-com/vitest@workspace:packages/vitest"
+  languageName: unknown
+  linkType: soft
+
 "@chromaui/chromatic-e2e@workspace:.":
   version: 0.0.0-use.local
   resolution: "@chromaui/chromatic-e2e@workspace:."


### PR DESCRIPTION
## What Changed

<!-- Insert a description below. -->

In order to be able to do preview/canary releases, we need `@chromatic-com/vitest` package to exist in npm registry. Let's add an empty package that gets published.

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. Test against the published, canary versions of the packages (which are published along with this PR). -->

Once merged and released we should be able to create draft PRs and get preview releases for `@chromatic-com/vitest` package.
