### PR TITLE
feat(vitest): rework story naming logic

### DIFF
--- a/.changeset/grumpy-geese-mate.md
+++ b/.changeset/grumpy-geese-mate.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: Rework story naming logic

--- a/packages/shared/src/write-archive/index.test.ts
+++ b/packages/shared/src/write-archive/index.test.ts
@@ -3,6 +3,7 @@ import { resolve } from 'path';
 import { NodeType } from '@rrweb/types';
 import * as filePaths from '../utils/filePaths';
 import { writeTestResult } from '.';
+import { uniqueId } from './stories-files';
 
 vi.mock(import('../utils/filePaths'), async (importOriginal) => ({
   ...(await importOriginal()),
@@ -30,6 +31,7 @@ const snapshotJson = {
 
 afterEach(() => {
   vi.resetAllMocks();
+  uniqueId.value = 1;
 });
 
 describe('writeTestResult', () => {
@@ -57,7 +59,7 @@ describe('writeTestResult', () => {
     expect(filePaths.outputFile).toHaveBeenCalledTimes(2);
     expect(filePaths.outputJSONFile).toHaveBeenCalledTimes(1);
     expect(filePaths.outputJSONFile).toHaveBeenCalledWith(
-      resolve('./test-results/chromatic-archives/file-test-story.stories.json'),
+      resolve('./test-results/chromatic-archives/file-test-story-1.stories.json'),
       {
         stories: [
           {
@@ -166,7 +168,9 @@ describe('writeTestResult', () => {
     expect(filePaths.outputFile).toHaveBeenCalledTimes(2);
     expect(filePaths.outputJSONFile).toHaveBeenCalledTimes(1);
     expect(filePaths.outputJSONFile).toHaveBeenCalledWith(
-      resolve('./some-custom-directory/directory/chromatic-archives/file-test-story.stories.json'),
+      resolve(
+        './some-custom-directory/directory/chromatic-archives/file-test-story-1.stories.json'
+      ),
       expect.anything()
     );
   });

--- a/packages/shared/src/write-archive/stories-files.test.ts
+++ b/packages/shared/src/write-archive/stories-files.test.ts
@@ -12,12 +12,13 @@ const vports = [
 
 beforeEach(() => {
   vi.resetAllMocks();
+  storiesFiles.uniqueId.value = 1;
 });
 
 describe('storiesFileName', () => {
   it('sanitizes the file name', () => {
     const fileName = storiesFiles.storiesFileName('--a title *() with $%& chars---');
-    expect(fileName).toEqual('a-title-with-chars.stories.json');
+    expect(fileName).toEqual(`a-title-with-chars-1.stories.json`);
   });
 
   it('truncates long file names', () => {
@@ -34,7 +35,7 @@ describe('storiesFileName', () => {
     const title = '\n\n\r\rThere\nShould\rBe\r\nNo\n\rNewlines\r\r\n\n';
 
     const filename = storiesFiles.storiesFileName(title);
-    expect(filename).toEqual('there-should-be-no-newlines.stories.json');
+    expect(filename).toEqual('there-should-be-no-newlines-1.stories.json');
   });
 });
 

--- a/packages/shared/src/write-archive/stories-files.ts
+++ b/packages/shared/src/write-archive/stories-files.ts
@@ -7,9 +7,11 @@ import { MAX_FILE_NAME_BYTE_LENGTH, truncateFileName } from '../utils/filePaths'
 
 const STORIES_FILE_EXT = 'stories.json';
 
+export const uniqueId = { value: 1 };
+
 // Generates a file-system-safe file name from a story title
 export function storiesFileName(testTitle: string) {
-  const fileName = [sanitize(testTitle), STORIES_FILE_EXT].join('.');
+  const fileName = [sanitize(testTitle) + '-' + uniqueId.value++, STORIES_FILE_EXT].join('.');
   // Leave room for built storybook extensions that may be added (like `-stories.iframe.bundle.js`)
   const maxByteLength = MAX_FILE_NAME_BYTE_LENGTH - 25;
   return truncateFileName(fileName, maxByteLength);

--- a/packages/vitest/src/browser/public/configure.test.ts
+++ b/packages/vitest/src/browser/public/configure.test.ts
@@ -296,6 +296,30 @@ describe('configure(ChromaticConfig)', () => {
       }
     `);
   });
+
+  test('configure({ title })', async () => {
+    await runFixture({
+      include,
+      provide: {
+        configureScope: 'module',
+        configureOptions: { title: 'Components/Accordion' },
+      },
+    });
+
+    const titles = vi
+      .mocked(shared.writeTestResult)
+      .mock.calls.flatMap((call) => call[0].titlePath);
+
+    expect(titles).toMatchInlineSnapshot(`
+      [
+        "Components/Accordion",
+        "Components/Accordion",
+        "Components/Accordion",
+        "Components/Accordion",
+        "Components/Accordion",
+      ]
+    `);
+  });
 });
 
 function getSnapshottedTests() {

--- a/packages/vitest/src/browser/public/configure.test.ts
+++ b/packages/vitest/src/browser/public/configure.test.ts
@@ -300,14 +300,14 @@ describe('configure(ChromaticConfig)', () => {
 
 function getSnapshottedTests() {
   return vi.mocked(shared.writeTestResult).mock.calls.map((call) => {
-    return call[0].titlePath.pop();
+    return Object.keys(call[1])[0].split(' / ')[0];
   });
 }
 
 function getChromaticOptions() {
   return Object.fromEntries(
     vi.mocked(shared.writeTestResult).mock.calls.map((call) => {
-      const title = call[0].titlePath.pop();
+      const title = Object.keys(call[1])[0].split(' / ')[0];
 
       // Options are written to file system as JSON, simulate that in mocked writeTestResult stub:
       const options = JSON.parse(JSON.stringify(call[3]));

--- a/packages/vitest/src/browser/public/takeSnapshot.test.ts
+++ b/packages/vitest/src/browser/public/takeSnapshot.test.ts
@@ -107,18 +107,12 @@ test('viewports are correct when --browser.ui=true', async () => {
 
   expect(getSnapshottedTests()).toMatchInlineSnapshot(`
     {
-      "calls page.viewport multiple times in one test": {
-        "1280 x 1024": "width=1280, height=1024",
-        "480 x 320": "width=480, height=320",
-        "720 x 680": "width=720, height=680",
-        "Snapshot #4": "width=1280, height=1024",
-      },
-      "calls page.viewport(480, 320)": {
-        "Snapshot #1": "width=480, height=320",
-      },
-      "default viewport": {
-        "Snapshot #1": "width=1280, height=720",
-      },
+      "calls page.viewport multiple times in one test / 1280 x 1024": "width=1280, height=1024",
+      "calls page.viewport multiple times in one test / 480 x 320": "width=480, height=320",
+      "calls page.viewport multiple times in one test / 720 x 680": "width=720, height=680",
+      "calls page.viewport multiple times in one test / Snapshot #4": "width=1280, height=1024",
+      "calls page.viewport(480, 320) / Snapshot #1": "width=480, height=320",
+      "default viewport / Snapshot #1": "width=1280, height=720",
     }
   `);
 });
@@ -131,18 +125,12 @@ test('viewports are correct when --browser.ui=false', async () => {
 
   expect(getSnapshottedTests()).toMatchInlineSnapshot(`
     {
-      "calls page.viewport multiple times in one test": {
-        "1280 x 1024": "width=1280, height=1024",
-        "480 x 320": "width=480, height=320",
-        "720 x 680": "width=720, height=680",
-        "Snapshot #4": "width=1280, height=1024",
-      },
-      "calls page.viewport(480, 320)": {
-        "Snapshot #1": "width=480, height=320",
-      },
-      "default viewport": {
-        "Snapshot #1": "width=1280, height=720",
-      },
+      "calls page.viewport multiple times in one test / 1280 x 1024": "width=1280, height=1024",
+      "calls page.viewport multiple times in one test / 480 x 320": "width=480, height=320",
+      "calls page.viewport multiple times in one test / 720 x 680": "width=720, height=680",
+      "calls page.viewport multiple times in one test / Snapshot #4": "width=1280, height=1024",
+      "calls page.viewport(480, 320) / Snapshot #1": "width=480, height=320",
+      "default viewport / Snapshot #1": "width=1280, height=720",
     }
   `);
 });
@@ -160,9 +148,9 @@ test.each(['list', 'stack'] as const)(
     expect(shared.writeTestResult).toHaveBeenCalledTimes(1);
 
     const [, snapshots] = vi.mocked(shared.writeTestResult).mock.calls[0];
-    expect(snapshots).toHaveProperty('Snapshot #1');
+    expect(snapshots).toHaveProperty('test #4 / Snapshot #1');
 
-    const { snapshot } = snapshots['Snapshot #1'];
+    const { snapshot } = snapshots['test #4 / Snapshot #1'];
 
     expect(JSON.parse(snapshot.toString())).toMatchInlineSnapshot(`
     {
@@ -208,11 +196,11 @@ test('user defined afterEach can call takeSnapshot()', async () => {
 
   const [, snapshots] = vi.mocked(shared.writeTestResult).mock.calls[0];
 
-  expect.soft(snapshots).toHaveProperty('Snapshot #1');
-  expect.soft(snapshots).toHaveProperty("user's after each snapshot!");
+  expect.soft(snapshots).toHaveProperty('test #4 / Snapshot #1');
+  expect.soft(snapshots).toHaveProperty("test #4 / user's after each snapshot!");
 
-  const autoSnapshot = snapshots['Snapshot #1'].snapshot;
-  const userSnapshot = snapshots["user's after each snapshot!"].snapshot;
+  const autoSnapshot = snapshots['test #4 / Snapshot #1'].snapshot;
+  const userSnapshot = snapshots["test #4 / user's after each snapshot!"].snapshot;
 
   expect(JSON.parse(autoSnapshot.toString())).toMatchInlineSnapshot(`
     {
@@ -251,8 +239,7 @@ test('user defined afterEach can call takeSnapshot()', async () => {
 
 function getSnapshottedTests() {
   return vi.mocked(shared.writeTestResult).mock.calls.reduce((all, call) => {
-    const [e2eTestInfo, domSnapshots] = call;
-    const title = e2eTestInfo.titlePath.pop()!;
+    const [, domSnapshots] = call;
 
     const snapshots = Object.fromEntries(
       Object.entries(domSnapshots).map(([name, { viewport }]) => [
@@ -261,6 +248,6 @@ function getSnapshottedTests() {
       ])
     );
 
-    return { ...all, [title]: snapshots };
+    return { ...all, ...snapshots };
   }, {});
 }

--- a/packages/vitest/src/browser/setupFile.test.ts
+++ b/packages/vitest/src/browser/setupFile.test.ts
@@ -135,6 +135,6 @@ test('cleans up internal test meta properties', async () => {
 
 function getSnapshottedTests() {
   return vi.mocked(shared.writeTestResult).mock.calls.map((call) => {
-    return call[0].titlePath.pop();
+    return Object.keys(call[1])[0].split(' / ')[0];
   });
 }

--- a/packages/vitest/src/node/commands.test.ts
+++ b/packages/vitest/src/node/commands.test.ts
@@ -9,24 +9,23 @@ test('writes test results with full test name', async () => {
   /** See {@link file://./../../test/fixtures/test-names.test.ts} */
   await runFixture({ include: ['test-names.test.ts'] });
 
-  const titlePaths = vi.mocked(shared.writeTestResult).mock.calls.map((call) => call[0].titlePath);
+  const tests = vi
+    .mocked(shared.writeTestResult)
+    .mock.calls.map((call) => [...call[0].titlePath, ...Object.keys(call[1])]);
 
-  expect(titlePaths).toMatchInlineSnapshot(`
+  expect(tests).toMatchInlineSnapshot(`
     [
       [
         "test-names.test.ts",
-        "test #1",
+        "test #1 / Snapshot #1",
       ],
       [
         "test-names.test.ts",
-        "suite #2",
-        "test #2",
+        "suite #2 / test #2 / Snapshot #1",
       ],
       [
         "test-names.test.ts",
-        "suite #3",
-        "nested suite #3",
-        "test #3",
+        "suite #3 / nested suite #3 / test #3 / Snapshot #1",
       ],
     ]
   `);
@@ -38,9 +37,9 @@ test('writes test results with DOM snapshot', async () => {
 
   const snapshots = vi.mocked(shared.writeTestResult).mock.calls.map((call) => call[1]);
 
-  expect(snapshots[0]).toHaveProperty('Snapshot #1');
+  expect(snapshots[0]).toHaveProperty('mount some elements / Snapshot #1');
 
-  const { snapshot } = snapshots[0]['Snapshot #1'];
+  const { snapshot } = snapshots[0]['mount some elements / Snapshot #1'];
   const json = JSON.parse(Buffer.from(snapshot).toString());
 
   expect(json).toMatchInlineSnapshot(`

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -117,7 +117,9 @@ export function createCommands(options: ResolvedOptions) {
       const snapshotBuffers: DOMSnapshots = {};
 
       for (const [name, { snapshot, viewport, pseudoClassIds }] of sessionSnapshots) {
-        snapshotBuffers[name] = {
+        const names = getSnapshotPrefix(entity).concat(name).join(' / ');
+
+        snapshotBuffers[names] = {
           snapshot: Buffer.from(JSON.stringify(snapshot)),
           viewport,
           pseudoClassIds,
@@ -128,7 +130,7 @@ export function createCommands(options: ResolvedOptions) {
         {
           outputDir: resolve(context.project.vitest.config.root, options.outputDirectory),
           pageUrl: context.page.url(),
-          titlePath: getNames(entity),
+          titlePath: getTitle(entity),
         },
         snapshotBuffers,
         archive,
@@ -189,7 +191,22 @@ export function createCommands(options: ResolvedOptions) {
   }
 }
 
-function getNames(test: TestCase): string[] {
+function getTitle(test: TestCase): string[] {
+  const names = [test.module.relativeModuleId];
+
+  // If Vitest was configured with multiple projects, namespace the results with project name
+  const hasManyProjects =
+    test.project.vitest.projects.filter((project) => project.config.browser.name === 'chromium')
+      .length > 1;
+
+  if (hasManyProjects && test.project.name) {
+    names.unshift(test.project.name);
+  }
+
+  return names;
+}
+
+function getSnapshotPrefix(test: TestCase): string[] {
   const names = [test.name];
   let current: TestCase | TestSuite | TestModule = test;
 
@@ -199,19 +216,6 @@ function getNames(test: TestCase): string[] {
     if ('name' in current && current.name) {
       names.unshift(current.name);
     }
-  }
-
-  if (current.type === 'module') {
-    names.unshift(current.relativeModuleId);
-  }
-
-  // If Vitest was configured with multiple projects, namespace the results with project name
-  const hasManyProjects =
-    test.project.vitest.projects.filter((project) => project.config.browser.name === 'chromium')
-      .length > 1;
-
-  if (hasManyProjects && test.project.name) {
-    names.unshift(test.project.name);
   }
 
   return names;

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -130,7 +130,7 @@ export function createCommands(options: ResolvedOptions) {
         {
           outputDir: resolve(context.project.vitest.config.root, options.outputDirectory),
           pageUrl: context.page.url(),
-          titlePath: getTitle(entity),
+          titlePath: testOptions.title ? [testOptions.title] : getTitle(entity),
         },
         snapshotBuffers,
         archive,

--- a/packages/vitest/src/node/plugin.test.ts
+++ b/packages/vitest/src/node/plugin.test.ts
@@ -1,7 +1,8 @@
 import { resolve } from 'node:path';
 import { mkdir, readdir, rm } from 'node:fs/promises';
-import { expect, onTestFinished, test } from 'vitest';
+import { beforeEach, expect, onTestFinished, test } from 'vitest';
 import { createVitest, type TestModule } from 'vitest/node';
+import { uniqueId } from '@chromatic-com/shared-e2e/write-archive/stories-files';
 import { chromaticPlugin } from './plugin';
 import {
   createOutputStreams,
@@ -9,6 +10,10 @@ import {
   getResolvedConfig,
   runFixture,
 } from '../../test/utils/node';
+
+beforeEach(() => {
+  uniqueId.value = 1;
+});
 
 test.each([
   { name: 'string', setupFiles: 'some-user-defined-setup.ts' },
@@ -141,6 +146,7 @@ test('writes results to root when in Vitest projects setup', async () => {
   await runFixture(
     {
       root,
+      fileParallelism: false,
       projects: [
         {
           plugins: [chromaticPlugin()],
@@ -149,6 +155,7 @@ test('writes results to root when in Vitest projects setup', async () => {
             browser: getBrowserConfig('first-browser'),
             include: ['**/dom.test.ts'],
             root: resolve(import.meta.dirname, '../../test/fixtures'),
+            sequence: { groupOrder: 1 },
           },
         },
         {
@@ -158,6 +165,7 @@ test('writes results to root when in Vitest projects setup', async () => {
             browser: getBrowserConfig('second-browser'),
             include: ['**/dom.test.ts'],
             root: resolve(import.meta.dirname, '../../test/fixtures'),
+            sequence: { groupOrder: 2 },
           },
         },
       ],
@@ -173,8 +181,8 @@ test('writes results to root when in Vitest projects setup', async () => {
   expect(results).toMatchInlineSnapshot(`
     [
       "archive",
-      "first-browser-dom-mount-some-elements.stories.json",
-      "second-browser-dom-mount-some-elements.stories.json",
+      "first-browser-dom-1.stories.json",
+      "second-browser-dom-2.stories.json",
     ]
   `);
 });
@@ -212,30 +220,32 @@ test('does not clean existing output directory when "vitest --merge-reports" is 
   await expect(readdir(archives)).resolves.toMatchInlineSnapshot(`
     [
       "archive",
-      "dom-mount-some-elements.stories.json",
+      "dom-1.stories.json",
     ]
   `);
 });
 
-test('works in multi project instance setup', async () => {
+test('works in multi project instance setup', { timeout: 30_000 }, async () => {
   const root = resolve(import.meta.dirname, '../../test/fixtures');
   const tests: TestModule[] = [];
 
-  await runFixture({
-    name: 'custom-project-name',
-    browser: {
-      ...getBrowserConfig(),
-      instances: [
-        { browser: 'chromium', name: 'custom-name-for-chromium-browser' },
-        { browser: 'webkit', name: 'custom-name-for-webkit-browser' },
-        { browser: 'firefox', name: 'custom-name-for-firefox-browser' },
-      ],
-    },
-    reporters: ['default', { onTestRunEnd: (testModules) => void tests.push(...testModules) }],
-    /** See {@link file://./../../test/fixtures/public-apis.test.ts} */
-    include: ['**/public-apis.test.ts'],
-    root,
-  });
+  await expect(
+    runFixture({
+      name: 'custom-project-name',
+      browser: {
+        ...getBrowserConfig(),
+        instances: [
+          { browser: 'chromium', name: 'custom-name-for-chromium-browser' },
+          { browser: 'webkit', name: 'custom-name-for-webkit-browser' },
+          { browser: 'firefox', name: 'custom-name-for-firefox-browser' },
+        ],
+      },
+      reporters: ['default', { onTestRunEnd: (testModules) => void tests.push(...testModules) }],
+      /** See {@link file://./../../test/fixtures/public-apis.test.ts} */
+      include: ['**/public-apis.test.ts'],
+      root,
+    })
+  ).resolves.not.toThrow();
 
   // Non-Chromium browsers should not crash
   expect.soft(tests).toHaveLength(3);
@@ -249,8 +259,8 @@ test('works in multi project instance setup', async () => {
   expect(results).toMatchInlineSnapshot(`
     [
       "archive",
-      "public-apis-calls-takesnapshot.stories.json",
-      "public-apis-calls-waitforidlenetwork.stories.json",
+      "public-apis-1.stories.json",
+      "public-apis-2.stories.json",
     ]
   `);
 });

--- a/packages/vitest/src/types.ts
+++ b/packages/vitest/src/types.ts
@@ -52,7 +52,10 @@ export interface ResolvedOptions
  * Options that can be set per test, suite or module via `configure()`
  * - `assetDomains` is excluded as it can only be configured globally on the plugin
  */
-export type ConfigureOptions = Omit<ChromaticConfig, 'assetDomains'>;
+export type ConfigureOptions = {
+  /** Custom title to be shown in Chromatic. Default is derived from test file name. */
+  title?: string;
+} & Omit<ChromaticConfig, 'assetDomains'>;
 
 /** @internal */
 type InternalMeta = Record<ChromaticNamespace, unknown> & {

--- a/packages/vitest/test/snapshot-names.test.ts
+++ b/packages/vitest/test/snapshot-names.test.ts
@@ -1,3 +1,4 @@
+import { describe, beforeEach } from 'vitest';
 import { test } from './utils/browser';
 import { configure, takeSnapshot } from '../dist';
 
@@ -13,4 +14,19 @@ test('in test case name あ', async () => {
   document.body.innerHTML = '<div>Test #2</div>';
 
   await takeSnapshot();
+});
+
+describe('', () => {
+  configure({ title: 'Components/Button', disableAutoSnapshot: false });
+
+  beforeEach(() => {
+    document.body.innerHTML = '<button>Example</button>';
+  });
+
+  test('Primary', () => {});
+  test('Secondary', () => {});
+  test('Hovered', () => {});
+  test('Pressed', () => {});
+  test('Focused', () => {});
+  test('Disabled', () => {});
 });


### PR DESCRIPTION
Issue: Milestone 1 of https://github.com/chromaui/chromatic-e2e/issues/353

See Chromatic projects with this PR changes:
- https://www.chromatic.com/build?appId=69aa98655596f48823e883c7&number=231
- https://www.chromatic.com/build?appId=69d8f64ba22267db6c7c27d6&number=24 (check build 22 to see how it works with `main`/`@chromatic-com/vitest@0.0.8`)

This PR introduces temporary solution for story naming issue. However changes of this PR will never be reverted - the `title` and `stories[].name` need to remain stable. We'll introduce proper long-term fix in https://github.com/chromaui/chromatic-e2e/pull/376 using other fields in the story JSON.

## What Changed

1. `"title"` of a `*.stories.json` is now just the file name, e.g. `src/components/accordion/accordion.test.tsx`. Previously it also contained `(optional test suite) / (test case)`.
2. Story name now contains test suite and test case, postfixed with snapshot name.

<img width="600"   src="https://github.com/user-attachments/assets/b4863ff3-69e9-4f65-89a7-29cc6cfd179f" />


```diff
{
-  "title": "accordion/opens and closes",
+  "title": "accordion",
  "stories": [
    {
-     "name": "default",
+     "name": "opens and closes / default",
      "globals": { ... },
      "parameters": {...}
    },
    {
-     "name": "open",
+     "name": "opens and closes / open",
      "globals": { ... },
      "parameters": {...}
    },
    {
-     "name": "close",
+     "name": "opens and closes / close",
      "globals": { ... },
      "parameters": {...}
    }
  ]
}
``` 

| Before | After |
|---|---|
| <img width="282" height="142" alt="Before" src="https://github.com/user-attachments/assets/1d958507-a846-4589-a940-5544d22cab1f" /> | <img width="282" height="117" alt="After" src="https://github.com/user-attachments/assets/ba0a7344-1dac-45e0-93d0-2dca4776c7db" /> |
| <img width="666" height="687" alt="image" src="https://github.com/user-attachments/assets/111a4c17-bfa8-4b1c-9722-03878f247346" /> | <img width="666" height="684" alt="image" src="https://github.com/user-attachments/assets/ff56b689-b452-4d3f-ad7e-da68b855a337" /> |

Also adds new `title` option in `configure()` API, that can be used to set completely custom title in the story. This is similar as Storybook's `meta.component` property.

<img width="800" src="https://github.com/user-attachments/assets/9da24ec0-475f-4af0-aa29-7e8eab667254" />

This is especially useful in following cases:

- `test/sign-in/Page.test.tsx`
- `test/sign-out/Page.test.tsx`

| Before, inferred title from file path | After, using `configure({ title })` |
|---|---|
| <img width="278" height="366" alt="image" src="https://github.com/user-attachments/assets/2f8e32ef-16a4-481f-9b62-4e5d55e72777" /> | <img width="278" height="366" alt="image" src="https://github.com/user-attachments/assets/ea240929-0e8a-4cfb-9bee-1dd006491fe7" /> |
| <img width="239" height="243" alt="image" src="https://github.com/user-attachments/assets/bac42496-6ca4-4c9d-8914-64626abe3a98" /> | <img width="242" height="239" alt="image" src="https://github.com/user-attachments/assets/ad36e9ff-ef04-45bc-a096-54feb9a346f6" /> |

## How to test

- Preview release https://github.com/chromaui/chromatic-e2e/pull/364#issuecomment-4517514018
- Checkout PR branch locally and check `yarn install; yarn build; yarn test:vitest; yarn archive-storybook:vitest`
