### PR TITLE
fix: sanitize story titles

### DIFF
--- a/packages/shared/src/write-archive/index.test.ts
+++ b/packages/shared/src/write-archive/index.test.ts
@@ -165,6 +165,24 @@ describe('writeTestResult', () => {
     );
   });
 
+  it('sanitizes story titles', async () => {
+    await writeTestResult(
+      {
+        titlePath: ['src/components/accordion.test.tsx', '<Accordion />', 'opens and closes'],
+        outputDir: resolve('test-results'),
+        pageUrl: 'http://localhost:3000/',
+      },
+      {
+        home: { snapshot: Buffer.from(JSON.stringify({})), viewport: { height: 800, width: 800 } },
+      },
+      {},
+      {}
+    );
+
+    const { title } = vi.mocked(filePaths.outputJSONFile).mock.calls[0][1];
+    expect(title).toBe('src/components/accordion/<Accordion >/opens and closes');
+  });
+
   describe('archive file system path windows', () => {
     it('handles system paths', async () => {
       await writeTestResult(

--- a/packages/shared/src/write-archive/index.ts
+++ b/packages/shared/src/write-archive/index.ts
@@ -35,7 +35,13 @@ export async function writeTestResult(
     pathPart.replace(/\.(ts|js|mjs|cjs|tsx|jsx|cjsx|coffee)$/, '').replace(/\.(spec|test|cy)$/, '')
   );
   // in Storybook, `/` splits the title out into hierarchies (folders)
-  const title = titlePathWithoutFileExtensions.join('/');
+  const title = titlePathWithoutFileExtensions
+    .join('/')
+    // Make sure we don't end up with folders with just special characters
+    // Transforms paths like "src/components/accordion/<Accordion/>/opens and closes" to "src/components/accordion/<Accordion>/opens and closes "
+    // eslint-disable-next-line no-useless-escape
+    .replace(/\/([ ’–—―′¿'`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\]+)\//gi, '$1/');
+
   const finalOutputDir = join(outputDir, 'chromatic-archives');
 
   const archiveDir = join(finalOutputDir, 'archive');


### PR DESCRIPTION
Issue: Related to #295 

## What Changed

Makes sure Story-files don't end up with titles that are incompatible with Storybook. 

For example `"title": "src/Accordion/Accordion/<Accordion />/should render and not be controlled"` would have caused following crash:

<img width="1373" height="478" alt="image" src="https://github.com/user-attachments/assets/b468f913-10dd-4a95-a2c6-c581502d2914" />


## How to test

1. Add plugin to https://github.com/mui/material-ui
2. Run tests
3. `pnpm exec archive-storybook`
4. Storybook fails to render stories with the error shown above.

Error originates from https://github.com/mui/material-ui/blob/64f0b491155616b44e41421c6cb5513f32b22391/packages/mui-material/src/Accordion/Accordion.test.js#L27 test title.