### PR TITLE
fix: allow plugin to be set in non-browser context

### DIFF
--- a/.changeset/curvy-onions-laugh.md
+++ b/.changeset/curvy-onions-laugh.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: Allow chromaticPlugin to be defined in non-browser context

--- a/packages/vitest/src/node/plugin.test.ts
+++ b/packages/vitest/src/node/plugin.test.ts
@@ -17,9 +17,9 @@ test.each([
 
   const result = config.setupFiles.map((s) => s.replace(process.cwd(), '<process-cwd>'));
 
-  expect(result).toHaveLength(2);
-  expect(result[0]).toBe('<process-cwd>/some-user-defined-setup.ts');
-  expect(result[1]).toBe('<process-cwd>/packages/vitest/src/browser/setupFile.ts');
+  expect.soft(result).toHaveLength(2);
+  expect.soft(result[0]).toBe('<process-cwd>/some-user-defined-setup.ts');
+  expect.soft(result[1]).toBe('<process-cwd>/packages/vitest/src/browser/setupFile.ts');
 });
 
 test('adds browser commands', async () => {
@@ -81,10 +81,14 @@ test('warns if tags are used with Vitest 4.0', async () => {
   );
   onTestFinished(() => vitest.close());
 
+  const project = vitest.projects[0];
+  project.config.browser.enabled = true;
+
   // @ts-expect-error -- intentional
   vitest.version = '4.0.1';
 
-  plugin.configureVitest?.({ vitest, project: vitest.getRootProject() } as any);
+  // @ts-expect-error -- intentional
+  plugin.configureVitest?.({ vitest, project });
 
   expect(getOutput().stderr).toContain(
     'chromatic  Tags cannot be used with Vitest 4.0.1. Please upgrade to Vitest 4.1 or later to use this feature.'
@@ -127,13 +131,10 @@ test('can be scoped to a Vitest project', async () => {
   expect(tests[1].state()).toBe('passed');
 });
 
-test('warns when used on non-browser context', async () => {
-  const { stderr } = await runFixture({
-    browser: undefined,
-    /** See {@link file://./../../test/fixtures/node-environment.test.ts} */
-    include: ['**/node-environment.test.ts'],
-    root: resolve(import.meta.dirname, '../../test/fixtures'),
+test('skips configuration when used on non-browser context', async () => {
+  const config = await getResolvedConfig({
+    browser: { enabled: false },
   });
 
-  expect(stderr).toContain('chromatic  Plugin is used in a non-browser context.');
+  expect(config.setupFiles).toHaveLength(0);
 });

--- a/packages/vitest/src/node/plugin.ts
+++ b/packages/vitest/src/node/plugin.ts
@@ -23,18 +23,21 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
     ...userOptions,
   };
 
+  const isDist = import.meta.url.includes('dist/plugin.js');
+
+  const setupFile = resolve(
+    import.meta.dirname,
+    isDist ? './setupFile.js' : '../browser/setupFile.ts'
+  );
+
   return {
     name: 'vitest:chromatic',
     config() {
-      const isDist = import.meta.url.includes('dist/plugin.js');
-      const setupFile = resolve(
-        import.meta.dirname,
-        isDist ? './setupFile.js' : '../browser/setupFile.ts'
-      );
-
       return {
+        optimizeDeps: {
+          entries: [setupFile],
+        },
         test: {
-          setupFiles: [setupFile],
           browser: {
             commands: createCommands(options),
           },
@@ -44,6 +47,12 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
 
     configureVitest(context) {
       const project = context.project;
+
+      if (!project.config.browser.enabled) {
+        return;
+      }
+
+      project.config.setupFiles.push(setupFile);
 
       // We support Vitest 4.0.0, but tags were introduced in 4.1.0
       if (options.tags && context.vitest.version.startsWith('4.0')) {
@@ -68,13 +77,6 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
       }
 
       clean();
-
-      if (!project.config.browser.enabled) {
-        context.vitest.logger.warn(
-          colors.bgYellow(colors.black(' chromatic ')),
-          colors.yellow('Plugin is used in a non-browser context.')
-        );
-      }
 
       project.onTestsRerun(async () => {
         clean();

--- a/packages/vitest/test/utils/node.ts
+++ b/packages/vitest/test/utils/node.ts
@@ -3,7 +3,7 @@
 import { resolve } from 'node:path';
 import { Writable } from 'node:stream';
 import { stripVTControlCharacters } from 'node:util';
-import { type Mock, onTestFinished, vi } from 'vitest';
+import { type Mock, vi } from 'vitest';
 import { type CliOptions, createVitest, type InlineConfig, startVitest } from 'vitest/node';
 import { playwright } from '@vitest/browser-playwright';
 import { chromaticPlugin } from '../../src/node/plugin';
@@ -39,7 +39,7 @@ export async function runFixture(
     },
     streams
   );
-  vitest.close();
+  await vitest.close();
 
   return getOutput();
 }
@@ -50,13 +50,13 @@ export async function getResolvedConfig(
 ) {
   const vitest = await createVitest(
     'test',
-    { config: false, watch: false },
+    { config: false, watch: false, browser: options.browser || getBrowserConfig() },
     { plugins: [chromaticPlugin(pluginOptions)], test: options },
     createOutputStreams().streams
   );
-  onTestFinished(() => vitest.close());
+  await vitest.close();
 
-  return vitest.config;
+  return vitest.projects[0].config;
 }
 
 export function createOutputStreams() {


### PR DESCRIPTION
Issue: Related to https://github.com/chromaui/chromatic-e2e/issues/295

## What Changed

Allow users to define `chromaticPlugin` in non-browser context too.

Previously we would have failed in following case:

```ts
export default defineConfig({
  plugins: [react(), chromaticPlugin()],
  test: {
    projects: [
      {
        extends: true, // So that it gets react plugin
        test: {
          name: "unit",
          environment: "jsdom",
          include: ["**/*.test.ts"],
        },
      },
      {
        test: {
          name: "browser",
          include: ["**/*.browser.test.ts"],
          browser: { ... }
        },
      },
    ],
  },
})
```

Now we just skip adding browser specific `setupFiles` for projects that don't have browser mode enabled.

## How to test

Added unit test to verify this. 
