### PR TITLE
fix: prevent Storybook load failure for non-ASCII story names

### DIFF
--- a/.changeset/late-windows-speak.md
+++ b/.changeset/late-windows-speak.md
@@ -1,0 +1,8 @@
+---
+'@chromatic-com/playwright': patch
+'@chromatic-com/cypress': patch
+'@chromatic-com/shared-e2e': patch
+'@chromatic-com/vitest': patch
+---
+
+Fix: Prevent Storybook load failure for non-ASCII story names

--- a/packages/cypress/tests/cypress/e2e/snapshot-names.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/snapshot-names.cy.ts
@@ -1,0 +1,11 @@
+it('in snapshot name', { env: { disableAutoSnapshot: true } }, () => {
+  cy.visit('/');
+
+  cy.takeSnapshot('あ');
+});
+
+it('in test case name あ', { env: { disableAutoSnapshot: true } }, () => {
+  cy.visit('/');
+
+  cy.takeSnapshot();
+});

--- a/packages/playwright/src/makeTest.test.ts
+++ b/packages/playwright/src/makeTest.test.ts
@@ -31,7 +31,7 @@ describe('makeTest', () => {
   });
 
   const mockTestInfo: Partial<TestInfo> = {
-    titlePath: [],
+    titlePath: ['example'],
     outputDir: '',
     testId: 'a',
   };

--- a/packages/playwright/tests/snapshot-names.spec.ts
+++ b/packages/playwright/tests/snapshot-names.spec.ts
@@ -1,0 +1,17 @@
+import { test, takeSnapshot } from '../src';
+
+test.describe('', () => {
+  test.use({ disableAutoSnapshot: true });
+
+  test('in snapshot name', async ({ page }, testInfo) => {
+    await page.goto('/');
+
+    await takeSnapshot(page, 'あ', testInfo);
+  });
+
+  test('in test case name あ', async ({ page }, testInfo) => {
+    await page.goto('/');
+
+    await takeSnapshot(page, testInfo);
+  });
+});

