### PR TITLE
fix: resolve viewport dimensions from Vitest's iframe

### DIFF
--- a/.changeset/hungry-hotels-bathe.md
+++ b/.changeset/hungry-hotels-bathe.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: resolve viewport from Vitest's iframe

--- a/packages/vitest/src/browser/public/takeSnapshot.test.ts
+++ b/packages/vitest/src/browser/public/takeSnapshot.test.ts
@@ -1,13 +1,20 @@
-import { expect, test } from 'vitest';
-import { runFixture } from '../../../test/utils/node';
+import { expect, test, vi } from 'vitest';
+import * as shared from '@chromatic-com/shared-e2e';
+import { getBrowserConfig, runFixture } from '../../../test/utils/node';
+
+vi.mock('@chromatic-com/shared-e2e');
+vi.mocked(shared.writeTestResult).mockImplementation(() => Promise.resolve());
 
 /** See {@link file://./../../../test/fixtures/take-snapshot.test.ts} */
-const include = ['take-snapshot.test.ts'];
+const takeSnapshotTest = 'take-snapshot.test.ts';
+
+/** See {@link file://./../../../test/fixtures/viewports.test.ts} */
+const viewportsTest = 'viewports.test.ts';
 
 test('provides descriptive error when called in non-registered test', async () => {
   const { stderr } = await runFixture(
     {
-      include,
+      include: [takeSnapshotTest],
       provide: { testName: 'one' },
     },
     { disabled: true }
@@ -33,7 +40,10 @@ test('provides descriptive error when called in non-registered test', async () =
 });
 
 test('provides descriptive error when called outside of a test()', async () => {
-  const { stderr } = await runFixture({ include, provide: { testName: 'two' } });
+  const { stderr } = await runFixture({
+    include: [takeSnapshotTest],
+    provide: { testName: 'two' },
+  });
 
   expect(stderr).toMatchInlineSnapshot(`
     "
@@ -54,7 +64,10 @@ test('provides descriptive error when called outside of a test()', async () => {
 });
 
 test('provides descriptive error when not awaited', async () => {
-  const { stderr } = await runFixture({ include, provide: { testName: 'three' } });
+  const { stderr } = await runFixture({
+    include: [takeSnapshotTest],
+    provide: { testName: 'three' },
+  });
 
   expect(stderr).toMatchInlineSnapshot(`
     "
@@ -85,3 +98,61 @@ test('provides descriptive error when not awaited', async () => {
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯"
   `);
 });
+
+test('viewports are correct when --browser.ui=true', async () => {
+  await runFixture({
+    include: [viewportsTest],
+    browser: { ...getBrowserConfig(), ui: true, viewport: { width: 1280, height: 720 } },
+  });
+
+  expect(getSnapshottedTests()).toMatchInlineSnapshot(`
+    [
+      {
+        "title": "default viewport",
+        "viewport": {
+          "height": 1080,
+          "width": 1920,
+        },
+      },
+      {
+        "title": "calls page.viewport(480, 320)",
+        "viewport": {
+          "height": 1080,
+          "width": 1920,
+        },
+      },
+    ]
+  `);
+});
+
+test('viewports are correct when --browser.ui=false', async () => {
+  await runFixture({
+    include: [viewportsTest],
+    browser: { ...getBrowserConfig(), ui: false, viewport: { width: 1280, height: 720 } },
+  });
+
+  expect(getSnapshottedTests()).toMatchInlineSnapshot(`
+    [
+      {
+        "title": "default viewport",
+        "viewport": {
+          "height": 720,
+          "width": 1280,
+        },
+      },
+      {
+        "title": "calls page.viewport(480, 320)",
+        "viewport": {
+          "height": 720,
+          "width": 1280,
+        },
+      },
+    ]
+  `);
+});
+
+function getSnapshottedTests() {
+  return vi.mocked(shared.writeTestResult).mock.calls.map((call) => {
+    return { title: call[0].titlePath.pop(), viewport: call[0].viewport };
+  });
+}

--- a/packages/vitest/src/browser/public/takeSnapshot.test.ts
+++ b/packages/vitest/src/browser/public/takeSnapshot.test.ts
@@ -110,15 +110,15 @@ test('viewports are correct when --browser.ui=true', async () => {
       {
         "title": "default viewport",
         "viewport": {
-          "height": 1080,
-          "width": 1920,
+          "height": 720,
+          "width": 1280,
         },
       },
       {
         "title": "calls page.viewport(480, 320)",
         "viewport": {
-          "height": 1080,
-          "width": 1920,
+          "height": 320,
+          "width": 480,
         },
       },
     ]
@@ -143,8 +143,8 @@ test('viewports are correct when --browser.ui=false', async () => {
       {
         "title": "calls page.viewport(480, 320)",
         "viewport": {
-          "height": 720,
-          "width": 1280,
+          "height": 320,
+          "width": 480,
         },
       },
     ]

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -102,12 +102,19 @@ export function createCommands(options: ResolvedOptions) {
         snapshotBuffers[name] = Buffer.from(JSON.stringify(domSnapshot));
       }
 
+      const frame = await context.frame();
+
+      const viewport = await frame.evaluate(() => ({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      }));
+
       await writeTestResult(
         {
           outputDir: resolve(context.project.config.root, options.outputDirectory),
           pageUrl: context.page.url(),
           titlePath: getNames(entity),
-          viewport: context.page.viewportSize() || { width: 1920, height: 1080 },
+          viewport,
         },
         snapshotBuffers,
         archive,

--- a/packages/vitest/test/fixtures/viewports.test.ts
+++ b/packages/vitest/test/fixtures/viewports.test.ts
@@ -1,0 +1,8 @@
+import { test } from 'vitest';
+import { page } from 'vitest/browser';
+
+test('default viewport', async () => {});
+
+test('calls page.viewport(480, 320)', async () => {
+  await page.viewport(480, 320);
+});


### PR DESCRIPTION
Issue: Related to https://github.com/chromaui/chromatic-e2e/issues/295

## What Changed

While testing in downstream projects, noticed that viewports were completely off. Vitests' built-in `page.viewport()` only adjust the UI's iframe's scaling and dimensions - not the whole viewport.

## How to test

Added two commits that show the fix before-and-after. The test case can be used to reproduce the bug before fix is applied.
