### PR TITLE
fix: use Storybook viewport globals

### DIFF
--- a/packages/shared/src/write-archive/index.test.ts
+++ b/packages/shared/src/write-archive/index.test.ts
@@ -62,6 +62,7 @@ describe('writeTestResult', () => {
         stories: [
           {
             name: 'home',
+            globals: { viewport: 'w800h800' },
             parameters: {
               chromatic: {
                 diffThreshold: 5,
@@ -71,8 +72,12 @@ describe('writeTestResult', () => {
               server: { id: 'file-test-story-home' },
               viewport: {
                 defaultViewport: 'w800h800',
-                viewports: {
-                  w800h800: { name: 'w800h800', styles: { height: '800px', width: '800px' } },
+                options: {
+                  w800h800: {
+                    name: 'w800h800',
+                    type: 'tablet',
+                    styles: { height: '800px', width: '800px' },
+                  },
                 },
               },
             },

--- a/packages/shared/src/write-archive/stories-files.test.ts
+++ b/packages/shared/src/write-archive/stories-files.test.ts
@@ -57,6 +57,7 @@ describe('createStories', () => {
       stories: [
         {
           name: 'snapshot 1',
+          globals: { viewport: 'w100h200' },
           parameters: {
             server: { id: 'some-test-title-snapshot-1' },
             chromatic: {
@@ -70,9 +71,10 @@ describe('createStories', () => {
             },
             viewport: {
               defaultViewport: 'w100h200',
-              viewports: {
+              options: {
                 w100h200: {
                   name: 'w100h200',
+                  type: 'mobile',
                   styles: {
                     height: '200px',
                     width: '100px',
@@ -84,6 +86,7 @@ describe('createStories', () => {
         },
         {
           name: 'another snapshot',
+          globals: { viewport: 'w300h400' },
           parameters: {
             server: { id: 'some-test-title-another-snapshot' },
             chromatic: {
@@ -97,9 +100,10 @@ describe('createStories', () => {
             },
             viewport: {
               defaultViewport: 'w300h400',
-              viewports: {
+              options: {
                 w300h400: {
                   name: 'w300h400',
+                  type: 'mobile',
                   styles: {
                     height: '400px',
                     width: '300px',
@@ -131,6 +135,7 @@ describe('buildStoryViewportsConfig', () => {
     expect(viewportsConfig).toEqual({
       w100h1000: {
         name: 'w100h1000',
+        type: 'mobile',
         styles: {
           width: '100px',
           height: '1000px',
@@ -138,6 +143,7 @@ describe('buildStoryViewportsConfig', () => {
       },
       w1200h100: {
         name: 'w1200h100',
+        type: 'desktop',
         styles: {
           width: '1200px',
           height: '100px',
@@ -145,6 +151,7 @@ describe('buildStoryViewportsConfig', () => {
       },
       w500h500: {
         name: 'w500h500',
+        type: 'mobile',
         styles: {
           width: '500px',
           height: '500px',

--- a/packages/shared/src/write-archive/stories-files.ts
+++ b/packages/shared/src/write-archive/stories-files.ts
@@ -24,6 +24,10 @@ export function createStories(
     title,
     stories: Object.entries(domSnapshots).map(([name, { viewport }]) => ({
       name,
+      // Viewport addon (Storybook 10+): `parameters.viewport.options` registers sizes; `globals.viewport`
+      // selects the active one. See https://storybook.js.org/docs/essentials/viewport#defining-the-viewport-for-a-story
+      // `defaultViewport` is not read by SB 10's types but our archive preview uses it as a fetch fallback.
+      globals: { viewport: viewportToString(viewport) },
       parameters: {
         server: { id: snapshotId(title, name) },
         chromatic: {
@@ -31,7 +35,7 @@ export function createStories(
           modes: buildStoryModesConfig([viewport]),
         },
         viewport: {
-          viewports: buildStoryViewportsConfig([viewport]),
+          options: buildStoryViewportsConfig([viewport]),
           defaultViewport: viewportToString(findDefaultViewport([viewport])),
         },
       },
@@ -50,14 +54,14 @@ export function buildStoryModesConfig(viewports: Viewport[]) {
   }, {});
 }
 
-// Converts the given list of viewports into the viewports
-// config object needed for the Storybook parameters.
+// Converts the given list of viewports into Storybook 10 `parameters.viewport.options`.
 export function buildStoryViewportsConfig(viewports: Viewport[]) {
   return viewports.reduce((viewportsConfig: any, viewport: Viewport) => {
     const viewportName = viewportToString(viewport);
 
     viewportsConfig[viewportName] = {
       name: viewportName,
+      type: viewportAddonType(viewport),
       styles: {
         width: `${viewport.width}px`,
         height: `${viewport.height}px`,
@@ -65,6 +69,16 @@ export function buildStoryViewportsConfig(viewports: Viewport[]) {
     };
     return viewportsConfig;
   }, {});
+}
+
+function viewportAddonType(viewport: Viewport): 'mobile' | 'tablet' | 'desktop' | 'other' {
+  if (viewport.width < 600) {
+    return 'mobile';
+  }
+  if (viewport.width < 1024) {
+    return 'tablet';
+  }
+  return 'desktop';
 }
 
 // Finds a viewport to use as the default.


### PR DESCRIPTION
Issue: Split from https://github.com/chromaui/chromatic-e2e/pull/330

## What Changed

<!-- Insert a description below. -->

> Emit Storybook 10 viewport globals (`globals.viewport` as `w{width}h{height}`, matching the archive snapshot key) so archive stories open in the captured viewport.
> 
> [...]
> 
> Storybook 10 selects the active viewport through `globals.viewport`, together with `parameters.viewport` (available sizes / default). See [Defining the viewport for a story](https://storybook.js.org/docs/essentials/viewport#defining-the-viewport-for-a-story).
> 
> For archive stories we emit the captured archive viewport key as the story global, e.g.:
> 
> ```json
> {
>   "globals": { "viewport": "w1280h720" }
> }
> ```
> 
> That value matches the archive snapshot filename segment, so the renderer can fetch the matching rrweb snapshot. The archive still includes `parameters.viewport.viewports` and `parameters.viewport.defaultViewport` so the viewport option is defined for Storybook.
> 

## How to test

> * `yarn vitest run packages/shared/src/write-archive/stories-files.test.ts packages/shared/src/write-archive/index.test.ts packages/vitest/src/node/commands.test.ts`
> * `yarn lint`
> * Patched `@chromatic-com/vitest` into a consumer app and confirmed Vitest browser tests + `chromatic --vitest` complete successfully (expect baseline diffs until snapshots are accepted).

