### PR TITLE
ci: set permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,10 @@ on:
 
 permissions:
   id-token: write # Required for npm Trusted Publisher (OIDC)
-  contents: read
+  contents: write # Others are required by changesets/action@v1
+  packages: write
+  pull-requests: write
+  issues: read
 
 jobs:
   release-stable:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ on:
 permissions:
   id-token: write # Required for npm Trusted Publisher (OIDC)
   contents: write # Others are required by changesets/action@v1
-  packages: write
   pull-requests: write
   issues: read
 


### PR DESCRIPTION
## What Changed

CI fails to publish from `main`:

- https://github.com/chromaui/chromatic-e2e/actions/runs/23839811708/job/69492303858

> ```sh
> /usr/bin/git push origin HEAD:changeset-release/main --force
> remote: Permission to chromaui/chromatic-e2e.git denied to github-actions[bot].
> fatal: unable to access 'https://github.com/chromaui/chromatic-e2e/': The requested URL returned error: 403
> Error: Error: The process '/usr/bin/git' failed with exit code 128
> Error: The process '/usr/bin/git' failed with exit code 128
> ```
> 

Reading related issues from `changeset` repo, it's related to permissions.

## How to test

Let's merge and see if CI is able to publish.