### PR TITLE
fix(playwright): avoid crash on deeply nested DOMs

### DIFF
--- a/.changeset/deep-papayas-check.md
+++ b/.changeset/deep-papayas-check.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/playwright': patch
+---
+
+Fix: Avoid crashing on deeply nested DOMs

--- a/packages/playwright/src/takeSnapshot.test.ts
+++ b/packages/playwright/src/takeSnapshot.test.ts
@@ -8,7 +8,7 @@ import { chromaticSnapshots, takeSnapshot } from './takeSnapshot';
 // (where page is probably too tied up into takeSnapshot anyway)
 const fakePage = {
   on: () => {},
-  evaluate: () => ({ domSnapshot: {}, pseudoClassIds: {} }),
+  evaluate: () => JSON.stringify({ domSnapshot: {}, pseudoClassIds: {} }),
   viewportSize: () => ({ width: 100, height: 200 }),
   frames: () => [],
   addScriptTag: () => {},
@@ -80,31 +80,34 @@ describe('Snapshot storage', () => {
 
     const pageWithIframes = {
       on: () => {},
-      evaluate: () => ({
-        domSnapshot: {
-          type: NodeType.Document,
-          childNodes: [{ type: NodeType.Element, tagName: 'html', childNodes: iframes, id: 1 }],
-          id: 0,
-        },
-        pseudoClassIds: {},
-      }),
+      evaluate: () =>
+        JSON.stringify({
+          domSnapshot: {
+            type: NodeType.Document,
+            childNodes: [{ type: NodeType.Element, tagName: 'html', childNodes: iframes, id: 1 }],
+            id: 0,
+          },
+          pseudoClassIds: {},
+        }),
       addScriptTag: () => {},
       viewportSize: () => ({ width: 100, height: 200 }),
       frames: () => [
         fakePage,
         {
-          evaluate: () => ({
-            domSnapshot: { type: NodeType.Element, tagName: 'div', textContent: 'One', id: 10 },
-            pseudoClassIds: { ':hover': [10] },
-          }),
+          evaluate: () =>
+            JSON.stringify({
+              domSnapshot: { type: NodeType.Element, tagName: 'div', textContent: 'One', id: 10 },
+              pseudoClassIds: { ':hover': [10] },
+            }),
           url: () => iframes[0].attributes.src,
           addScriptTag: () => {},
         },
         {
-          evaluate: () => ({
-            domSnapshot: { type: NodeType.Element, tagName: 'span', textContent: 'Two', id: 20 },
-            pseudoClassIds: { ':focus': [20] },
-          }),
+          evaluate: () =>
+            JSON.stringify({
+              domSnapshot: { type: NodeType.Element, tagName: 'span', textContent: 'Two', id: 20 },
+              pseudoClassIds: { ':focus': [20] },
+            }),
           url: () => iframes[1].attributes.src,
           addScriptTag: () => {},
         },

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -84,9 +84,12 @@ async function executeSnapshotScript(context: Page | Frame) {
     path: require.resolve('@chromatic-com/playwright/browser'),
   });
 
-  return await context.evaluate(async () => {
-    return await (window as unknown as WindowContext).__chromatic_takeSnapshot();
+  const snapshot = await context.evaluate(async () => {
+    // Additional JSON.stringify + parse needed for deeply nested DOMs: https://github.com/chromaui/chromatic-e2e/issues/307
+    return JSON.stringify(await (window as unknown as WindowContext).__chromatic_takeSnapshot());
   });
+
+  return JSON.parse(snapshot) as ReturnType<WindowContext['__chromatic_takeSnapshot']>;
 }
 
 function findIframes(

--- a/packages/playwright/tests/deeply-nested-dom.spec.ts
+++ b/packages/playwright/tests/deeply-nested-dom.spec.ts
@@ -1,0 +1,5 @@
+import { test } from '../src';
+
+test('pages with a deeply nested DOM are archived', async ({ page }) => {
+  await page.goto('/deeply-nested-dom');
+});

--- a/test-server/fixtures/deeply-nested-dom.html
+++ b/test-server/fixtures/deeply-nested-dom.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Deeply Nested DOM</title>
+  </head>
+  <body>
+    <div id="root"></div>
+
+    <script>
+      // Minimal reproduction for https://github.com/chromaui/chromatic-e2e/issues/307
+      const DEPTH = 100;
+
+      let node = document.getElementById('root');
+
+      for (let i = 0; i < DEPTH; i++) {
+        const child = document.createElement('div');
+        node.appendChild(child);
+        node = child;
+      }
+
+      node.textContent = 'Deeply nested content';
+    </script>
+  </body>
+</html>

--- a/test-server/server.js
+++ b/test-server/server.js
@@ -126,6 +126,10 @@ app.get('/no-doctype', (req, res) => {
   res.sendFile(path.join(__dirname, 'fixtures/no-doctype.html'));
 });
 
+app.get('/deeply-nested-dom', (req, res) => {
+  res.sendFile(path.join(__dirname, 'fixtures/deeply-nested-dom.html'));
+});
+
 app.get('/viewports', (req, res) => {
   res.sendFile(path.join(__dirname, 'fixtures/viewports.html'));
 });


### PR DESCRIPTION
Issue:
- Fixes https://github.com/chromaui/chromatic-e2e/issues/307
- Mentioned on WFL-267

## What Changed

When `page.evaluate()` returns DOM snapshot that contains too deeply nested JSON, Playwright crashes the function call with `Execution context was destroyed, most likely because of a navigation.` error. Under the hood CDP is responding with `Failed to convert response to JSON: CBOR: stack limit exceeded at position <x>` error, but Playwright hides this error. Upstream fix for misleading error was fixed in:

- https://github.com/microsoft/playwright/issues/40940

Fix for our side is to avoid returning objects as return value of `page.evaluate`, and return plain string instead. So let's do `JSON.stringify` on client side, and `JSON.parse` immediately on server side.


## How to test

- [x] Added test case that reproduces the original bug
- [x] Test canary release `@chromatic-com/playwright@0.14.3-7de78ce-20260522064559` with https://github.com/AriPerkkio/minimal-repro-chromatic-playwright/pull/1