### PR TITLE
ci: use `pkg-pr-new` for canary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,10 @@
 # This file must be merged to main before Release will run; it will not run from a PR.
 #
 # - On main (after "Test and Release Main"): changeset version PR or publish (stable).
-# - On PRs (after "Test and Release PR"): snapshot version + publish with tag canary.
 #
 # Re-running the test workflow triggers this again. Concurrency ensures we don't run
 # two release jobs for the same commit at once (later trigger cancels in-progress).
-# Stable: republish is safe (npm rejects existing versions). Canary: may publish again.
+# Stable: republish is safe (npm rejects existing versions).
 concurrency:
   group: release-${{ github.event.workflow_run.head_sha }}
   cancel-in-progress: true
@@ -19,7 +18,7 @@ name: Release
 
 on:
   workflow_run:
-    workflows: ['Test and Release Main', 'Test and Release PR']
+    workflows: ['Test and Release Main']
     types: [completed]
 
 permissions:
@@ -62,42 +61,3 @@ jobs:
           publish: yarn run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  release-canary:
-    name: Release (canary)
-    runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.name == 'Test and Release PR'
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Install Dependencies
-        run: yarn install
-
-      - name: Build (canary)
-        run: yarn run build
-
-      - name: Set canary snapshot hash
-        run: |
-          echo "GIT_HASH=$(git rev-parse --short ${{ github.event.workflow_run.head_sha }})" >> "$GITHUB_ENV"
-
-      - name: Update npm
-        run: |
-          npm --version
-          npm install -g npm@~11.10.0 # Work-around for https://github.com/npm/cli/issues/9151#issuecomment-4131466208
-          npm install -g npm@latest
-          npm --version
-
-      - name: Publish canary
-        run: |
-          yarn run changeset version --snapshot $GIT_HASH
-          yarn run changeset publish --no-git-tag --tag canary

--- a/.github/workflows/test-base.yml
+++ b/.github/workflows/test-base.yml
@@ -20,13 +20,16 @@ jobs:
       - name: Install Dependencies
         run: yarn install
 
-      - name: Install Playwright
-        run: |
-          yarn playwright install --with-deps
-
       - name: Build
         run: |
           yarn run build
+
+      - name: Publish canary
+        run: yarn dlx pkg-pr-new publish --commentWithDev --commentWithSha './packages/cypress' './packages/playwright' './packages/vitest'
+
+      - name: Install Playwright
+        run: |
+          yarn playwright install --with-deps
 
       - name: Run lint
         run: |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -79,9 +79,9 @@ After your PR is merged, if you included a changeset, the repo will auto-create 
 
 ### Canary Releases
 
-The changeset file on a branch will be used to cut canary releases of the changed packages in the PR.
+When a PR is opened, [`pkg.pr.new`](https://github.com/stackblitz-labs/pkg.pr.new) will automatically create a canary release for the changes. It will post a comment on the PR with published package versions. Whenever new changes are pushed to the PR, it updates the comment automatically with new versions.
 
-At this time you'll need to look at the output of the `Canary Release` job to find the versioned name it was published under.
+As `pkg.pr.new` publishes packages outside the official npm registry there is no need to worry about releasing too many canary releases. All packages in this registry are temporary and are automatically removed after 6 months, or after being inactive for a month.
 
 ### Final Releases
 


### PR DESCRIPTION
Issue: Part of https://github.com/chromaui/chromatic-e2e/issues/348

## What Changed

Use https://pkg.pr.new instead of `chagesets` for canary releases.

## How to test

Github application should automatically post new comment on this PR. 👀 