### PR TITLE
feat: add internal `ResourceArchiver.unwatch` method

### DIFF
--- a/packages/shared/src/resource-archiver/index.ts
+++ b/packages/shared/src/resource-archiver/index.ts
@@ -24,6 +24,7 @@ export type HttpCredentials = {
 // a custom interface that satisfies both playwright's CDPSession and chrome-remote-interface's CDP.Client types.
 interface CDPClient {
   on: (eventName: keyof Protocol.Events, handlerFunction: (params?: any) => void) => void;
+  off?: (eventName: keyof Protocol.Events, handlerFunction: (params?: any) => void) => void;
   send: (eventName: keyof Protocol.CommandParameters, payload?: any) => Promise<any>;
 }
 
@@ -32,7 +33,7 @@ export class ResourceArchiver {
 
   private client: CDPClient;
 
-  /** 
+  /**
    Specifies which domains (origins) we should archive resources for (by default we only archive same-origin resources).
    Useful in situations where the environment running the archived storybook (e.g. in CI) may be restricted to an intranet or other domain restrictions
   */
@@ -58,9 +59,15 @@ export class ResourceArchiver {
   }
 
   async watch() {
-    this.client.on('Fetch.requestPaused', this.requestPaused.bind(this));
-    this.client.on('Fetch.authRequired', this.authRequired.bind(this));
+    this.client.on('Fetch.requestPaused', this.requestPaused);
+    this.client.on('Fetch.authRequired', this.authRequired);
     await this.client.send('Fetch.enable', { handleAuthRequests: true });
+  }
+
+  async off() {
+    this.client.off?.('Fetch.requestPaused', this.requestPaused);
+    this.client.off?.('Fetch.authRequired', this.authRequired);
+    await this.client.send('Fetch.disable');
   }
 
   async clientSend<T extends keyof Protocol.CommandParameters>(
@@ -77,7 +84,7 @@ export class ResourceArchiver {
     }
   }
 
-  async authRequired({ requestId, request }: Protocol.Fetch.authRequiredPayload): Promise<void> {
+  authRequired = async ({ requestId, request }: Protocol.Fetch.authRequiredPayload) => {
     await this.clientSend(request, 'Fetch.continueWithAuth', {
       requestId,
       authChallengeResponse: {
@@ -85,16 +92,16 @@ export class ResourceArchiver {
         ...this.httpCredentials,
       },
     });
-  }
+  };
 
-  async requestPaused({
+  requestPaused = async ({
     requestId,
     request,
     responseStatusCode,
     responseStatusText,
     responseErrorReason,
     responseHeaders,
-  }: Protocol.Fetch.requestPausedPayload) {
+  }: Protocol.Fetch.requestPausedPayload) => {
     // We only need to capture assets that will render when the DOM snapshot is rendered,
     // so we only need to handle GET requests.
     if (!request.method.match(/get/i)) {
@@ -150,7 +157,7 @@ export class ResourceArchiver {
       requestId,
       interceptResponse: true,
     });
-  }
+  };
 
   private async handleSuccessfulResponse(
     requestPausedPayload: Pick<

--- a/packages/shared/src/resource-archiver/index.ts
+++ b/packages/shared/src/resource-archiver/index.ts
@@ -64,7 +64,7 @@ export class ResourceArchiver {
     await this.client.send('Fetch.enable', { handleAuthRequests: true });
   }
 
-  async off() {
+  async unwatch() {
     this.client.off?.('Fetch.requestPaused', this.requestPaused);
     this.client.off?.('Fetch.authRequired', this.authRequired);
     await this.client.send('Fetch.disable');


### PR DESCRIPTION
Issue: Split from https://github.com/chromaui/chromatic-e2e/pull/292

## What Changed

Adds `unwatch()` method to resource archiver that can be used to unsubscribe all the listeners it attaches in `watch()` method. This is useful in test runners that can re-use the same CDP session between test files, like Vitest.

## How to test

Existing checks should pass:

```sh
$ yarn build
$ yarn lint
$ yarn test:unit
$ yarn test:playwright
$ yarn test:cypress
```
