### PR TITLE
fix(vitest): `afterEach` not called early when `sequence.hooks` is set

### DIFF
--- a/packages/vitest/src/browser/public/takeSnapshot.test.ts
+++ b/packages/vitest/src/browser/public/takeSnapshot.test.ts
@@ -147,6 +147,56 @@ test('viewports are correct when --browser.ui=false', async () => {
   `);
 });
 
+test.each(['list', 'stack'] as const)(
+  "autosnapshot is taken before user registered afterEach runs when {sequence.hooks: '%s'}",
+  async (hooks) => {
+    await runFixture({
+      include: [takeSnapshotTest],
+      provide: { testName: 'four' },
+      setupFiles: ['custom-setup-file.ts'],
+      sequence: { hooks },
+    });
+
+    expect(shared.writeTestResult).toHaveBeenCalledTimes(1);
+
+    const [, snapshots] = vi.mocked(shared.writeTestResult).mock.calls[0];
+    expect(snapshots).toHaveProperty('Snapshot #1');
+
+    const { snapshot } = snapshots['Snapshot #1'];
+
+    expect(JSON.parse(snapshot.toString())).toMatchInlineSnapshot(`
+    {
+      "attributes": {},
+      "childNodes": [
+        {
+          "id": "number",
+          "textContent": "Example heading",
+          "type": 3,
+        },
+      ],
+      "id": "number",
+      "tagName": "h1",
+      "type": 2,
+    }
+  `);
+  }
+);
+
+test("warns when {sequence.hooks: 'parallel'} is used", async () => {
+  const { stderr } = await runFixture({
+    include: [takeSnapshotTest],
+    provide: { testName: 'four' },
+    setupFiles: ['custom-setup-file.ts'],
+    sequence: { hooks: 'parallel' },
+  });
+
+  expect(shared.writeTestResult).toHaveBeenCalledTimes(1);
+
+  expect(stderr).toMatchInlineSnapshot(
+    `" chromatic  Using { sequence.hooks: 'parallel' } may cause unstable snapshots. Please set 'sequence.hooks' to 'list' or 'stack' to ensure reliable snapshot ordering."`
+  );
+});
+
 function getSnapshottedTests() {
   return vi.mocked(shared.writeTestResult).mock.calls.reduce((all, call) => {
     const [e2eTestInfo, domSnapshots] = call;

--- a/packages/vitest/src/browser/setupFile.ts
+++ b/packages/vitest/src/browser/setupFile.ts
@@ -1,4 +1,4 @@
-import { beforeEach } from 'vitest';
+import { afterEach, beforeEach } from 'vitest';
 import { commands } from 'vitest/browser';
 import { takeSnapshot } from './public/takeSnapshot';
 import { waitForIdleNetwork } from './public/waitForIdleNetwork';
@@ -15,7 +15,7 @@ beforeEach<InternalTestContext>(async ({ task }) => {
 
     if (!hasMatchingTag) {
       task.meta.__chromatic_isRegistered = false;
-      return cleanup;
+      return;
     }
   }
 
@@ -26,41 +26,48 @@ beforeEach<InternalTestContext>(async ({ task }) => {
   task.meta.__chromatic_autoSnapshot ??= !options.disableAutoSnapshot;
 
   await commands.__chromatic_interceptFetch(task.id);
+});
 
-  return async function afterEach() {
-    // These can be overriden during test run too
-    const {
-      __chromatic_autoSnapshot: autoSnapshot,
-      __chromatic_isTakeSnapshotCalled: isTakeSnapshotCalled,
-      __chromatic_pendingTakeSnapshots: pendingTakeSnapshots,
-    } = task.meta;
+afterEach<InternalTestContext>(async ({ task }) => {
+  // These can be overriden during test run too
+  const {
+    __chromatic_autoSnapshot: autoSnapshot,
+    __chromatic_isTakeSnapshotCalled: isTakeSnapshotCalled,
+    __chromatic_pendingTakeSnapshots: pendingTakeSnapshots,
+    __chromatic_isRegistered: isRegistered,
+  } = task.meta;
 
-    if (pendingTakeSnapshots?.length) {
-      throw new AggregateError(
-        pendingTakeSnapshots.map((call) => call.error),
-        `${pendingTakeSnapshots.length} unawaited takeSnapshot() call(s)`
-      );
-    }
+  if (!isRegistered) {
+    return cleanup();
+  }
 
-    // Bail out early if it's detected that no snapshots are needed
-    if (!autoSnapshot && !isTakeSnapshotCalled) {
-      await commands.__chromatic_stopWithoutSnapshots(task.id);
+  if (pendingTakeSnapshots?.length) {
+    throw new AggregateError(
+      pendingTakeSnapshots.map((call) => call.error),
+      `${pendingTakeSnapshots.length} unawaited takeSnapshot() call(s)`
+    );
+  }
 
-      return cleanup();
-    }
-
-    if (options.resourceArchiveTimeout !== 0) {
-      await waitForIdleNetwork(options.resourceArchiveTimeout);
-    }
-
-    if (autoSnapshot) {
-      await takeSnapshot(undefined, { ignoreUnawaited: true });
-    }
-
-    await commands.__chromatic_writeTestResult(task.id);
+  // Bail out early if it's detected that no snapshots are needed
+  if (!autoSnapshot && !isTakeSnapshotCalled) {
+    await commands.__chromatic_stopWithoutSnapshots(task.id);
 
     return cleanup();
-  };
+  }
+
+  const options = await commands.__chromatic_getOptions();
+
+  if (options.resourceArchiveTimeout !== 0) {
+    await waitForIdleNetwork(options.resourceArchiveTimeout);
+  }
+
+  if (autoSnapshot) {
+    await takeSnapshot(undefined, { ignoreUnawaited: true });
+  }
+
+  await commands.__chromatic_writeTestResult(task.id);
+
+  return cleanup();
 
   /**
    * Clean internal task meta so that it doesn't show up on Vitest's reporters

--- a/packages/vitest/src/node/plugin.ts
+++ b/packages/vitest/src/node/plugin.ts
@@ -47,12 +47,27 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
 
     configureVitest(context) {
       const project = context.project;
+      const sequence = context.vitest.config.sequence;
 
       if (!project.config.browser.enabled) {
         return;
       }
 
-      project.config.setupFiles.push(setupFile);
+      // Ensure our setup file is registered first so that afterEach runs before any user-defined hooks.
+      if (sequence.hooks === 'stack') {
+        project.config.setupFiles.push(setupFile);
+      } else if (sequence.hooks === 'list') {
+        project.config.setupFiles.unshift(setupFile);
+      } else {
+        project.config.setupFiles.push(setupFile);
+
+        context.vitest.logger.warn(
+          colors.bgYellow(colors.black(' chromatic ')),
+          colors.yellow(
+            `Using { sequence.hooks: 'parallel' } may cause unstable snapshots. Please set 'sequence.hooks' to 'list' or 'stack' to ensure reliable snapshot ordering.`
+          )
+        );
+      }
 
       // We support Vitest 4.0.0, but tags were introduced in 4.1.0
       if (options.tags && context.vitest.version.startsWith('4.0')) {

--- a/packages/vitest/test/fixtures/custom-setup-file.ts
+++ b/packages/vitest/test/fixtures/custom-setup-file.ts
@@ -1,0 +1,5 @@
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  document.body.innerHTML = '<div>DOM cleaned up by setup file</div>';
+});

--- a/packages/vitest/test/fixtures/take-snapshot.test.ts
+++ b/packages/vitest/test/fixtures/take-snapshot.test.ts
@@ -25,3 +25,7 @@ test.runIf(inject('testName') === 'three')('test #3', async () => {
   // another
   takeSnapshot();
 });
+
+test.runIf(inject('testName') === 'four')('test #4', async () => {
+  document.body.innerHTML = '<h1>Example heading</h1>';
+});


### PR DESCRIPTION
Issue:
- Related to #295 
- Ref. https://github.com/vitest-dev/vitest/pull/10230

## What Changed

In Material UI they have setup file that cleans DOM in `afterEach`. They also use `sequence.hooks: "list"`, which made their setup file run before ours. This caused automatic snapshots to be empty.

Now we'll look for `sequence.hooks` config when deciding whether setup file should be in the start of end. Also noticed Vitest bug (or feature) where callbacks returned from `beforeEach(() => () => void)` were always run last. Now using explicit `afterEach` to work-around that.

## How to test

Added test cases that fail without the fix. Revert the changes and see tests fail. 