### PR TITLE
fix(playwright): don't inline `@playwright/test` types

### DIFF
--- a/.changeset/slow-keys-dance.md
+++ b/.changeset/slow-keys-dance.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/playwright': patch
+---
+
+Fix: don't inline playwright types

--- a/packages/playwright/src/createResourceArchive.ts
+++ b/packages/playwright/src/createResourceArchive.ts
@@ -1,4 +1,4 @@
-import type { Page } from 'playwright';
+import type { Page } from '@playwright/test';
 import {
   ResourceArchiver,
   ResourceArchive,

--- a/packages/playwright/tsup.config.ts
+++ b/packages/playwright/tsup.config.ts
@@ -3,7 +3,7 @@ import { Options, defineConfig } from 'tsup';
 const common: Partial<Options> = {
   splitting: false,
   dts: {
-    resolve: true,
+    resolve: [/^@chromatic-com\//],
   },
   treeshake: true,
   minify: false,


### PR DESCRIPTION
Issue: https://github.com/chromaui/chromatic-e2e/issues/309

## What Changed

Tsup is configured to inline all types via `resolve: true`. It should really just inline `@chromatic-com/shared-e2e` that's a private package.

Compare these two:

- https://npmx.dev/package-code/@chromatic-com/playwright/v/0.12.0/dist%2Findex.d.ts
- https://npmx.dev/package-code/@chromatic-com/playwright/v/0.13.0/dist%2Findex.d.ts

## How to test

Publish new canary release and see if it fixes issues in the reported issue.

- https://github.com/chromaui/chromatic-e2e/issues/309#issuecomment-4318738548 ✅ 

> 🦋  success packages published successfully:
> 🦋  @chromatic-com/cypress@0.12.2-3200a34-20260424065539
> 🦋  @chromatic-com/playwright@0.13.2-3200a34-20260424065539
> 🦋  @chromatic-com/vitest@0.0.2-3200a34-20260424065539