### PR TITLE
fix(build): properly handle embedded packages that don't export `package.json`

### DIFF
--- a/.changeset/salty-sheep-boil.md
+++ b/.changeset/salty-sheep-boil.md
@@ -1,0 +1,7 @@
+---
+'@chromatic-com/cypress': patch
+'@chromatic-com/playwright': patch
+'@chromatic-com/shared-e2e': patch
+---
+
+Include missing packages in embedded directory

--- a/scripts/prepare-embedded.ts
+++ b/scripts/prepare-embedded.ts
@@ -22,7 +22,23 @@ function resolvePackagePath(req: NodeRequire, packageId: string): string | null 
   try {
     const p = req.resolve(`${packageId}/package.json`);
     return path.dirname(p);
-  } catch {
+  } catch (error: any) {
+    /*
+     * Attempt to parse package.json from error message:
+     * ```
+     * Package subpath './package.json' is not defined by "exports" in /x/chromatic-e2e/node_modules/supports-color/package.json
+     * ```
+     */
+    if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+      const parsed = error.message.split('is not defined by "exports" in ')[1];
+
+      if (fs.existsSync(parsed)) {
+        return path.dirname(parsed);
+      }
+    }
+
+    console.log(styleText('bgRed', `Failed to resolve package.json for "${packageId}".`));
+
     return null;
   }
 }


### PR DESCRIPTION
Issue: 
- Fixes https://github.com/chromaui/chromatic-e2e/issues/305

## What Changed

During `/embedded` packing we are silently ignoring resolving errors. All packages that run into this error are excluded from `/embedded`. If end-user's project doesn't have these missing dependendcies, they'll see runtime errors. Luckily these dependencies are usually present as transitive dependencies from other popular packages, but that's not always the case. 

This function throws `Package subpath './package.json' is not defined by "exports"` for packages that have `exports` defined in `package.json`:

https://github.com/chromaui/chromatic-e2e/blob/6dc1219f63929a6e83efaaa8ac1ba4024cac8395/scripts/prepare-embedded.ts#L21-L28


## How to test

I recommend to download the Stackblitz projects locally and test that way.

### Verify error case

1. Download https://stackblitz.com/~/edit/node-41f2ygly?file=package.json&view=editor locally
2. `npm install`
3. `npm run archive-storybook`
4. Errors about missing dependencies should show up

### Fixed case

1. Download https://stackblitz.com/~/edit/node-f5bxrpy3?file=package.json&view=editor locally
2. `npm install --legacy-peer-deps` (to make chromatic cli accept `0.0.0-` version)
3. `npm run archive-storybook`
4. Storybook opens succesfully

### Manual diff of `/embedded`

Compare these two. Look for `has-flag` and `baseline-browser-mapping` for example:
- `latest` / 0.13.0: https://npmx.dev/package-code/@chromatic-com/playwright/v/0.13.0/embedded%2Fnode_modules
- `canary` / This PR: https://npmx.dev/package-code/@chromatic-com/playwright/v/0.13.1-9775a40-20260409130941/embedded%2Fnode_modules
- Diff: https://npmx.dev/diff/@chromatic-com/playwright/v/0.13.1-9775a40-20260409130941...0.13.0
  <img height="400" alt="image" src="https://github.com/user-attachments/assets/ac81eef6-e00c-493d-917b-4591fc55ff0f" />


> 🦋  @chromatic-com/cypress@0.12.1-9775a40-20260409130941
> 🦋  @chromatic-com/playwright@0.13.1-9775a40-20260409130941