### PR TITLE
ci: apply work-around from #298 to canary releases too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
       - name: Update npm
         run: |
           npm --version
+          npm install -g npm@~11.10.0 # Work-around for https://github.com/npm/cli/issues/9151#issuecomment-4131466208
           npm install -g npm@latest
           npm --version
 


### PR DESCRIPTION
Issue: #298 

## What Changed

Apply same work-around from #298 to canary releases too. Currently canary releases are failing with same error message:

> ```sh
> npm error code MODULE_NOT_FOUND
> npm error Cannot find module 'promise-retry'
> ```
> 

https://github.com/chromaui/chromatic-e2e/actions/runs/24121061592/job/70374976686

## How to test

Merge to `main` and see that canary releases from PRs start to work again.