### PR TITLE
refactor: `writeTestResult` to require passing all properties

### DIFF
--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -11,7 +11,7 @@ import { CypressSnapshot } from './types';
 interface WriteParams {
   testTitlePath: string[];
   domSnapshots: CypressSnapshot[];
-  chromaticStorybookParams: ChromaticStorybookParameters;
+  chromaticStorybookParams: Required<ChromaticStorybookParameters>;
   pageUrl: string;
   viewport: Viewport;
   outputDir: string;

--- a/packages/playwright/src/makeTest.ts
+++ b/packages/playwright/src/makeTest.ts
@@ -67,17 +67,6 @@ export const performChromaticSnapshot = async (
     const snapshots: NonNullable<ReturnType<typeof chromaticSnapshots.get>> =
       chromaticSnapshots.get(testId) || new Map();
 
-    const chromaticStorybookParams = {
-      ...(delay && { delay }),
-      ...(diffIncludeAntiAliasing && { diffIncludeAntiAliasing }),
-      ...(diffThreshold && { diffThreshold }),
-      ...(forcedColors && { forcedColors }),
-      ...(pauseAnimationAtEnd && { pauseAnimationAtEnd }),
-      ...(prefersReducedMotion && { prefersReducedMotion }),
-      ...(cropToViewport && { cropToViewport }),
-      ...(ignoreSelectors && { ignoreSelectors }),
-    };
-
     // TestInfo.outputDir gives us the test-specific subfolder (https://playwright.dev/docs/api/class-testconfig#test-config-output-dir);
     // we want to write one level above that
     const outputDir = join(testInfo.outputDir, '..');
@@ -85,7 +74,16 @@ export const performChromaticSnapshot = async (
       { ...testInfo, outputDir, pageUrl: page.url() },
       Object.fromEntries(snapshots),
       resourceArchive,
-      chromaticStorybookParams
+      {
+        delay,
+        diffIncludeAntiAliasing,
+        diffThreshold,
+        forcedColors,
+        pauseAnimationAtEnd,
+        prefersReducedMotion,
+        cropToViewport,
+        ignoreSelectors,
+      }
     );
 
     trackComplete();

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -43,7 +43,10 @@ export interface ChromaticConfig {
   ignoreSelectors?: string[];
 }
 
-export type ChromaticStorybookParameters = Omit<ChromaticConfig, 'disableAutoSnapshot'>;
+export type ChromaticStorybookParameters = Omit<
+  ChromaticConfig,
+  'disableAutoSnapshot' | 'resourceArchiveTimeout' | 'assetDomains'
+>;
 
 export type DOMSnapshots = Record<
   string,

--- a/packages/shared/src/write-archive/index.ts
+++ b/packages/shared/src/write-archive/index.ts
@@ -19,11 +19,16 @@ interface E2ETestInfo {
   pageUrl: string;
 }
 
+// Converts { name?: string } to { name: string | undefined }, so that passing "name" is required
+type RequiredButOptional<T> = {
+  [P in keyof Required<T>]: T[P] | undefined;
+};
+
 export async function writeTestResult(
   e2eTestInfo: E2ETestInfo,
   domSnapshots: DOMSnapshots,
   archive: ResourceArchive,
-  chromaticStorybookParams: ChromaticStorybookParameters
+  chromaticStorybookParams: RequiredButOptional<ChromaticStorybookParameters>
 ) {
   const { titlePath, outputDir, pageUrl } = e2eTestInfo;
   // remove the test file extensions (.spec.ts|ts, .cy.ts|js), preserving other periods in directory, file name, or test titles


### PR DESCRIPTION
Issue: Follow-up from https://github.com/chromaui/chromatic-e2e/pull/358#discussion_r3273452490

## What Changed

Make `writeTestResult` to require passing all properties, but allow passing `undefined` as value.

```ts
// OK:
writeTestResult({
  delay: undefined,
  diffIncludeAntiAliasing: undefined,
  diffThreshold: undefined,
  disableAutoSnapshot: undefined,
  forcedColors: undefined,
  pauseAnimationAtEnd: undefined,
  prefersReducedMotion: undefined,
  resourceArchiveTimeout: undefined,
  assetDomains: undefined,
  cropToViewport: undefined,
  ignoreSelectors: undefined,
});

// Type errors:
writeTestResult({
  delay: undefined,
});
```

## How to test

Build passes