### PR TITLE
fix(playwright): proper browser entrypoint

### DIFF
--- a/.changeset/polite-things-make.md
+++ b/.changeset/polite-things-make.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/playwright': patch
+---
+
+Fix: Proper browser entrypoint

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -20,6 +20,7 @@
         "default": "./dist/index.js"
       }
     },
+    "./browser": "./dist/browser.mjs",
     "./bin/archive-storybook": "./dist/bin/archive-storybook.js",
     "./bin/build-archive-storybook": "./dist/bin/build-archive-storybook.js",
     "./package.json": "./package.json"
@@ -48,8 +49,7 @@
   "dependencies": {
     "@chromaui/rrweb-snapshot": "2.0.0-alpha.19-noAbsolute",
     "@segment/analytics-node": "2.1.3",
-    "storybook": "10.2.13",
-    "ts-dedent": "^2.2.0"
+    "storybook": "10.2.13"
   },
   "devDependencies": {
     "@chromatic-com/shared-e2e": "workspace:*",
@@ -60,7 +60,8 @@
     "@storybook/server-webpack5": "10.2.13",
     "express": "^4.18.2",
     "playwright": "^1.46.1",
-    "playwright-core": "^1.46.1"
+    "playwright-core": "^1.46.1",
+    "ts-dedent": "^2.2.0"
   },
   "peerDependencies": {
     "@playwright/test": "^1.0.0"

--- a/packages/playwright/src/browser.ts
+++ b/packages/playwright/src/browser.ts
@@ -1,0 +1,57 @@
+import { snapshot, createMirror } from '@chromaui/rrweb-snapshot';
+import { type DOMSnapshots } from '@chromatic-com/shared-e2e';
+import { serializedNodeWithId } from '@rrweb/types';
+
+export async function takeSnapshot() {
+  const mirror = createMirror();
+  const domSnapshot = snapshot(document, { recordCanvas: true, mirror });
+
+  const pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'] = {};
+
+  for (const className of [':hover', ':focus', ':focus-visible', ':active'] as const) {
+    const elements = document.querySelectorAll(className);
+    const ids = Array.from(elements, (el) => mirror.getId(el)).filter((id) => id !== -1);
+    pseudoClassIds[className] = ids;
+  }
+
+  await replaceBlobUrls(domSnapshot);
+
+  return { domSnapshot, pseudoClassIds };
+}
+
+async function replaceBlobUrls(node: serializedNodeWithId) {
+  if (!('childNodes' in node)) {
+    return;
+  }
+
+  await Promise.all(
+    node.childNodes.map(async (childNode) => {
+      if (
+        'tagName' in childNode &&
+        childNode.tagName === 'img' &&
+        typeof childNode.attributes.src === 'string' &&
+        childNode.attributes.src?.startsWith('blob:')
+      ) {
+        const base64Url = await toDataURL(childNode.attributes.src);
+        childNode.attributes.src = base64Url;
+      }
+
+      if ('childNodes' in childNode && childNode.childNodes?.length) {
+        await replaceBlobUrls(childNode);
+      }
+    })
+  );
+}
+
+async function toDataURL(url: string): Promise<string> {
+  const blob = await fetch(url).then((res) => res.blob());
+
+  return new Promise<string>((resolveFileRead, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolveFileRead(reader.result?.toString() || '');
+    reader.onerror = reject;
+
+    // convert the blob to base64 string
+    reader.readAsDataURL(blob);
+  });
+}

--- a/packages/playwright/src/browser.ts
+++ b/packages/playwright/src/browser.ts
@@ -1,8 +1,14 @@
 import { snapshot, createMirror } from '@chromaui/rrweb-snapshot';
 import { type DOMSnapshots } from '@chromatic-com/shared-e2e';
-import { serializedNodeWithId } from '@rrweb/types';
+import { type serializedNodeWithId } from '@rrweb/types';
 
-export async function takeSnapshot() {
+export type WindowContext = Window & {
+  __chromatic_takeSnapshot: typeof takeSnapshot;
+};
+
+(window as unknown as WindowContext).__chromatic_takeSnapshot = takeSnapshot;
+
+async function takeSnapshot() {
   const mirror = createMirror();
   const domSnapshot = snapshot(document, { recordCanvas: true, mirror });
 

--- a/packages/playwright/src/browser.ts
+++ b/packages/playwright/src/browser.ts
@@ -6,6 +6,9 @@ export type WindowContext = Window & {
   __chromatic_takeSnapshot: typeof takeSnapshot;
 };
 
+/**
+ * Expose a function that server side will call. See {@link file://./takeSnapshot.ts}
+ */
 (window as unknown as WindowContext).__chromatic_takeSnapshot = takeSnapshot;
 
 async function takeSnapshot() {

--- a/packages/playwright/src/makeTest.test.ts
+++ b/packages/playwright/src/makeTest.test.ts
@@ -21,6 +21,18 @@ describe('makeTest', () => {
     browser = await chromium.launch();
     page = await browser.newPage();
     pageTwo = await browser.newPage();
+
+    // Vite SSR transforms import() that's meant for browsers
+    await Promise.all(
+      [page, pageTwo].map((ctx) =>
+        ctx.evaluate(() => {
+          // @ts-expect-error -- untyped
+          window.__vite_ssr_dynamic_import__ = () => ({
+            takeSnapshot: () => ({ domSnapshot: {} }),
+          });
+        })
+      )
+    );
   });
 
   afterEach(async () => {

--- a/packages/playwright/src/makeTest.test.ts
+++ b/packages/playwright/src/makeTest.test.ts
@@ -21,18 +21,6 @@ describe('makeTest', () => {
     browser = await chromium.launch();
     page = await browser.newPage();
     pageTwo = await browser.newPage();
-
-    // Vite SSR transforms import() that's meant for browsers
-    await Promise.all(
-      [page, pageTwo].map((ctx) =>
-        ctx.evaluate(() => {
-          // @ts-expect-error -- untyped
-          window.__vite_ssr_dynamic_import__ = () => ({
-            takeSnapshot: () => ({ domSnapshot: {} }),
-          });
-        })
-      )
-    );
   });
 
   afterEach(async () => {

--- a/packages/playwright/src/takeSnapshot.test.ts
+++ b/packages/playwright/src/takeSnapshot.test.ts
@@ -11,6 +11,7 @@ const fakePage = {
   evaluate: () => ({ domSnapshot: {}, pseudoClassIds: {} }),
   viewportSize: () => ({ width: 100, height: 200 }),
   frames: () => [],
+  addScriptTag: () => {},
 } as Page;
 
 describe('Snapshot storage', () => {
@@ -87,6 +88,7 @@ describe('Snapshot storage', () => {
         },
         pseudoClassIds: {},
       }),
+      addScriptTag: () => {},
       viewportSize: () => ({ width: 100, height: 200 }),
       frames: () => [
         fakePage,
@@ -96,6 +98,7 @@ describe('Snapshot storage', () => {
             pseudoClassIds: { ':hover': [10] },
           }),
           url: () => iframes[0].attributes.src,
+          addScriptTag: () => {},
         },
         {
           evaluate: () => ({
@@ -103,6 +106,7 @@ describe('Snapshot storage', () => {
             pseudoClassIds: { ':focus': [20] },
           }),
           url: () => iframes[1].attributes.src,
+          addScriptTag: () => {},
         },
       ],
     } as unknown as Page;

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -1,10 +1,10 @@
 import type { Frame, Page, TestInfo } from '@playwright/test';
-import { readFileSync } from 'fs';
-import { dedent } from 'ts-dedent';
+import { readFileSync } from 'node:fs';
 import { NodeType, type serializedNodeWithId } from '@rrweb/types';
 import { type DOMSnapshots, type SerializedIframeNode, logger } from '@chromatic-com/shared-e2e';
 
-const rrweb = readFileSync(require.resolve('@chromaui/rrweb-snapshot'), 'utf8');
+const browserEntry = require.resolve('@chromatic-com/playwright/browser');
+const browserScript = readFileSync(browserEntry, 'base64');
 
 type TestID = TestInfo['testId'];
 type SnapshotName = keyof DOMSnapshots;
@@ -85,81 +85,13 @@ async function executeSnapshotScript(context: Page | Frame): Promise<{
   domSnapshot: serializedNodeWithId;
   pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'];
 }> {
-  return await context.evaluate(dedent`
-    ${rrweb};
-
-    // this code was erroring the page.evaluate() when it was passed as a function to page.evaluate(),
-    // so for now it is being passed as a string until that can be resolved.
-    const doPostProcessing = (rrwebSnapshotInstance, documentToSnapshot) => {
-      return new Promise((resolve) => {
-        const mirror = rrwebSnapshotInstance.createMirror();
-        const domSnapshot = rrwebSnapshotInstance.snapshot(documentToSnapshot, { recordCanvas: true, mirror });
-
-        const pseudoClassIds = {};
-
-        for (const className of [':hover', ':focus', ':focus-visible', ':active']) {
-          const elements = documentToSnapshot.querySelectorAll(className);
-          const ids = Array.from(elements, (el) => mirror.getId(el)).filter((id) => id !== -1);
-          pseudoClassIds[className] = ids;
-        }
-
-        // do some post-processing on the snapshot
-        const toDataURL = async (url) => {
-          // read contents of the blob URL
-          const response = await fetch(url);
-          const blob = await response.blob();
-          return new Promise((resolveFileRead, reject) => {
-            const reader = new FileReader();
-            reader.onloadend = () => resolveFileRead(reader.result);
-            reader.onerror = reject;
-            // convert the blob to base64 string
-            reader.readAsDataURL(blob);
-          });
-        };
-
-        const replaceBlobUrls = async (node) => {
-          await Promise.all(
-            node.childNodes.map(async (childNode) => {
-              if (childNode.tagName === 'img' && childNode.attributes.src?.startsWith('blob:')) {
-                const base64Url = await toDataURL(childNode.attributes.src);
-                // eslint-disable-next-line no-param-reassign
-                childNode.attributes.src = base64Url;
-              }
-
-              if (childNode.childNodes?.length) {
-                await replaceBlobUrls(childNode);
-              }
-            })
-          );
-        };
-
-        replaceBlobUrls(domSnapshot).then(() => {
-          resolve({ domSnapshot, pseudoClassIds });
-        });
-      });
-    };
-
-    // page.evaluate returns the value of the function being evaluated. In this case, it means that
-    // it is returning either the resolved value of the Promise or the return value of the call to
-    // the snapshot function. See https://playwright.dev/docs/api/class-page#page-evaluate.
-    if (typeof define === 'function' && define.amd) {
-      // AMD support is detected, so we need to load rrwebSnapshot asynchronously
-      new Promise((resolve) => {
-        // eslint-disable-next-line import/no-dynamic-require, global-require
-        require(['rrwebSnapshot'], (rrwebSnapshot) => {
-          doPostProcessing(rrwebSnapshot, document).then((domSnapshot) => {
-            resolve(domSnapshot);
-          });
-        });
-      });
-    } else {
-      new Promise((resolve) => {
-        doPostProcessing(rrwebSnapshot, document).then((domSnapshot) => {
-          resolve(domSnapshot);
-        });
-      });
-    }
-  `);
+  return await context.evaluate(
+    async ({ moduleURL }) => {
+      const mod = await import(moduleURL);
+      return mod.takeSnapshot();
+    },
+    { moduleURL: `data:text/javascript;base64,${browserScript}` }
+  );
 }
 
 function findIframes(

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -1,10 +1,7 @@
 import type { Frame, Page, TestInfo } from '@playwright/test';
-import { readFileSync } from 'node:fs';
 import { NodeType, type serializedNodeWithId } from '@rrweb/types';
 import { type DOMSnapshots, type SerializedIframeNode, logger } from '@chromatic-com/shared-e2e';
-
-const browserEntry = require.resolve('@chromatic-com/playwright/browser');
-const browserScript = readFileSync(browserEntry, 'base64');
+import type { WindowContext } from './browser';
 
 type TestID = TestInfo['testId'];
 type SnapshotName = keyof DOMSnapshots;
@@ -81,17 +78,15 @@ async function takeSnapshot(
   });
 }
 
-async function executeSnapshotScript(context: Page | Frame): Promise<{
-  domSnapshot: serializedNodeWithId;
-  pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'];
-}> {
-  return await context.evaluate(
-    async ({ moduleURL }) => {
-      const mod = await import(moduleURL);
-      return mod.takeSnapshot();
-    },
-    { moduleURL: `data:text/javascript;base64,${browserScript}` }
-  );
+async function executeSnapshotScript(context: Page | Frame) {
+  await context.addScriptTag({
+    type: 'module',
+    path: require.resolve('@chromatic-com/playwright/browser'),
+  });
+
+  return await context.evaluate(async () => {
+    return await (window as unknown as WindowContext).__chromatic_takeSnapshot();
+  });
 }
 
 function findIframes(

--- a/packages/playwright/tsup.config.ts
+++ b/packages/playwright/tsup.config.ts
@@ -68,4 +68,14 @@ export default defineConfig((options) => [
       options.conditions = ['module'];
     },
   },
+  {
+    ...common,
+    entry: {
+      browser: 'src/browser.ts',
+    },
+    format: ['esm'],
+    bundle: true,
+    noExternal: ['@chromaui/rrweb-snapshot'],
+    platform: 'browser',
+  },
 ]);

--- a/packages/playwright/tsup.config.ts
+++ b/packages/playwright/tsup.config.ts
@@ -70,6 +70,7 @@ export default defineConfig((options) => [
   },
   {
     ...common,
+    dts: false,
     entry: {
       browser: 'src/browser.ts',
     },


### PR DESCRIPTION
Issue: Unrelated to iframe capturing, but mentioned in WFL-267.

## What Changed

Create proper browser entrypoint that has all dependencies inlined. No amd runtime checks.

## How to test

- `"@chromatic-com/playwright": "0.14.1-cc2091f-20260515082535"`
- https://npmx.dev/package-code/@chromatic-com/playwright/v/0.14.1-cc2091f-20260515082535/dist%2Fbrowser.mjs