### PR TITLE
fix(vitest): support multi browser instance setups

### DIFF
--- a/.changeset/tame-parents-cough.md
+++ b/.changeset/tame-parents-cough.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: support multi browser instance setups

--- a/.github/workflows/test-base.yml
+++ b/.github/workflows/test-base.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install Playwright
         run: |
-          yarn playwright install
+          yarn playwright install --with-deps
 
       - name: Build
         run: |

--- a/packages/vitest/src/browser/isChromium.ts
+++ b/packages/vitest/src/browser/isChromium.ts
@@ -1,0 +1,5 @@
+import { server } from 'vitest/browser';
+
+export function isChromium(): boolean {
+  return server.browser === 'chromium';
+}

--- a/packages/vitest/src/browser/public/autoSnapshot.ts
+++ b/packages/vitest/src/browser/public/autoSnapshot.ts
@@ -1,5 +1,6 @@
 import { beforeAll } from 'vitest';
 import { getCurrentTest, type Test } from '../getCurrentTest';
+import { isChromium } from '../isChromium';
 
 /**
  * Disable automatic test snapshotting for specific scope.
@@ -62,6 +63,10 @@ import { getCurrentTest, type Test } from '../getCurrentTest';
  *
  */
 export function disableAutoSnapshot() {
+  if (!isChromium()) {
+    return;
+  }
+
   const test = getCurrentTest();
 
   // Called within test()

--- a/packages/vitest/src/browser/public/takeSnapshot.ts
+++ b/packages/vitest/src/browser/public/takeSnapshot.ts
@@ -4,6 +4,7 @@ import { snapshot, createMirror } from '@chromaui/rrweb-snapshot';
 import { serializedNodeWithId } from '@rrweb/types';
 import { type DOMSnapshots } from '@chromatic-com/shared-e2e';
 import { getCurrentTest } from '../getCurrentTest';
+import { isChromium } from '../isChromium';
 import type {} from '../../node/commands';
 
 interface Options {
@@ -19,6 +20,10 @@ async function takeSnapshot(name?: string): Promise<void>;
 async function takeSnapshot(name: string | undefined, options: Options): Promise<void>;
 
 async function takeSnapshot(name?: string, options?: Options): Promise<void> {
+  if (!isChromium()) {
+    return;
+  }
+
   const test = getCurrentTest();
 
   if (!test) {

--- a/packages/vitest/src/browser/public/waitForIdleNetwork.ts
+++ b/packages/vitest/src/browser/public/waitForIdleNetwork.ts
@@ -1,5 +1,6 @@
 import { commands } from 'vitest/browser';
 import { getCurrentTest } from '../getCurrentTest';
+import { isChromium } from '../isChromium';
 import type {} from '../../node/commands';
 
 /**
@@ -16,6 +17,10 @@ import type {} from '../../node/commands';
  * Use `timeout` argument to reject if network doesn't become idle within given time.
  */
 export async function waitForIdleNetwork(timeout: number) {
+  if (!isChromium()) {
+    return;
+  }
+
   const test = getCurrentTest();
 
   if (!test) {

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -205,7 +205,9 @@ function getNames(test: TestCase): string[] {
   }
 
   // If Vitest was configured with multiple projects, namespace the results with project name
-  const hasManyProjects = test.project.vitest.projects.length > 1;
+  const hasManyProjects =
+    test.project.vitest.projects.filter((project) => project.config.browser.name === 'chromium')
+      .length > 1;
 
   if (hasManyProjects && test.project.name) {
     names.unshift(test.project.name);

--- a/packages/vitest/src/node/plugin.test.ts
+++ b/packages/vitest/src/node/plugin.test.ts
@@ -84,6 +84,7 @@ test('warns if tags are used with Vitest 4.0', async () => {
 
   const project = vitest.projects[0];
   project.config.browser.enabled = true;
+  project.config.browser.name = 'chromium';
 
   // @ts-expect-error -- intentional
   vitest.version = '4.0.1';
@@ -212,6 +213,44 @@ test('does not clean existing output directory when "vitest --merge-reports" is 
     [
       "archive",
       "dom-mount-some-elements.stories.json",
+    ]
+  `);
+});
+
+test('works in multi project instance setup', async () => {
+  const root = resolve(import.meta.dirname, '../../test/fixtures');
+  const tests: TestModule[] = [];
+
+  await runFixture({
+    name: 'custom-project-name',
+    browser: {
+      ...getBrowserConfig(),
+      instances: [
+        { browser: 'chromium', name: 'custom-name-for-chromium-browser' },
+        { browser: 'webkit', name: 'custom-name-for-webkit-browser' },
+        { browser: 'firefox', name: 'custom-name-for-firefox-browser' },
+      ],
+    },
+    reporters: ['default', { onTestRunEnd: (testModules) => void tests.push(...testModules) }],
+    /** See {@link file://./../../test/fixtures/public-apis.test.ts} */
+    include: ['**/public-apis.test.ts'],
+    root,
+  });
+
+  // Non-Chromium browsers should not crash
+  expect.soft(tests).toHaveLength(3);
+  expect.soft(tests[0].state()).toBe('passed');
+  expect.soft(tests[1].state()).toBe('passed');
+  expect.soft(tests[2].state()).toBe('passed');
+
+  // Results for Chromium should still be written to disk
+  const results = await readdir(resolve(root, '.vitest/chromatic/chromatic-archives'));
+
+  expect(results).toMatchInlineSnapshot(`
+    [
+      "archive",
+      "public-apis-calls-takesnapshot.stories.json",
+      "public-apis-calls-waitforidlenetwork.stories.json",
     ]
   `);
 });

--- a/packages/vitest/src/node/plugin.ts
+++ b/packages/vitest/src/node/plugin.ts
@@ -47,9 +47,11 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
 
     configureVitest(context) {
       const project = context.project;
+      const browser = project.config.browser;
       const sequence = context.vitest.config.sequence;
 
-      if (!project.config.browser.enabled) {
+      // browser.name is instances[].browser, not instances[].name: https://github.com/vitest-dev/vitest/blob/d22b029ae056b9515033d75c1249e9db26612770/packages/vitest/src/node/projects/resolveProjects.ts#L307
+      if (!browser.enabled || browser.name !== 'chromium') {
         return;
       }
 

--- a/packages/vitest/src/node/plugin.ts
+++ b/packages/vitest/src/node/plugin.ts
@@ -52,7 +52,7 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
 
       // browser.name is instances[].browser, not instances[].name: https://github.com/vitest-dev/vitest/blob/d22b029ae056b9515033d75c1249e9db26612770/packages/vitest/src/node/projects/resolveProjects.ts#L307
       if (!browser.enabled || browser.name !== 'chromium') {
-        return;
+        return clean();
       }
 
       // Ensure our setup file is registered first so that afterEach runs before any user-defined hooks.

--- a/packages/vitest/test/fixtures/public-apis.test.ts
+++ b/packages/vitest/test/fixtures/public-apis.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, test } from 'vitest';
+import { takeSnapshot, waitForIdleNetwork, disableAutoSnapshot } from '../../src';
+
+beforeEach(() => {
+  document.body.innerHTML = '<h1>Example heading</h1>';
+
+  return () => {
+    document.body.innerHTML = '';
+  };
+});
+
+test('calls disableAutoSnapshot()', async () => {
+  disableAutoSnapshot();
+});
+
+test('calls waitForIdleNetwork()', async () => {
+  await waitForIdleNetwork(1);
+});
+
+test('calls takeSnapshot()', async () => {
+  await takeSnapshot('manual snapshot');
+});


### PR DESCRIPTION
Issue: #295 

## What Changed

Support cases where user defines multiple browser instances:

```ts
browser: {
  instances: [{ browser: 'chromium' }, { browser: 'webkit' }, { browser: 'firefox' }],
},
```

## How to test

- https://github.com/vanessayuenn/remotion