--- a/packages/shared/src/write-archive/index.test.ts
+++ b/packages/shared/src/write-archive/index.test.ts
@@ -64,6 +64,7 @@ describe('writeTestResult', () => {
             name: 'home',
             globals: { viewport: 'w800h800' },
             parameters: {
+              __id: 'file-test-story--home',
               chromatic: {
                 diffThreshold: 5,
                 pauseAnimationAtEnd: true,

--- a/packages/shared/src/write-archive/stories-files.test.ts
+++ b/packages/shared/src/write-archive/stories-files.test.ts
@@ -59,6 +59,7 @@ describe('createStories', () => {
           name: 'snapshot 1',
           globals: { viewport: 'w100h200' },
           parameters: {
+            __id: 'some-test-title--snapshot-1',
             server: { id: 'some-test-title-snapshot-1' },
             chromatic: {
               delay: 200,
@@ -88,6 +89,7 @@ describe('createStories', () => {
           name: 'another snapshot',
           globals: { viewport: 'w300h400' },
           parameters: {
+            __id: 'some-test-title--another-snapshot',
             server: { id: 'some-test-title-another-snapshot' },
             chromatic: {
               delay: 200,

--- a/packages/shared/src/write-archive/stories-files.ts
+++ b/packages/shared/src/write-archive/stories-files.ts
@@ -1,3 +1,4 @@
+import { storyNameFromExport, toId } from 'storybook/internal/csf';
 import type { ChromaticStorybookParameters, DOMSnapshots } from '../types';
 import { snapshotId } from './snapshot-files';
 import { collapseNewlines, sanitize } from './storybook-sanitize';
@@ -29,6 +30,9 @@ export function createStories(
       // `defaultViewport` is not read by SB 10's types but our archive preview uses it as a fetch fallback.
       globals: { viewport: viewportToString(viewport) },
       parameters: {
+        // Work-around for cases where "あ" in story name would cause Storybook to fail to load the story due to an invalid story ID.
+        // See https://github.com/chromaui/chromatic-e2e/issues/365
+        __id: toId(title, storyNameFromExport(name)),
         server: { id: snapshotId(title, name) },
         chromatic: {
           ...chromaticStorybookParams,

--- a/packages/shared/src/write-archive/stories-files.ts
+++ b/packages/shared/src/write-archive/stories-files.ts
@@ -17,33 +17,39 @@ export function storiesFileName(testTitle: string) {
 
 // Converts the DOM snapshots into a JSON stories file.
 export function createStories(
-  title: string,
+  storyTitle: string,
   domSnapshots: DOMSnapshots,
   chromaticStorybookParams: ChromaticStorybookParameters
 ) {
+  const title = collapseNewlines(storyTitle);
+
   return {
-    title: collapseNewlines(title),
-    stories: Object.entries(domSnapshots).map(([name, { viewport }]) => ({
-      name: collapseNewlines(name),
-      // Viewport addon (Storybook 10+): `parameters.viewport.options` registers sizes; `globals.viewport`
-      // selects the active one. See https://storybook.js.org/docs/essentials/viewport#defining-the-viewport-for-a-story
-      // `defaultViewport` is not read by SB 10's types but our archive preview uses it as a fetch fallback.
-      globals: { viewport: viewportToString(viewport) },
-      parameters: {
-        // Work-around for cases where "あ" in story name would cause Storybook to fail to load the story due to an invalid story ID.
-        // See https://github.com/chromaui/chromatic-e2e/issues/365
-        __id: toId(title, storyNameFromExport(name)),
-        server: { id: snapshotId(title, name) },
-        chromatic: {
-          ...chromaticStorybookParams,
-          modes: buildStoryModesConfig([viewport]),
+    title,
+    stories: Object.entries(domSnapshots).map(([snapshotName, { viewport }]) => {
+      const name = collapseNewlines(snapshotName);
+
+      return {
+        name,
+        // Viewport addon (Storybook 10+): `parameters.viewport.options` registers sizes; `globals.viewport`
+        // selects the active one. See https://storybook.js.org/docs/essentials/viewport#defining-the-viewport-for-a-story
+        // `defaultViewport` is not read by SB 10's types but our archive preview uses it as a fetch fallback.
+        globals: { viewport: viewportToString(viewport) },
+        parameters: {
+          // Work-around for cases where "あ" in story name would cause Storybook to fail to load the story due to an invalid story ID.
+          // See https://github.com/chromaui/chromatic-e2e/issues/365
+          __id: toId(title, storyNameFromExport(name)),
+          server: { id: snapshotId(title, name) },
+          chromatic: {
+            ...chromaticStorybookParams,
+            modes: buildStoryModesConfig([viewport]),
+          },
+          viewport: {
+            options: buildStoryViewportsConfig([viewport]),
+            defaultViewport: viewportToString(findDefaultViewport([viewport])),
+          },
         },
-        viewport: {
-          options: buildStoryViewportsConfig([viewport]),
-          defaultViewport: viewportToString(findDefaultViewport([viewport])),
-        },
-      },
-    })),
+      };
+    }),
   };
 }
 

--- a/packages/vitest/test/snapshot-names.test.ts
+++ b/packages/vitest/test/snapshot-names.test.ts
@@ -1,0 +1,16 @@
+import { test } from './utils/browser';
+import { configure, takeSnapshot } from '../dist';
+
+configure({ disableAutoSnapshot: true });
+
+test('in snapshot name', async () => {
+  document.body.innerHTML = '<div>Test #1</div>';
+
+  await takeSnapshot('あ');
+});
+
+test('in test case name あ', async () => {
+  document.body.innerHTML = '<div>Test #2</div>';
+
+  await takeSnapshot();
+});


### PR DESCRIPTION
Issue:
- Fixes https://github.com/chromaui/chromatic-e2e/issues/365

## What Changed

Claude code figured out we can populate `parameters.__id` early so that Storybook doesn't fallback to some other logic. This is quite fragile, but as we already pin Storybook version and "bundle" it in `/embedded`, it's maintainable. 

## How to test

- Chromatic links in PR's CI open and show correct UI
- `yarn install; yarn build; yarn test:playwright; yarn archive-storybook:playwright`