### PR TITLE
fix(vitest): split autosnapshot and cleanup phases

### DIFF
--- a/.changeset/old-baboons-act.md
+++ b/.changeset/old-baboons-act.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: Split autosnapshot and cleanups in different test lifecycle phases

--- a/packages/vitest/src/browser/public/takeSnapshot.test.ts
+++ b/packages/vitest/src/browser/public/takeSnapshot.test.ts
@@ -197,6 +197,58 @@ test("warns when {sequence.hooks: 'parallel'} is used", async () => {
   );
 });
 
+test('user defined afterEach can call takeSnapshot()', async () => {
+  await runFixture({
+    include: [takeSnapshotTest],
+    provide: { testName: 'four' },
+    setupFiles: ['takesnapshot-setup-file.ts'],
+  });
+
+  expect(shared.writeTestResult).toHaveBeenCalledTimes(1);
+
+  const [, snapshots] = vi.mocked(shared.writeTestResult).mock.calls[0];
+
+  expect.soft(snapshots).toHaveProperty('Snapshot #1');
+  expect.soft(snapshots).toHaveProperty("user's after each snapshot!");
+
+  const autoSnapshot = snapshots['Snapshot #1'].snapshot;
+  const userSnapshot = snapshots["user's after each snapshot!"].snapshot;
+
+  expect(JSON.parse(autoSnapshot.toString())).toMatchInlineSnapshot(`
+    {
+      "attributes": {},
+      "childNodes": [
+        {
+          "id": "number",
+          "textContent": "Example heading",
+          "type": 3,
+        },
+      ],
+      "id": "number",
+      "tagName": "h1",
+      "type": 2,
+    }
+  `);
+
+  expect(JSON.parse(userSnapshot.toString())).toMatchInlineSnapshot(`
+    {
+      "attributes": {},
+      "childNodes": [
+        {
+          "id": "number",
+          "rootId": 40,
+          "textContent": "This should be in user snapshot",
+          "type": 3,
+        },
+      ],
+      "id": "number",
+      "rootId": 40,
+      "tagName": "h1",
+      "type": 2,
+    }
+  `);
+});
+
 function getSnapshottedTests() {
   return vi.mocked(shared.writeTestResult).mock.calls.reduce((all, call) => {
     const [e2eTestInfo, domSnapshots] = call;

--- a/packages/vitest/src/browser/setupFile.ts
+++ b/packages/vitest/src/browser/setupFile.ts
@@ -15,7 +15,7 @@ beforeEach<InternalTestContext>(async ({ task }) => {
 
     if (!hasMatchingTag) {
       task.meta.__chromatic_isRegistered = false;
-      return;
+      return cleanup;
     }
   }
 
@@ -26,48 +26,35 @@ beforeEach<InternalTestContext>(async ({ task }) => {
   task.meta.__chromatic_autoSnapshot ??= !options.disableAutoSnapshot;
 
   await commands.__chromatic_interceptFetch(task.id);
-});
 
-afterEach<InternalTestContext>(async ({ task }) => {
-  // These can be overriden during test run too
-  const {
-    __chromatic_autoSnapshot: autoSnapshot,
-    __chromatic_isTakeSnapshotCalled: isTakeSnapshotCalled,
-    __chromatic_pendingTakeSnapshots: pendingTakeSnapshots,
-    __chromatic_isRegistered: isRegistered,
-  } = task.meta;
+  // This runs after any user-defined afterEach hooks
+  return async function beforeEachCleanup() {
+    // These can be overriden during test run too
+    const {
+      __chromatic_isTakeSnapshotCalled: isTakeSnapshotCalled,
+      __chromatic_pendingTakeSnapshots: pendingTakeSnapshots,
+      __chromatic_isRegistered: isRegistered,
+    } = task.meta;
 
-  if (!isRegistered) {
+    if (!isRegistered) {
+      return cleanup();
+    }
+
+    if (pendingTakeSnapshots?.length) {
+      throw new PendingSnapshotsError(pendingTakeSnapshots);
+    }
+
+    // Bail out early if it's detected that no snapshots were taken
+    if (!isTakeSnapshotCalled) {
+      await commands.__chromatic_stopWithoutSnapshots(task.id);
+
+      return cleanup();
+    }
+
+    await commands.__chromatic_writeTestResult(task.id);
+
     return cleanup();
-  }
-
-  if (pendingTakeSnapshots?.length) {
-    throw new AggregateError(
-      pendingTakeSnapshots.map((call) => call.error),
-      `${pendingTakeSnapshots.length} unawaited takeSnapshot() call(s)`
-    );
-  }
-
-  // Bail out early if it's detected that no snapshots are needed
-  if (!autoSnapshot && !isTakeSnapshotCalled) {
-    await commands.__chromatic_stopWithoutSnapshots(task.id);
-
-    return cleanup();
-  }
-
-  const options = await commands.__chromatic_getOptions();
-
-  if (options.resourceArchiveTimeout !== 0) {
-    await waitForIdleNetwork(options.resourceArchiveTimeout);
-  }
-
-  if (autoSnapshot) {
-    await takeSnapshot(undefined, { ignoreUnawaited: true });
-  }
-
-  await commands.__chromatic_writeTestResult(task.id);
-
-  return cleanup();
+  };
 
   /**
    * Clean internal task meta so that it doesn't show up on Vitest's reporters
@@ -79,3 +66,44 @@ afterEach<InternalTestContext>(async ({ task }) => {
     task.meta.__chromatic_pendingTakeSnapshots = undefined;
   }
 });
+
+// This runs before any user-defined afterEach hooks
+afterEach<InternalTestContext>(async ({ task }) => {
+  // These can be overriden during test run too
+  const {
+    __chromatic_autoSnapshot: autoSnapshot,
+    __chromatic_pendingTakeSnapshots: pendingTakeSnapshots,
+    __chromatic_isRegistered: isRegistered,
+  } = task.meta;
+
+  if (!isRegistered) {
+    return;
+  }
+
+  if (pendingTakeSnapshots?.length) {
+    throw new PendingSnapshotsError(pendingTakeSnapshots);
+  }
+
+  if (!autoSnapshot) {
+    return;
+  }
+
+  const options = await commands.__chromatic_getOptions();
+
+  if (options.resourceArchiveTimeout !== 0) {
+    await waitForIdleNetwork(options.resourceArchiveTimeout);
+  }
+
+  // Take automatic snapshot
+  await takeSnapshot(undefined, { ignoreUnawaited: true });
+});
+
+class PendingSnapshotsError extends AggregateError {
+  constructor(public pendingCalls: Array<{ error: Error }>) {
+    super(
+      pendingCalls.map((call) => call.error),
+      `${pendingCalls.length} unawaited takeSnapshot() call(s)`
+    );
+    this.name = 'PendingSnapshotsError';
+  }
+}

--- a/packages/vitest/test/fixtures/takesnapshot-setup-file.ts
+++ b/packages/vitest/test/fixtures/takesnapshot-setup-file.ts
@@ -1,0 +1,8 @@
+import { afterEach } from 'vitest';
+import { takeSnapshot } from '../../src';
+
+afterEach(async () => {
+  document.body.innerHTML = '<h1>This should be in user snapshot</h1>';
+
+  await takeSnapshot("user's after each snapshot!");
+});


### PR DESCRIPTION
Issue: Related to #295 

## What Changed

Split current `afterEach` into two phases:
- Auto snapshot: Runs right after test case finishes
- Clean up + result writing: Runs after all other `afterEach` hooks

This allows users to call `takeSnapshot()` in their own `afterEach` hooks.

## How to test

Added test cases. 
