### PR TITLE
refactor(playwright): replace `page.evaluate` with `page.exposeFunction`

### DIFF
--- a/.changeset/quiet-candies-repeat.md
+++ b/.changeset/quiet-candies-repeat.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/playwright': patch
+---
+
+Fix: Refactor takeSnapshot internals

--- a/packages/playwright/src/browser.ts
+++ b/packages/playwright/src/browser.ts
@@ -2,14 +2,21 @@ import { snapshot, createMirror } from '@chromaui/rrweb-snapshot';
 import { type DOMSnapshots } from '@chromatic-com/shared-e2e';
 import { type serializedNodeWithId } from '@rrweb/types';
 
-export type WindowContext = Window & {
-  __chromatic_takeSnapshot: typeof takeSnapshot;
-};
+/** Function in global `Window` that is used to report the snapshot results */
+export type ResultFunctionName = '__chromatic_report_results__';
 
-/**
- * Expose a function that server side will call. See {@link file://./takeSnapshot.ts}
- */
-(window as unknown as WindowContext).__chromatic_takeSnapshot = takeSnapshot;
+/** Shape of the {@link ResultFunctionName} report callback */
+export type SnapshotOutput = Awaited<ReturnType<typeof takeSnapshot>>;
+
+/** Server side is expected to expose this function in {@link file://./takeSnapshot.ts} */
+if (!isWindowWithReportFunction(window)) {
+  throw new Error(
+    'Missing __chromatic_report_results__ function on window. Was exposeFunction called?'
+  );
+}
+
+const results = await takeSnapshot();
+window.__chromatic_report_results__(results);
 
 async function takeSnapshot() {
   const mirror = createMirror();
@@ -63,4 +70,13 @@ async function toDataURL(url: string): Promise<string> {
     // convert the blob to base64 string
     reader.readAsDataURL(blob);
   });
+}
+
+function isWindowWithReportFunction(
+  win: object
+): win is Record<ResultFunctionName, (result: SnapshotOutput) => void> {
+  return (
+    ('__chromatic_report_results__' satisfies ResultFunctionName) in win &&
+    typeof win.__chromatic_report_results__ === 'function'
+  );
 }

--- a/packages/playwright/src/takeSnapshot.test.ts
+++ b/packages/playwright/src/takeSnapshot.test.ts
@@ -8,11 +8,23 @@ import { chromaticSnapshots, takeSnapshot } from './takeSnapshot';
 // (where page is probably too tied up into takeSnapshot anyway)
 const fakePage = {
   on: () => {},
-  evaluate: () => ({ domSnapshot: {}, pseudoClassIds: {} }),
   viewportSize: () => ({ width: 100, height: 200 }),
   frames: () => [],
-  addScriptTag: () => {},
+  addScriptTag: onAddScriptTag({ domSnapshot: {}, pseudoClassIds: {} }),
+  exposeFunction,
 } as Page;
