### PR TITLE
ci: revert release + fix tests that rely on published storybook

### DIFF
--- a/.changeset/nice-vans-shine.md
+++ b/.changeset/nice-vans-shine.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: Resolve root from root config

--- a/.changeset/six-roses-jam.md
+++ b/.changeset/six-roses-jam.md
@@ -1,0 +1,8 @@
+---
+'@chromatic-com/playwright': patch
+'@chromatic-com/cypress': patch
+'@chromatic-com/shared-e2e': patch
+'@chromatic-com/vitest': patch
+---
+
+Fix: Preserve CSS pseudo states in snapshots

--- a/packages/cypress/CHANGELOG.md
+++ b/packages/cypress/CHANGELOG.md
@@ -1,11 +1,5 @@
 # chromatic-cypress
 
-## 0.12.3
-
-### Patch Changes
-
-- e4f8c87: Fix: Preserve CSS pseudo states in snapshots
-
 ## 0.12.2
 
 ### Patch Changes

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chromatic-com/cypress",
-  "version": "0.12.3",
+  "version": "0.12.2",
   "description": "Chromatic Visual Regression Testing for Cypress",
   "repository": {
     "type": "git",

--- a/packages/cypress/tests/cypress/e2e/storybook.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/storybook.cy.ts
@@ -1,6 +1,6 @@
 it('visits hosted storybook page', () => {
   cy.visit(
-    'https://main--653fef099b8957739e7534a4.chromatic.com/iframe.html?globals=viewport:w1280h720&id=options-pause-animation-at-end--snapshot-1&viewMode=story'
+    'https://main--653fef099b8957739e7534a4.chromatic.com/iframe.html?id=options-pause-animation-at-end--snapshot-1&viewMode=story'
   );
   cy.contains('The image').should('be.visible');
 });

--- a/packages/playwright/CHANGELOG.md
+++ b/packages/playwright/CHANGELOG.md
@@ -1,11 +1,5 @@
 # chromatic-playwright
 
-## 0.13.3
-
-### Patch Changes
-
-- e4f8c87: Fix: Preserve CSS pseudo states in snapshots
-
 ## 0.13.2
 
 ### Patch Changes

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chromatic-com/playwright",
-  "version": "0.13.3",
+  "version": "0.13.2",
   "description": "Chromatic Visual Regression Testing for Playwright",
   "repository": {
     "type": "git",

--- a/packages/playwright/tests/storybook.spec.ts
+++ b/packages/playwright/tests/storybook.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '../src';
 test.use({ assetDomains: ['localhost:6006'] });
 test('visits hosted storybook page', async ({ page }) => {
   await page.goto(
-    'https://main--653fef099b8957739e7534a4.chromatic.com/iframe.html?globals=viewport:w1280h720&id=options-pause-animation-at-end--snapshot-1&viewMode=story'
+    'https://main--653fef099b8957739e7534a4.chromatic.com/iframe.html?id=options-pause-animation-at-end--snapshot-1&viewMode=story'
   );
   await expect(page.getByRole('heading', { name: /The image/i })).toBeVisible();
 });

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @chromaui/shared-e2e
 
-## 0.10.4
-
-### Patch Changes
-
-- e4f8c87: Fix: Preserve CSS pseudo states in snapshots
-
 ## 0.10.3
 
 ### Patch Changes

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chromatic-com/shared-e2e",
-  "version": "0.10.4",
+  "version": "0.10.3",
   "private": true,
   "description": "Shared Chromatic E2E",
   "repository": {

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @chromatic-com/vitest
 
-## 0.0.3
-
-### Patch Changes
-
-- 9f6728e: Fix: Resolve root from root config
-- e4f8c87: Fix: Preserve CSS pseudo states in snapshots
-
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chromatic-com/vitest",
-  "version": "0.0.3",
+  "version": "0.0.2",
   "description": "Chromatic Visual Regression Testing for Vitest",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Issue: #329 

## What Changed

Update URLs of published storybooks, so that test cases fetch the new format of story JSONs in that the runtime expects.


## How to test

CI pass.