### PR TITLE
fix(vitest): resolve `root` from root config

### DIFF
--- a/.changeset/nice-vans-shine.md
+++ b/.changeset/nice-vans-shine.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: Resolve root from root config

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -115,7 +115,7 @@ export function createCommands(options: ResolvedOptions) {
 
       await writeTestResult(
         {
-          outputDir: resolve(context.project.config.root, options.outputDirectory),
+          outputDir: resolve(context.project.vitest.config.root, options.outputDirectory),
           pageUrl: context.page.url(),
           titlePath: getNames(entity),
         },
@@ -191,6 +191,13 @@ function getNames(test: TestCase): string[] {
 
   if (current.type === 'module') {
     names.unshift(current.relativeModuleId);
+  }
+
+  // If Vitest was configured with multiple projects, namespace the results with project name
+  const hasManyProjects = test.project.vitest.projects.length > 1;
+
+  if (hasManyProjects && test.project.name) {
+    names.unshift(test.project.name);
   }
 
   return names;

--- a/packages/vitest/src/node/plugin.test.ts
+++ b/packages/vitest/src/node/plugin.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { readdir } from 'node:fs/promises';
+import { mkdir, readdir, rm } from 'node:fs/promises';
 import { expect, onTestFinished, test } from 'vitest';
 import { createVitest, type TestModule } from 'vitest/node';
 import { chromaticPlugin } from './plugin';
@@ -130,6 +130,52 @@ test('can be scoped to a Vitest project', async () => {
   expect(tests).toHaveLength(2);
   expect(tests[0].state()).toBe('passed');
   expect(tests[1].state()).toBe('passed');
+});
+
+test('writes results to root when in Vitest projects setup', async () => {
+  const root = resolve(import.meta.dirname, '../../test/custom-root');
+  await mkdir(root, { recursive: true });
+  onTestFinished(() => rm(root, { recursive: true, force: true }));
+
+  await runFixture(
+    {
+      root,
+      projects: [
+        {
+          plugins: [chromaticPlugin()],
+          test: {
+            name: 'first-project',
+            browser: getBrowserConfig('first-browser'),
+            include: ['**/dom.test.ts'],
+            root: resolve(import.meta.dirname, '../../test/fixtures'),
+          },
+        },
+        {
+          plugins: [chromaticPlugin()],
+          test: {
+            name: 'second-project',
+            browser: getBrowserConfig('second-browser'),
+            include: ['**/dom.test.ts'],
+            root: resolve(import.meta.dirname, '../../test/fixtures'),
+          },
+        },
+      ],
+    },
+    { disabled: true }
+  );
+
+  const results = await readdir(resolve(root, '.vitest/chromatic/chromatic-archives'));
+
+  // 1 for "archive" directory and 2 for each project's "*.stories.json" files
+  expect.soft(results).toHaveLength(3);
+
+  expect(results).toMatchInlineSnapshot(`
+    [
+      "archive",
+      "first-browser-dom-mount-some-elements.stories.json",
+      "second-browser-dom-mount-some-elements.stories.json",
+    ]
+  `);
 });
 
 test('skips configuration when used on non-browser context', async () => {

--- a/packages/vitest/src/node/plugin.ts
+++ b/packages/vitest/src/node/plugin.ts
@@ -86,7 +86,7 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
       });
 
       function clean() {
-        rmSync(resolve(project.config.root, options.outputDirectory, 'chromatic-archives'), {
+        rmSync(resolve(project.vitest.config.root, options.outputDirectory, 'chromatic-archives'), {
           recursive: true,
           force: true,
         });

--- a/packages/vitest/test/utils/node.ts
+++ b/packages/vitest/test/utils/node.ts
@@ -8,13 +8,13 @@ import { type CliOptions, createVitest, type InlineConfig, startVitest } from 'v
 import { playwright } from '@vitest/browser-playwright';
 import { chromaticPlugin } from '../../src/node/plugin';
 
-export function getBrowserConfig() {
+export function getBrowserConfig(name = 'chromium') {
   return {
     enabled: true,
     headless: true,
     screenshotFailures: false,
     provider: playwright(),
-    instances: [{ browser: 'chromium', name: 'chromium' }],
+    instances: [{ browser: 'chromium', name }],
   } satisfies NonNullable<InlineConfig['browser']>;
 }
 


### PR DESCRIPTION
Issue: Related to #295 

## What Changed

Results should be written in root of the whole Vitest process, not in Vitest `project`'s root. All test reporters should output to main root.

Also when outputting files to the same directory, we need to make sure multiple projects don't overwrite each other's results. So now we'll be namespacing results with project name, when there are multiple projects configured.


## How to test

There's test case that fails without this fix.

Noticed this while testing against https://github.com/skeletonlabs/skeleton.