+
+const listeners: ((..._: unknown[]) => void)[] = [];
+
+function exposeFunction(name: string, fn: (typeof listeners)[number]) {
+  if (name === '__chromatic_report_results__') {
+    listeners.push(fn);
+  }
+}
+
+function onAddScriptTag(snapshot: unknown) {
+  return () => listeners.forEach((listener) => listener(snapshot));
+}
 
 describe('Snapshot storage', () => {
   beforeEach(async () => {
@@ -80,7 +92,7 @@ describe('Snapshot storage', () => {
 
     const pageWithIframes = {
       on: () => {},
-      evaluate: () => ({
+      addScriptTag: onAddScriptTag({
         domSnapshot: {
           type: NodeType.Document,
           childNodes: [{ type: NodeType.Element, tagName: 'html', childNodes: iframes, id: 1 }],
@@ -88,25 +100,25 @@ describe('Snapshot storage', () => {
         },
         pseudoClassIds: {},
       }),
-      addScriptTag: () => {},
+      exposeFunction,
       viewportSize: () => ({ width: 100, height: 200 }),
       frames: () => [
         fakePage,
         {
-          evaluate: () => ({
+          addScriptTag: onAddScriptTag({
             domSnapshot: { type: NodeType.Element, tagName: 'div', textContent: 'One', id: 10 },
             pseudoClassIds: { ':hover': [10] },
           }),
           url: () => iframes[0].attributes.src,
-          addScriptTag: () => {},
+          exposeFunction,
         },
         {
-          evaluate: () => ({
+          addScriptTag: onAddScriptTag({
             domSnapshot: { type: NodeType.Element, tagName: 'span', textContent: 'Two', id: 20 },
             pseudoClassIds: { ':focus': [20] },
           }),
           url: () => iframes[1].attributes.src,
-          addScriptTag: () => {},
+          exposeFunction,
         },
       ],
     } as unknown as Page;

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -1,7 +1,7 @@
 import type { Frame, Page, TestInfo } from '@playwright/test';
 import { NodeType, type serializedNodeWithId } from '@rrweb/types';
 import { type DOMSnapshots, type SerializedIframeNode, logger } from '@chromatic-com/shared-e2e';
-import type { WindowContext } from './browser';
+import type { SnapshotOutput, ResultFunctionName } from './browser';
 
 type TestID = TestInfo['testId'];
 type SnapshotName = keyof DOMSnapshots;
@@ -9,6 +9,13 @@ export const chromaticSnapshots: Map<
   TestID,
   Map<SnapshotName, DOMSnapshots[SnapshotName]>
 > = new Map();
+
+type ResultCallback = (result: SnapshotOutput) => void;
+
+const pageToResultHandler = new WeakMap<
+  Page,
+  { listeners: ResultCallback[]; onResult: ResultCallback }
+>();
 
 async function takeSnapshot(page: Page, testInfo: TestInfo): Promise<void>;
 async function takeSnapshot(page: Page, name: string, testInfo: TestInfo): Promise<void>;
@@ -78,15 +85,43 @@ async function takeSnapshot(
   });
 }
 
+async function getResultHandler(context: Page | Frame) {
+  const page = 'page' in context ? context.page() : context;
+
+  // exposeFunction can be called once per page so we'll need caching
+  let handler = pageToResultHandler.get(page);
+
+  if (!handler) {
+    handler = {
+      listeners: [],
+
+      // Handlers are consumed once - use .splice() to empty previous listeners
+      onResult: (result) => handler.listeners.splice(0).forEach((listener) => listener(result)),
+    };
+
+    /** Expose reporting function for {@link file://./browser.ts} */
+    await page.exposeFunction(
+      '__chromatic_report_results__' satisfies ResultFunctionName,
+      handler.onResult
+    );
+
+    pageToResultHandler.set(page, handler);
+  }
+
+  return {
+    waitForResult: new Promise<SnapshotOutput>((resolve) => handler.listeners.push(resolve)),
+  };
+}
+
 async function executeSnapshotScript(context: Page | Frame) {
+  const { waitForResult } = await getResultHandler(context);
+
   await context.addScriptTag({
     type: 'module',
     path: require.resolve('@chromatic-com/playwright/browser'),
   });
 
-  return await context.evaluate(async () => {
-    return await (window as unknown as WindowContext).__chromatic_takeSnapshot();
-  });
+  return await waitForResult;
 }
 
 function findIframes(

--- a/packages/playwright/tsup.config.ts
+++ b/packages/playwright/tsup.config.ts
@@ -75,6 +75,7 @@ export default defineConfig((options) => [
       browser: 'src/browser.ts',
     },
     format: ['esm'],
+    target: 'esnext',
     bundle: true,
     noExternal: ['@chromaui/rrweb-snapshot'],
     platform: 'browser',


### PR DESCRIPTION
Issue: Continues https://github.com/chromaui/chromatic-e2e/pull/351#discussion_r3262952036

## What Changed

Instead of calling client side functions from server, we'll expose reporting function from the server side and make browser side script call that as soon as it's ready.

## How to test

CI should pass, no unexpected snapshot changes.

- [x] Test `@chromatic-com/playwright@0.14.2-3c15dcd-20260519102148` in example project