### PR TITLE
fix: don't clean results if `vitest --merge-reports` is used

### DIFF
--- a/.changeset/wide-mammals-hope.md
+++ b/.changeset/wide-mammals-hope.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: do not remove results when 'vitest --merge-reports' is run

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ packages/*/coverage/
 coverage
 packages/chromatic-archives/
 .vitest/
+.vitest-reports/

--- a/packages/vitest/src/node/plugin.test.ts
+++ b/packages/vitest/src/node/plugin.test.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path';
+import { readdir } from 'node:fs/promises';
 import { expect, onTestFinished, test } from 'vitest';
 import { createVitest, type TestModule } from 'vitest/node';
 import { chromaticPlugin } from './plugin';
@@ -136,4 +137,34 @@ test('warns when used on non-browser context', async () => {
   });
 
   expect(stderr).toContain('chromatic  Plugin is used in a non-browser context.');
+});
+
+test('does not clean existing output directory when "vitest --merge-reports" is run', async () => {
+  const options = {
+    /** See {@link file://./../../test/fixtures/dom.test.ts} */
+    include: ['**/dom.test.ts'],
+    root: resolve(import.meta.dirname, '../../test/fixtures'),
+  };
+
+  const outputDir = resolve(options.root, '.vitest-reports');
+  const outputFile = resolve(outputDir, 'blob.json');
+
+  // First run to generate blob
+  await runFixture({ reporters: [['blob', { outputFile }]], ...options });
+
+  // Second with --merge-reports to see if .vitest/chromatic is accidentally removed
+  const { stdout, stderr } = await runFixture({ mergeReports: outputDir, ...options });
+
+  expect(stdout).toContain('Test Files  1 passed (1)\n');
+  expect(stdout).toContain('Tests  1 passed (1)\n');
+  expect(stderr).toBe('');
+
+  // Chromatic results should preserve on file system
+  const archives = resolve(options.root, '.vitest/chromatic/chromatic-archives');
+  await expect(readdir(archives)).resolves.toMatchInlineSnapshot(`
+    [
+      "archive",
+      "dom-mount-some-elements.stories.json",
+    ]
+  `);
 });

--- a/packages/vitest/src/node/plugin.ts
+++ b/packages/vitest/src/node/plugin.ts
@@ -67,7 +67,9 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
         }
       }
 
-      clean();
+      if (!project.globalConfig.mergeReports) {
+        clean();
+      }
 
       if (!project.config.browser.enabled) {
         context.vitest.logger.warn(


### PR DESCRIPTION
## What Changed

Make sure following flow doesn't produce empty results:

```yml
- name: Download all workflow run artifacts
  uses: actions/download-artifact@v4
  with:
    path: .vitest/chromatic
    pattern: chromatic-archives-*
    merge-multiple: true

# This is now accidentally removing .vitest/chromatic that's used on 'Run Chromatic tests' step
- name: Merge reports
  run: npx vitest --merge-reports

- name: Run Chromatic tests
  uses: chromaui/action@latest
  with:
    projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
    vitest: true
```


## How to test

- https://github.com/chromaui/chromatic-e2e/actions/runs/24389997095/job/71233248742

<details>

```yml
name: Tests
on:
  push:
    branches:
      - main
  workflow_dispatch:

jobs:
  tests:
    runs-on: ubuntu-latest
    strategy:
      matrix:
        shard: [1, 2, 3, 4]
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with:
          node-version: 22

      - name: Install pnpm
        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0

      - name: Install dependencies
        run: pnpm i

      - name: Install Playwright Dependencies
        run: pnpm exec playwright install chromium --with-deps --only-shell

      - name: Run tests
        run: pnpm run test --reporter=blob --shard=${{ matrix.shard }}/${{ strategy.job-total }}

      - name: Upload Chromatic archives to GitHub Actions Artifacts
        if: ${{ !cancelled() }}
        uses: actions/upload-artifact@v4
        with:
          name: chromatic-archives-${{ matrix.shard }}
          path: .vitest/chromatic/*
          include-hidden-files: true
          retention-days: 1

      - name: Upload blob report to GitHub Actions Artifacts
        if: ${{ !cancelled() }}
        uses: actions/upload-artifact@v4
        with:
          name: blob-report-${{ matrix.shard }}
          path: .vitest-reports/*
          include-hidden-files: true
          retention-days: 1

      - name: Upload attachments to GitHub Actions Artifacts
        if: ${{ !cancelled() }}
        uses: actions/upload-artifact@v4
        with:
          name: blob-attachments-${{ matrix.shard }}
          path: .vitest-attachments/**
          include-hidden-files: true
          retention-days: 1

  merge-reports:
    if: ${{ !cancelled() }}
    needs: [tests]

    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
        with:
          fetch-depth: 0
      - uses: actions/setup-node@v4
        with:
          node-version: 22

      - name: Install pnpm
        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0

      - name: Install dependencies
        run: pnpm i

      - name: Download Chromatic archives from GitHub Actions Artifacts
        uses: actions/download-artifact@v4
        with:
          path: .vitest/chromatic
          pattern: chromatic-archives-*
          merge-multiple: true

      - name: Download blob reports from GitHub Actions Artifacts
        uses: actions/download-artifact@v4
        with:
          path: .vitest-reports
          pattern: blob-report-*
          merge-multiple: true

      - name: Download attachments from GitHub Actions Artifacts
        uses: actions/download-artifact@v4
        with:
          path: .vitest-attachments
          pattern: blob-attachments-*
          merge-multiple: true

      - name: Merge reports
        run: npx vitest --merge-reports

      - name: Run Chromatic tests
        run: npx chromatic --vitest
        env:
          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
```

</details