### PR TITLE
fix: preserve CSS pseudo states in snapshots

### DIFF
--- a/.changeset/six-roses-jam.md
+++ b/.changeset/six-roses-jam.md
@@ -1,0 +1,8 @@
+---
+'@chromatic-com/playwright': patch
+'@chromatic-com/cypress': patch
+'@chromatic-com/shared-e2e': patch
+'@chromatic-com/vitest': patch
+---
+
+Fix: Preserve CSS pseudo states in snapshots

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -31,9 +31,9 @@ const writeArchives = async ({
 }: WriteArchivesParams) => {
   const allSnapshots = Object.fromEntries(
     // manual snapshots can be given a name; otherwise, just use the snapshot's place in line as the name
-    domSnapshots.map(({ name, snapshot, viewport }, index) => [
+    domSnapshots.map(({ name, snapshot, viewport, pseudoClassIds }, index) => [
       name ?? `Snapshot #${index + 1}`,
-      { snapshot: Buffer.from(JSON.stringify(snapshot)), viewport },
+      { snapshot: Buffer.from(JSON.stringify(snapshot)), viewport, pseudoClassIds },
     ])
   );
 

--- a/packages/cypress/src/takeSnapshot.ts
+++ b/packages/cypress/src/takeSnapshot.ts
@@ -1,4 +1,4 @@
-import { snapshot } from '@chromaui/rrweb-snapshot';
+import { createMirror, snapshot } from '@chromaui/rrweb-snapshot';
 import { CypressSnapshot } from './types';
 import type { serializedNodeWithId } from '@rrweb/types';
 
@@ -12,7 +12,17 @@ export const takeSnapshot = (
       resolve(null);
     }
 
-    const domSnapshot = snapshot(doc, { recordCanvas: true });
+    const mirror = createMirror();
+    const domSnapshot = snapshot(doc, { recordCanvas: true, mirror })!;
+
+    const pseudoClassIds: CypressSnapshot['pseudoClassIds'] = {};
+
+    for (const className of [':hover', ':focus', ':focus-visible', ':active']) {
+      const elements = doc.querySelectorAll(className);
+      const ids = Array.from(elements, (el) => mirror.getId(el)).filter((id) => id !== -1);
+      pseudoClassIds[className] = ids;
+    }
+
     // do some post-processing on the snapshot
     const toDataURL = async (url: string) => {
       // read contents of the blob URL
@@ -44,7 +54,7 @@ export const takeSnapshot = (
     };
 
     replaceBlobUrls(domSnapshot).then(() => {
-      resolve({ snapshot: domSnapshot, viewport });
+      resolve({ snapshot: domSnapshot, viewport, pseudoClassIds });
     });
   });
 };

--- a/packages/cypress/src/types.ts
+++ b/packages/cypress/src/types.ts
@@ -1,11 +1,11 @@
 import type { serializedNodeWithId } from '@rrweb/types';
-import type { Viewport } from '@chromatic-com/shared-e2e';
+import type { DOMSnapshots } from '@chromatic-com/shared-e2e';
 
 export interface CypressSnapshot {
   // the name of the snapshot (optionally provided for manual snapshots, never provided for automatic snapshots)
   name?: string;
   // the DOM snapshot
   snapshot: serializedNodeWithId;
-  // the viewport at the time of the snapshot
-  viewport: Viewport;
+  viewport: DOMSnapshots[string]['viewport'];
+  pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'];
 }

--- a/packages/cypress/tests/cypress/e2e/css-pseudo-states.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/css-pseudo-states.cy.ts
@@ -1,0 +1,141 @@
+type Point = { x: number; y: number };
+
+it('captures :hover state', { env: { disableAutoSnapshot: true } }, () => {
+  cy.visit('/css-pseudo-states');
+  withElementCenter('button#target', mouseMove);
+
+  cy.get('button#target:hover').should('exist');
+  cy.takeSnapshot('hover');
+});
+
+it('captures :focus state', { env: { disableAutoSnapshot: true } }, () => {
+  cy.visit('/css-pseudo-states');
+
+  withElementCenter('button#target', (point) =>
+    mouseMove(point)
+      .then(() => mouseDown(point))
+      .then(() => mouseUp(point))
+  );
+
+  cy.get('button#target:focus').should('exist');
+  cy.takeSnapshot('focus');
+});
+
+it('captures :active state', { env: { disableAutoSnapshot: true } }, () => {
+  cy.visit('/css-pseudo-states');
+
+  let pressedCoords: Point = { x: 0, y: 0 };
+
+  withElementCenter('button#target', (point) =>
+    mouseMove(point)
+      .then(() => mouseDown(point))
+      .then(() => {
+        pressedCoords = point;
+      })
+  ).then(() => {
+    cy.get('button#target').should('have.css', 'background-color', 'rgb(0, 128, 0)');
+  });
+
+  cy.takeSnapshot('active');
+
+  cy.then(() => mouseUp(pressedCoords));
+});
+
+it('captures :focus-visible state', { env: { disableAutoSnapshot: true } }, () => {
+  cy.visit('/css-pseudo-states');
+  cy.get('button#tab-cycle').focus();
+
+  cy.wrap(null).then(keyboardTab);
+
+  cy.get('button#target:focus-visible').should('be.visible');
+  cy.takeSnapshot('focus-visible');
+});
+
+function cdp(command: string, params: Record<string, unknown>) {
+  return Cypress.automation('remote:debugger:protocol', { command, params });
+}
+
+function getCdpElementCenter(el: HTMLElement): Point {
+  const rect = el.getBoundingClientRect();
+  const autWindow = el.ownerDocument.defaultView!;
+
+  if (autWindow === autWindow.top) {
+    return {
+      x: Math.round(rect.left + rect.width / 2),
+      y: Math.round(rect.top + rect.height / 2),
+    };
+  }
+
+  const autIframe = [...autWindow.parent.document.querySelectorAll('iframe')].find(
+    (frame) => frame.contentWindow === autWindow
+  );
+
+  if (!autIframe) {
+    return {
+      x: Math.round(rect.left + rect.width / 2),
+      y: Math.round(rect.top + rect.height / 2),
+    };
+  }
+
+  const iframeRect = autIframe.getBoundingClientRect();
+  const frameScale = autIframe.offsetWidth ? iframeRect.width / autIframe.offsetWidth : 1;
+
+  return {
+    x: Math.round(iframeRect.left + rect.left * frameScale + (rect.width * frameScale) / 2),
+    y: Math.round(iframeRect.top + rect.top * frameScale + (rect.height * frameScale) / 2),
+  };
+}
+
+function withElementCenter(selector: string, cb: (point: Point) => Promise<unknown>) {
+  return cy.get(selector).then(($el) => cb(getCdpElementCenter($el[0])));
+}
+
+function mouseMove(point: Point) {
+  return cdp('Input.dispatchMouseEvent', {
+    type: 'mouseMoved',
+    x: point.x,
+    y: point.y,
+    button: 'none',
+    pointerType: 'mouse',
+  });
+}
+
+function mouseDown(point: Point) {
+  return cdp('Input.dispatchMouseEvent', {
+    type: 'mousePressed',
+    x: point.x,
+    y: point.y,
+    button: 'left',
+    buttons: 1,
+    clickCount: 1,
+    pointerType: 'mouse',
+  });
+}
+
+function mouseUp(point: Point) {
+  return cdp('Input.dispatchMouseEvent', {
+    type: 'mouseReleased',
+    x: point.x,
+    y: point.y,
+    button: 'left',
+    buttons: 0,
+    clickCount: 1,
+    pointerType: 'mouse',
+  });
+}
+
+function keyboardTab() {
+  return cdp('Input.dispatchKeyEvent', {
+    type: 'rawKeyDown',
+    windowsVirtualKeyCode: 9,
+    key: 'Tab',
+    code: 'Tab',
+  }).then(() =>
+    cdp('Input.dispatchKeyEvent', {
+      type: 'keyUp',
+      windowsVirtualKeyCode: 9,
+      key: 'Tab',
+      code: 'Tab',
+    })
+  );
+}

--- a/packages/playwright/src/takeSnapshot.test.ts
+++ b/packages/playwright/src/takeSnapshot.test.ts
@@ -7,7 +7,7 @@ import { chromaticSnapshots, takeSnapshot } from './takeSnapshot';
 // (where page is probably too tied up into takeSnapshot anyway)
 const fakePage = {
   on: () => {},
-  evaluate: () => null,
+  evaluate: () => ({ domSnapshot: null, pseudoClassIds: {} }),
   viewportSize: () => ({ width: 100, height: 200 }),
 } as Page;
 

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -2,14 +2,15 @@ import type { Page, TestInfo } from '@playwright/test';
 import { readFileSync } from 'fs';
 import { dedent } from 'ts-dedent';
 import type { serializedNodeWithId } from '@rrweb/types';
-import { logger, type Viewport } from '@chromatic-com/shared-e2e';
+import { type DOMSnapshots, logger } from '@chromatic-com/shared-e2e';
 
 const rrweb = readFileSync(require.resolve('@chromaui/rrweb-snapshot'), 'utf8');
 
-// top-level key is the test ID, next level key is the name of the snapshot (which we expect to be unique)
+type TestID = TestInfo['testId'];
+type SnapshotName = keyof DOMSnapshots;
 export const chromaticSnapshots: Map<
-  string,
-  Map<string, { snapshot: Buffer; viewport: Viewport }>
+  TestID,
+  Map<SnapshotName, DOMSnapshots[SnapshotName]>
 > = new Map();
 
 async function takeSnapshot(page: Page, testInfo: TestInfo): Promise<void>;
@@ -36,14 +37,28 @@ async function takeSnapshot(
   });
 
   // Serialize and capture the DOM
