### PR TITLE
ci: add work-around for npm/cli#9151

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Update npm
         run: |
           npm --version
+          npm install -g npm@~11.10.0 # Work-around for https://github.com/npm/cli/issues/9151#issuecomment-4131466208
           npm install -g npm@latest
           npm --version
 


### PR DESCRIPTION
## What Changed

Release script is running into following upstream bugs:

- https://github.com/npm/cli/issues/9151
- https://github.com/nodejs/node/issues/62425

Error at https://github.com/chromaui/chromatic-e2e/actions/runs/24079308453/job/70235542794

> ```sh
> npm --version
>   npm install -g npm@latest
>   npm --version
>   shell: /usr/bin/bash -e {0}
> 
> 10.9.7
> npm error code MODULE_NOT_FOUND
> npm error Cannot find module 'promise-retry'
> npm error Require stack:
> npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
> ...
> ```



Applies work-around from https://github.com/npm/cli/issues/9151#issuecomment-4131466208.

## How to test

Let's merge and see if `main` is able to do release.