-  const domSnapshot: serializedNodeWithId = await page.evaluate(dedent`
+  const {
+    domSnapshot,
+    pseudoClassIds,
+  }: { domSnapshot: serializedNodeWithId; pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'] } =
+    await page.evaluate(dedent`
     ${rrweb};
 
     // this code was erroring the page.evaluate() when it was passed as a function to page.evaluate(),
     // so for now it is being passed as a string until that can be resolved.
     const doPostProcessing = (rrwebSnapshotInstance, documentToSnapshot) => {
       return new Promise((resolve) => {
-        const domSnapshot = rrwebSnapshotInstance.snapshot(documentToSnapshot, { recordCanvas: true });
+        const mirror = rrwebSnapshotInstance.createMirror();
+        const domSnapshot = rrwebSnapshotInstance.snapshot(documentToSnapshot, { recordCanvas: true, mirror });
+
+        const pseudoClassIds = {};
+
+        for (const className of [':hover', ':focus', ':focus-visible', ':active']) {
+          const elements = documentToSnapshot.querySelectorAll(className);
+          const ids = Array.from(elements, (el) => mirror.getId(el)).filter((id) => id !== -1);
+          pseudoClassIds[className] = ids;
+        }
+
         // do some post-processing on the snapshot
         const toDataURL = async (url) => {
           // read contents of the blob URL
@@ -75,7 +90,7 @@ async function takeSnapshot(
         };
 
         replaceBlobUrls(domSnapshot).then(() => {
-          resolve(domSnapshot);
+          resolve({ domSnapshot, pseudoClassIds });
         });
       });
     };
@@ -107,12 +122,11 @@ async function takeSnapshot(
     // map used so the snapshots are always in order
     chromaticSnapshots.set(testId, new Map());
   }
-  chromaticSnapshots
-    .get(testId)
-    .set(name, {
-      snapshot: bufferedSnapshot,
-      viewport: page.viewportSize() || { width: 1280, height: 720 },
-    });
+  chromaticSnapshots.get(testId).set(name, {
+    snapshot: bufferedSnapshot,
+    viewport: page.viewportSize() || { width: 1280, height: 720 },
+    pseudoClassIds,
+  });
 }
 
 export { takeSnapshot };

--- a/packages/playwright/tests/css-pseudo-states.spec.ts
+++ b/packages/playwright/tests/css-pseudo-states.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test, takeSnapshot } from '../src';
+
+test.use({ disableAutoSnapshot: true });
+
+test('captures :hover state', async ({ page }, testInfo) => {
+  await page.goto('/css-pseudo-states');
+
+  await page.locator('button#target').hover();
+  expect(page.locator('button:hover')).toBeVisible();
+
+  await takeSnapshot(page, 'hover', testInfo);
+});
+
+test('captures :focus state', async ({ page }, testInfo) => {
+  await page.goto('/css-pseudo-states');
+
+  await page.getByRole('button', { name: 'target' }).click();
+  expect(page.locator('button:focus')).toBeVisible();
+
+  await takeSnapshot(page, 'focus', testInfo);
+});
+
+test('captures :focus-visible state', async ({ page }, testInfo) => {
+  await page.goto('/css-pseudo-states');
+
+  await page.getByRole('button', { name: 'Focus this before tab' }).click();
+  await page.keyboard.press('Tab');
+
+  expect(page.locator('button:focus-visible')).toBeVisible();
+
+  await takeSnapshot(page, 'focus-visible', testInfo);
+});
+
+test('captures :active state', async ({ page }, testInfo) => {
+  await page.goto('/css-pseudo-states');
+
+  const box = await page.locator('button#target').boundingBox();
+
+  if (!box) {
+    throw new Error('Cannot find button#target');
+  }
+
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+
+  await takeSnapshot(page, 'active', testInfo);
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,4 +5,9 @@ export * from './utils/logger';
 export * from './constants';
 export * from './utils/viewport';
 
-export type { ChromaticConfig, ChromaticStorybookParameters } from './types';
+export type {
+  ChromaticConfig,
+  ChromaticStorybookParameters,
+  DOMSnapshots,
+  SavedSnapshot,
+} from './types';

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,3 +1,4 @@
+import { serializedNodeWithId } from '@rrweb/types';
 import { Viewport } from './utils/viewport';
 
 export interface ChromaticConfig {
@@ -45,5 +46,12 @@ export type DOMSnapshots = Record<
   {
     snapshot: Buffer;
     viewport: Viewport;
+    pseudoClassIds: Record<string, number[]>;
   }
 >;
+
+/** Shape of the snapshot that is written to the file system */
+export interface SavedSnapshot {
+  snapshot: serializedNodeWithId;
+  pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'];
+}

--- a/packages/shared/src/write-archive/dom-snapshot.test.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.test.ts
@@ -262,40 +262,44 @@ sourceMap.set(queryUrl, queryUrlTransformed);
 describe('DOMSnapshot', () => {
   describe('mapAssetPaths', () => {
     it('maps asset paths in src attrs, style attrs, and external style sheets, and inline style elements', async () => {
-      const domSnapshot = new DOMSnapshot(snapshot);
+      const domSnapshot = new DOMSnapshot({ snapshot, pseudoClassIds: {} });
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
 
-      expect(mappedSnapshot).toEqual(expectedMappedSnapshot);
+      expect(mappedSnapshot).toEqual(`{"snapshot":${expectedMappedSnapshot},"pseudoClassIds":{}}`);
     });
 
     it('does not change paths that are not in the source map', async () => {
-      const domSnapshot = new DOMSnapshot(snapshot);
+      const domSnapshot = new DOMSnapshot({ snapshot, pseudoClassIds: {} });
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(new Map<string, string>());
 
-      expect(mappedSnapshot).toEqual(snapshot);
+      expect(mappedSnapshot).toEqual(`{"snapshot":${snapshot},"pseudoClassIds":{}}`);
     });
 
     it('maps img srcsets', async () => {
-      const domSnapshot = new DOMSnapshot(
-        createImgSrcsetSnapshot({
+      const domSnapshot = new DOMSnapshot({
+        snapshot: createImgSrcsetSnapshot({
           backupUrl: relativeUrl,
           smallUrl: externalUrl,
           largeUrl: queryUrl,
-        })
-      );
+        }),
+        pseudoClassIds: {},
+      });
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
 
       expect(JSON.parse(mappedSnapshot)).toEqual({
-        type: 2,
-        tagName: 'img',
-        attributes: {
-          src: `${queryUrlTransformed}`,
+        snapshot: {
+          type: 2,
+          tagName: 'img',
+          attributes: {
+            src: `${queryUrlTransformed}`,
+          },
+          childNodes: [],
+          id: 61,
         },
-        childNodes: [],
-        id: 61,
+        pseudoClassIds: {},
       });
     });
 
@@ -305,49 +309,55 @@ describe('DOMSnapshot', () => {
         smallUrl: externalUrl,
         largeUrl: queryUrl,
       });
-      const domSnapshot = new DOMSnapshot(originalSnapshot);
+      const domSnapshot = new DOMSnapshot({ snapshot: originalSnapshot, pseudoClassIds: {} });
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(new Map<string, string>());
 
-      expect(mappedSnapshot).toEqual(originalSnapshot);
+      expect(mappedSnapshot).toEqual(`{"snapshot":${originalSnapshot},"pseudoClassIds":{}}`);
     });
 
     it('maps picture srcsets, single <source>', async () => {
-      const domSnapshot = new DOMSnapshot(
-        createPictureSrcsetSnapshotSingleSource({ backupUrl: relativeUrl, matchingUrl: queryUrl })
-      );
+      const domSnapshot = new DOMSnapshot({
+        snapshot: createPictureSrcsetSnapshotSingleSource({
+          backupUrl: relativeUrl,
+          matchingUrl: queryUrl,
+        }),
+        pseudoClassIds: {},
+      });
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
 
-      expect(JSON.parse(mappedSnapshot)).toEqual(pictureWithJustImageTag);
+      expect(JSON.parse(mappedSnapshot).snapshot).toEqual(pictureWithJustImageTag);
     });
 
     it('maps picture srcsets, multiple <source>s', async () => {
-      const domSnapshot = new DOMSnapshot(
-        createPictureSrcsetSnapshotMultipleSources({
+      const domSnapshot = new DOMSnapshot({
+        snapshot: createPictureSrcsetSnapshotMultipleSources({
           backupUrl: relativeUrl,
           wrongUrl: externalUrl,
           matchingUrl: queryUrl,
-        })
-      );
+        }),
+        pseudoClassIds: {},
+      });
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
 
-      expect(JSON.parse(mappedSnapshot)).toEqual(pictureWithJustImageTag);
+      expect(JSON.parse(mappedSnapshot).snapshot).toEqual(pictureWithJustImageTag);
     });
 
     it('maps picture srcsets, single <source> with multiple srcset values', async () => {
-      const domSnapshot = new DOMSnapshot(
-        createPictureSrcsetSnapshotSingleSourceMultipleSrcsets({
+      const domSnapshot = new DOMSnapshot({
+        snapshot: createPictureSrcsetSnapshotSingleSourceMultipleSrcsets({
           backupUrl: relativeUrl,
           wrongUrl: externalUrl,
           matchingUrl: queryUrl,
-        })
-      );
+        }),
+        pseudoClassIds: {},
+      });
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
 
-      expect(JSON.parse(mappedSnapshot)).toEqual(pictureWithJustImageTag);
+      expect(JSON.parse(mappedSnapshot).snapshot).toEqual(pictureWithJustImageTag);
     });
 
     it('maps picture srcsets, <picture> and children left untouched if there is no URL match', async () => {
@@ -355,26 +365,27 @@ describe('DOMSnapshot', () => {
         wrongUrl: '/totally-bogus-url.png',
         alsoWrongUrl: 'https://another-totally-bogus.com/url.png',
       });
-      const domSnapshot = new DOMSnapshot(originalSnapshot);
+      const domSnapshot = new DOMSnapshot({ snapshot: originalSnapshot, pseudoClassIds: {} });
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
 
-      expect(JSON.parse(mappedSnapshot)).toEqual(JSON.parse(originalSnapshot));
+      expect(JSON.parse(mappedSnapshot).snapshot).toEqual(JSON.parse(originalSnapshot));
     });
 
     // important that we only blow away what we need to; since <picture> contents are styled by their <img> tag,
     // we don't want to get rid of any existing <img> attributes (like class for example)
     it('maps picture srcsets, preserves existing <img> attributes', async () => {
-      const domSnapshot = new DOMSnapshot(
-        createPictureSrcsetSnapshotSingleSourceImageHasAttributes({
+      const domSnapshot = new DOMSnapshot({
+        snapshot: createPictureSrcsetSnapshotSingleSourceImageHasAttributes({
           backupUrl: relativeUrl,
           matchingUrl: queryUrl,
-        })
-      );
+        }),
+        pseudoClassIds: {},
+      });
 
       const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
 
-      expect(JSON.parse(mappedSnapshot)).toEqual({
+      expect(JSON.parse(mappedSnapshot).snapshot).toEqual({
         ...pictureWithJustImageTag,
         childNodes: [
           {
@@ -390,23 +401,38 @@ describe('DOMSnapshot', () => {
 
     it('does change base tag href when there is a localhost', async () => {
       const originalSnapshot = createBaseTagSnapshot('http://localhost:3000/');
-      const domSnapshot = new DOMSnapshot(originalSnapshot);
+      const domSnapshot = new DOMSnapshot({ snapshot: originalSnapshot, pseudoClassIds: {} });
       const mappedSnapshot = await domSnapshot.mapAssetPaths(new Map());
-      expect(mappedSnapshot).toEqual(createBaseTagSnapshot('/'));
+      expect(mappedSnapshot).toEqual(
+        `{"snapshot":${createBaseTagSnapshot('/')},"pseudoClassIds":{}}`
+      );
     });
 
     it('does not change base tag href when not localhost', async () => {
       const originalSnapshot = createBaseTagSnapshot('https://example.com/app/');
-      const domSnapshot = new DOMSnapshot(originalSnapshot);
+      const domSnapshot = new DOMSnapshot({ snapshot: originalSnapshot, pseudoClassIds: {} });
       const mappedSnapshot = await domSnapshot.mapAssetPaths(new Map());
-      expect(mappedSnapshot).toEqual(originalSnapshot);
+      expect(mappedSnapshot).toEqual(`{"snapshot":${originalSnapshot},"pseudoClassIds":{}}`);
     });
 
     it('does not change base tag href when already relative', async () => {
       const originalSnapshot = createBaseTagSnapshot('/app/');
-      const domSnapshot = new DOMSnapshot(originalSnapshot);
+      const domSnapshot = new DOMSnapshot({ snapshot: originalSnapshot, pseudoClassIds: {} });
       const mappedSnapshot = await domSnapshot.mapAssetPaths(new Map());
-      expect(mappedSnapshot).toEqual(originalSnapshot);
+      expect(mappedSnapshot).toEqual(`{"snapshot":${originalSnapshot},"pseudoClassIds":{}}`);
+    });
+
+    it('maps pseudoClassIds', async () => {
+      const domSnapshot = new DOMSnapshot({
+        snapshot,
+        pseudoClassIds: { hover: [2, 3, 4], focus: [5, 6, 7], active: [8, 9, 10] },
+      });
+
+      const mappedSnapshot = await domSnapshot.mapAssetPaths(sourceMap);
+
+      expect(mappedSnapshot).toEqual(
+        `{"snapshot":${expectedMappedSnapshot},"pseudoClassIds":{"hover":[2,3,4],"focus":[5,6,7],"active":[8,9,10]}}`
+      );
     });
   });
 });

--- a/packages/shared/src/write-archive/dom-snapshot.ts
+++ b/packages/shared/src/write-archive/dom-snapshot.ts
@@ -2,6 +2,7 @@ import type { serializedElementNodeWithId, serializedNodeWithId } from '@rrweb/t
 import { NodeType } from '@rrweb/types';
 import srcset from 'srcset';
 import { removeLocalhostFromBaseUrl } from '../utils/filePaths';
+import type { DOMSnapshots, SavedSnapshot } from '../types';
 
 // Matches `url(...)` function in CSS text, excluding data URLs
 const CSS_URL_REGEX = /url\((?!['"]?(?:data):)['"]?([^'")]*)['"]?\)/gi;
@@ -11,19 +12,32 @@ const CSS_URL_REGEX = /url\((?!['"]?(?:data):)['"]?([^'")]*)['"]?\)/gi;
  */
 export class DOMSnapshot {
   snapshot: serializedNodeWithId;
+  pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'];
 
-  constructor(snapshot: Buffer | string) {
+  constructor({
+    snapshot,
+    pseudoClassIds,
+  }: {
+    snapshot: DOMSnapshots[string]['snapshot'] | string;
+    pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'];
+  }) {
     if (Buffer.isBuffer(snapshot)) {
       const bufferAsString = snapshot.toString('utf-8');
       this.snapshot = JSON.parse(bufferAsString);
     } else {
       this.snapshot = JSON.parse(snapshot);
     }
+
+    this.pseudoClassIds = pseudoClassIds;
   }
 
   async mapAssetPaths(sourceMap: Map<string, string>) {
-    const transformedSnapshot = await this.mapNode(this.snapshot, sourceMap);
-    return JSON.stringify(transformedSnapshot);
+    const savedSnapshot: SavedSnapshot = {
+      snapshot: await this.mapNode(this.snapshot, sourceMap),
+      pseudoClassIds: this.pseudoClassIds,
+    };
+
+    return JSON.stringify(savedSnapshot);
   }
 
   private async mapNode(node: serializedNodeWithId, sourceMap: Map<string, string>) {

--- a/packages/shared/src/write-archive/index.test.ts
+++ b/packages/shared/src/write-archive/index.test.ts
@@ -135,7 +135,7 @@ describe('writeTestResult', () => {
       resolve(
         './test-results/chromatic-archives/archive/file-toy-story-home.w800h800.snapshot.json'
       ),
-      JSON.stringify(expectedMappedJson)
+      JSON.stringify({ snapshot: expectedMappedJson })
     );
   });
 

--- a/packages/shared/src/write-archive/index.ts
+++ b/packages/shared/src/write-archive/index.ts
@@ -65,13 +65,13 @@ export async function writeTestResult(
   );
 
   await Promise.all(
-    Object.entries(domSnapshots).map(async ([name, { snapshot: domSnapshot, viewport }]) => {
+    Object.entries(domSnapshots).map(async ([name, domSnapshot]) => {
       // XXX_jwir3: We go through our stories here and map any instances that are found in
       //            the keys of the source map to their respective values.
       const snapshot = new DOMSnapshot(domSnapshot);
       const mappedSnapshot = await snapshot.mapAssetPaths(sourceMap);
 
-      const snapshotFile = snapshotFileName(snapshotId(title, name), viewport);
+      const snapshotFile = snapshotFileName(snapshotId(title, name), domSnapshot.viewport);
       await outputFile(join(archiveDir, snapshotFile), mappedSnapshot);
     })
   );

--- a/packages/shared/storybook-config/preview.ts
+++ b/packages/shared/storybook-config/preview.ts
@@ -1,7 +1,8 @@
 import type { RenderContext, RenderToCanvas, WebRenderer } from 'storybook/internal/types';
 import type { serializedNodeWithId } from '@rrweb/types';
 import { NodeType } from '@rrweb/types';
-import { rebuild } from '@chromaui/rrweb-snapshot';
+import { rebuild, createMirror, createCache } from '@chromaui/rrweb-snapshot';
+import { type SavedSnapshot } from '@chromatic-com/shared-e2e';
 
 const pageUrl = new URL(window.location.href);
 pageUrl.pathname = '';
@@ -33,7 +34,7 @@ function snapshotFileName(snapshotId: string, viewport: string) {
   return fileNameParts.join('.');
 }
 
-async function fetchSnapshot(context: RenderContext<RRWebFramework>) {
+async function fetchSnapshot(context: RenderContext<RRWebFramework>): Promise<SavedSnapshot> {
   const { url, id } = context.storyContext.parameters.server;
   const { viewport } = context.storyContext.globals;
 
@@ -58,7 +59,7 @@ async function fetchSnapshot(context: RenderContext<RRWebFramework>) {
 }
 
 const renderToCanvas: RenderToCanvas<RRWebFramework> = async (context) => {
-  const snapshot = await fetchSnapshot(context);
+  const { snapshot, pseudoClassIds } = await fetchSnapshot(context);
 
   // The snapshot is a representation of a complete HTML document
   const htmlNode = findHtmlNode(snapshot);
@@ -68,8 +69,18 @@ const renderToCanvas: RenderToCanvas<RRWebFramework> = async (context) => {
   // (and breaks Storybook).
   // However, if you just rebuild the html element part, it will recreate but not attempt to
   // insert it in the DOM.
-  // @ts-expect-error rebuild is typed incorreclty, cache and mirror are optional
-  const html = (await rebuild(htmlNode, { doc: document })) as HTMLElement;
+  const mirror = createMirror();
+  const html = rebuild(htmlNode!, { doc: document, mirror, cache: createCache() }) as HTMLElement;
+
+  for (const [className, ids] of Object.entries(pseudoClassIds)) {
+    for (const id of ids) {
+      const el = mirror.getNode(id) as Element | null;
+
+      if (el?.classList) {
+        el.classList.add(className);
+      }
+    }
+  }
 
   // Now we insert the rebuilt html element in the DOM
   document.replaceChild(html, document.children[0]);

--- a/packages/vitest/src/browser/public/takeSnapshot.browser.test.ts
+++ b/packages/vitest/src/browser/public/takeSnapshot.browser.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, expect, test } from 'vitest';
-import { commands } from 'vitest/browser';
+import { commands, page } from 'vitest/browser';
 import { takeSnapshot } from './takeSnapshot';
 
 beforeEach(() => {
@@ -29,6 +29,39 @@ test('saves snapshot on server', async ({ task }) => {
       "id": "number",
       "tagName": "h1",
       "type": 2,
+    }
+  `);
+});
+
+test('saves pseudo class ids on server', async ({ task }) => {
+  const hovered = document.createElement('button');
+  hovered.textContent = 'Hover here';
+  document.body.appendChild(hovered);
+
+  const focused = document.createElement('button');
+  focused.textContent = 'Focus here';
+  document.body.appendChild(focused);
+
+  await page.getByRole('button', { name: 'Focus here' }).click();
+  await page.getByRole('button', { name: 'Hover here' }).hover();
+
+  await takeSnapshot('example');
+
+  const snapshots = await commands.__chromatic_getSnapshots(task.id);
+  expect(snapshots).toHaveProperty('example');
+
+  expect(snapshots.example.pseudoClassIds).toMatchInlineSnapshot(`
+    {
+      ":active": [],
+      ":focus": [
+        118,
+      ],
+      ":focus-visible": [],
+      ":hover": [
+        81,
+        115,
+        116,
+      ],
     }
   `);
 });
@@ -88,7 +121,7 @@ test('blob URLs are replaced with data URLs', async ({ task }) => {
       },
       "childNodes": [],
       "id": "number",
-      "rootId": 301,
+      "rootId": 383,
       "tagName": "img",
       "type": 2,
     }

--- a/packages/vitest/src/browser/public/takeSnapshot.ts
+++ b/packages/vitest/src/browser/public/takeSnapshot.ts
@@ -1,7 +1,8 @@
 import { assert } from 'vitest';
 import { commands } from 'vitest/browser';
-import { snapshot } from '@chromaui/rrweb-snapshot';
+import { snapshot, createMirror } from '@chromaui/rrweb-snapshot';
 import { serializedNodeWithId } from '@rrweb/types';
+import { type DOMSnapshots } from '@chromatic-com/shared-e2e';
 import { getCurrentTest } from '../getCurrentTest';
 import type {} from '../../node/commands';
 
@@ -33,12 +34,21 @@ async function takeSnapshot(name?: string, options?: Options): Promise<void> {
 
   test.meta.__chromatic_isTakeSnapshotCalled = true;
 
-  const domSnapshot = snapshot(document, { recordCanvas: true });
+  const mirror = createMirror();
+  const domSnapshot = snapshot(document, { recordCanvas: true, mirror });
   assert(domSnapshot, 'Failed to capture DOM snapshot');
+
+  const pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'] = {};
+
+  for (const className of [':hover', ':focus', ':focus-visible', ':active']) {
+    const elements = document.querySelectorAll(className);
+    const ids = Array.from(elements, (el) => mirror.getId(el)).filter((id) => id !== -1);
+    pseudoClassIds[className] = ids;
+  }
 
   const save = async () => {
     await replaceBlobUrls(domSnapshot);
-    await commands.__chromatic_uploadDOMSnapshot(test.id, domSnapshot, name);
+    await commands.__chromatic_uploadDOMSnapshot(test.id, domSnapshot, pseudoClassIds, name);
   };
 
   // Ignore is set when called by automatic snapshots

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -4,12 +4,11 @@ import type { TestCase, TestModule, TestSuite, BrowserCommand } from 'vitest/nod
 import { type PlaywrightProviderOptions } from '@vitest/browser-playwright';
 import { type Task } from '@vitest/runner/types';
 import { type serializedNodeWithId } from '@rrweb/types';
-import { ResourceArchiver, Viewport, writeTestResult } from '@chromatic-com/shared-e2e';
+import { ResourceArchiver, writeTestResult, type DOMSnapshots } from '@chromatic-com/shared-e2e';
 import { type ChromaticNamespace, type ResolvedOptions } from '../types';
 import { NetworkIdleTracker } from './NetworkIdleTracker';
 
 type TestID = Task['id'];
-type DOMSnapshots = Parameters<typeof writeTestResult>[1];
 type SnapshotName = keyof DOMSnapshots;
 
 export function createCommands(options: ResolvedOptions) {
@@ -17,7 +16,14 @@ export function createCommands(options: ResolvedOptions) {
   const networkIdleTrackers = new Map<TestID, NetworkIdleTracker>();
   const snapshots = new Map<
     TestID,
-    Map<SnapshotName, { snapshot: serializedNodeWithId; viewport: Viewport }>
+    Map<
+      SnapshotName,
+      {
+        snapshot: serializedNodeWithId;
+        viewport: DOMSnapshots[string]['viewport'];
+        pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'];
+      }
+    >
   >();
 
   return {
@@ -37,6 +43,7 @@ export function createCommands(options: ResolvedOptions) {
       context,
       id: TestID,
       snapshot: serializedNodeWithId,
+      pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'],
       name?: string
     ) {
       let sessionSnapshots = snapshots.get(id);
@@ -54,7 +61,7 @@ export function createCommands(options: ResolvedOptions) {
         height: window.innerHeight,
       }));
 
-      sessionSnapshots.set(name, { snapshot, viewport });
+      sessionSnapshots.set(name, { snapshot, viewport, pseudoClassIds });
     },
 
     /**
@@ -107,10 +114,14 @@ export function createCommands(options: ResolvedOptions) {
       const { archive, sessionSnapshots } = await onTestCleanup(id);
       assert(sessionSnapshots, `No snapshots found for test ${id}`);
 
-      const snapshotBuffers: Parameters<typeof writeTestResult>[1] = {};
+      const snapshotBuffers: DOMSnapshots = {};
 
-      for (const [name, { snapshot, viewport }] of sessionSnapshots) {
-        snapshotBuffers[name] = { snapshot: Buffer.from(JSON.stringify(snapshot)), viewport };
+      for (const [name, { snapshot, viewport, pseudoClassIds }] of sessionSnapshots) {
+        snapshotBuffers[name] = {
+          snapshot: Buffer.from(JSON.stringify(snapshot)),
+          viewport,
+          pseudoClassIds,
+        };
       }
 
       await writeTestResult(

--- a/packages/vitest/test/css-pseudo-states.test.ts
+++ b/packages/vitest/test/css-pseudo-states.test.ts
@@ -1,0 +1,53 @@
+import { assert, expect } from 'vitest';
+import { commands, page, userEvent } from 'vitest/browser';
+import { test } from './utils/browser';
+import { disableAutoSnapshot, takeSnapshot } from '../dist';
+
+disableAutoSnapshot();
+
+test.override({ url: '/css-pseudo-states' });
+
+test('captures :hover state', async () => {
+  await page.getByRole('button', { name: 'target' }).hover();
+
+  const hovered = document.querySelector('button:hover');
+  assert(hovered, 'Expected the button to be hovered');
+
+  expect(page.elementLocator(hovered)).toBeVisible();
+
+  await takeSnapshot('hover');
+});
+
+test('captures :focus state', async () => {
+  await page.getByRole('button', { name: 'target' }).click();
+
+  const focused = document.querySelector('button:focus');
+  assert(focused, 'Expected the button to be focused');
+
+  expect(page.elementLocator(focused)).toBeVisible();
+
+  await takeSnapshot('focus');
+});
+
+test('captures :focus-visible state', async () => {
+  await page.getByRole('button', { name: 'Focus this before tab' }).click();
+  await userEvent.tab();
+
+  const focused = document.querySelector('button:focus-visible');
+  assert(focused, 'Expected the button to be focused');
+
+  expect(page.elementLocator(focused)).toBeVisible();
+
+  await takeSnapshot('focus-visible');
+});
+
+test('captures :active state', async () => {
+  await (commands as any).mousedown('button#target');
+
+  const active = document.querySelector('button:active');
+  assert(active, 'Expected the button to be active');
+
+  expect(page.elementLocator(active)).toBeVisible();
+
+  await takeSnapshot('active');
+});

--- a/packages/vitest/test/utils/browser.ts
+++ b/packages/vitest/test/utils/browser.ts
@@ -24,7 +24,10 @@ async function goTo(url: string): Promise<void> {
   const response = await fetch(url);
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch "${url}": ${response.statusText}`);
+    /** Proxy is set in {@link file://./../vitest.config.e2e.ts} */
+    throw new Error(
+      `Failed to fetch "${url}": ${response.statusText}. Does test/vitest.config.ts have proxy set for this?`
+    );
   }
 
   const html = await response.text();

--- a/packages/vitest/test/vitest.config.e2e.ts
+++ b/packages/vitest/test/vitest.config.e2e.ts
@@ -25,6 +25,20 @@ export default defineConfig({
       screenshotFailures: false,
       viewport: { width: 1280, height: 720 },
 
+      commands: {
+        async mousedown(context, selector: string) {
+          const frame = await context.frame();
+          const box = await frame.locator(selector).boundingBox();
+
+          if (!box) {
+            throw new Error(`Could not find element with selector: ${selector}`);
+          }
+
+          await context.page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+          await context.page.mouse.down();
+        },
+      },
+
       provider: playwright({
         contextOptions: {
           httpCredentials: {
@@ -68,6 +82,7 @@ function testServerProxy() {
     'createObjectUrl',
     'canvas',
     'amd',
+    'css-pseudo-states',
     '@fz',
   ];
 

--- a/test-server/fixtures/css-pseudo-states.html
+++ b/test-server/fixtures/css-pseudo-states.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html>
+  <head>
+    <style>
+      body {
+        font-family: sans-serif;
+        padding: 20px;
+      }
+
+      button {
+        display: inline-block;
+        padding: 10px 20px;
+        margin: 10px;
+        font-size: 18px;
+        font-weight: bold;
+        background: black;
+        color: white;
+        border: 2px solid #333;
+        text-decoration: none;
+      }
+
+      .label {
+        padding: 5px 10px;
+        margin: 2px;
+        display: inline-block;
+        color: white;
+      }
+
+      #tab-cycle {
+        font-size: 10px;
+        padding: 0;
+        margin: 0;
+      }
+
+      #target {
+        display: block;
+      }
+
+      #target:hover {
+        background: blue;
+      }
+
+      #target:focus {
+        background: red;
+      }
+
+      #target:focus-visible {
+        background: orange;
+      }
+
+      #target:active {
+        background: green;
+      }
+    </style>
+  </head>
+  <body>
+    <ul>
+      <li><span>Hover:</span> <span class="label" style="background-color: blue">Blue</span></li>
+      <li><span>Active:</span> <span class="label" style="background-color: green">Green</span></li>
+      <li><span>Focus:</span> <span class="label" style="background-color: red">Red</span></li>
+      <li>
+        <span>Focus Visible:</span>
+        <span class="label" style="background-color: orange">Orange</span>
+      </li>
+    </ul>
+    <button id="tab-cycle">Focus this before tab</button>
+
+    <button id="target">target</button>
+  </body>
+</html>

--- a/test-server/server.js
+++ b/test-server/server.js
@@ -134,6 +134,10 @@ app.get('/manual-snapshots', (req, res) => {
   res.sendFile(path.join(__dirname, 'fixtures/manual-snapshots.html'));
 });
 
+app.get('/css-pseudo-states', (req, res) => {
+  res.sendFile(path.join(__dirname, 'fixtures/css-pseudo-states.html'));
+});
+
 app.get('/constructable-stylesheets/:page', (req, res) => {
   const page = req.params.page.replace(/[^a-zA-Z0-9-]/g, '');
   res.sendFile(path.join(__dirname, `fixtures/constructable-stylesheets/${page}.html`));


### PR DESCRIPTION
Issue: Related to https://github.com/chromaui/chromatic-e2e/issues/295

Requires https://github.com/chromaui/rrweb/pull/7

## What Changed

When a snapshot is taken, store IDs (rrweb serialized DOM IDs) of elements with [CSS pseudo states](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/Pseudo-classes#user_action_pseudo-classes) right next to the snapshot in the archive file. When we rebuild the DOM in Storybook, we "hydrate" the states back to the DOM by applying CSS classes with corresponding names as the state had. `rrweb-snapshot` makes sure CSS is rewritten during serialization: https://github.com/chromaui/rrweb/pull/7.

## How to test

1. Setup this PR locally
2. Clone https://github.com/chromaui/rrweb locally as `chromaui-web`.
3. Build local rrweb
4. Switch e2e packages to use local rrweb:
  ```diff
  -    "@chromaui/rrweb-snapshot": "2.0.0-alpha.18-noAbsolute",
  +    "@chromaui/rrweb-snapshot": "file:../../../chromaui-rrweb/packages/rrweb-snapshot",
  ```
5. Run `css-pseudo-states` test of each test runner package
6. Build Storybooks and verify CSS is applied correctly.


https://github.com/user-attachments/assets/d3daa78d-7564-44c9-b8b4-28e1034581e5

