### PR TITLE
fix: stories with newlines don't open in Storybook

### DIFF
--- a/.changeset/brown-points-reply.md
+++ b/.changeset/brown-points-reply.md
@@ -1,0 +1,8 @@
+---
+'@chromatic-com/shared-e2e': patch
+'@chromatic-com/cypress': patch
+'@chromatic-com/playwright': patch
+'@chromatic-com/vitest': patch
+---
+
+Fix: Trim newlines from story titles

--- a/packages/cypress/tests/cypress/e2e/newline-test-names.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/newline-test-names.cy.ts
@@ -6,4 +6,9 @@ newlines
   it('Are\n\rRemoved\r\nFrom\nFile\rNames\n\n\r\r', () => {
     cy.visit('/');
   });
+
+  it('newlines in snapshot name', { env: { disableAutoSnapshot: true } }, () => {
+    cy.visit('/');
+    cy.takeSnapshot('snapshot name\nwith newlines\r\nand carriage returns');
+  });
 });

--- a/packages/playwright/tests/newline-test-names.spec.ts
+++ b/packages/playwright/tests/newline-test-names.spec.ts
@@ -1,11 +1,19 @@
-import { test } from '../src';
+import { takeSnapshot, test } from '../src';
 
 test.describe(`
 Test
 name
 newlines
 `, () => {
-  test('Are\n\rRemoved\r\nFrom\nFile\rNames\n\n\r\r', async ({ page }) => {
+  test.use({ disableAutoSnapshot: true });
+
+  test('Are\n\rRemoved\r\nFrom\nFile\rNames\n\n\r\r', async ({ page }, testInfo) => {
     await page.goto('/');
+    await takeSnapshot(page, testInfo);
+  });
+
+  test('newlines in snapshot name', async ({ page }, testInfo) => {
+    await page.goto('/');
+    await takeSnapshot(page, 'snapshot name\nwith newlines\r\nand carriage returns', testInfo);
   });
 });

--- a/packages/shared/src/write-archive/stories-files.test.ts
+++ b/packages/shared/src/write-archive/stories-files.test.ts
@@ -116,6 +116,16 @@ describe('createStories', () => {
       ],
     });
   });
+
+  it('collapses newlines in title', () => {
+    const storiesFileJSON = storiesFiles.createStories(
+      '\n\n\r\rThere\nShould\rBe\r\nNo\n\rNewlines\r\r\n\n',
+      {},
+      {}
+    );
+
+    expect(storiesFileJSON.title).toEqual(' There Should Be No Newlines ');
+  });
 });
 
 describe('buildStoryModesConfig', () => {

--- a/packages/shared/src/write-archive/stories-files.test.ts
+++ b/packages/shared/src/write-archive/stories-files.test.ts
@@ -124,7 +124,22 @@ describe('createStories', () => {
       {}
     );
 
-    expect(storiesFileJSON.title).toEqual(' There Should Be No Newlines ');
+    expect(storiesFileJSON.title).toEqual('There Should Be No Newlines');
+  });
+
+  it('collapses newlines in story names', () => {
+    const storiesFileJSON = storiesFiles.createStories(
+      'Some Title',
+      {
+        '\n\n\r\rSnapshot\nName\rWith\r\nNewlines\n\r\r\n': {
+          snapshot: Buffer.from('n/a'),
+          viewport: { width: 100, height: 200 },
+        },
+      },
+      {}
+    );
+
+    expect(storiesFileJSON.stories[0].name).toEqual('Snapshot Name With Newlines');
   });
 });
 

--- a/packages/shared/src/write-archive/stories-files.ts
+++ b/packages/shared/src/write-archive/stories-files.ts
@@ -1,6 +1,6 @@
 import type { ChromaticStorybookParameters, DOMSnapshots } from '../types';
 import { snapshotId } from './snapshot-files';
-import { sanitize } from './storybook-sanitize';
+import { collapseNewlines, sanitize } from './storybook-sanitize';
 import { Viewport, viewportToString } from '../utils/viewport';
 import { MAX_FILE_NAME_BYTE_LENGTH, truncateFileName } from '../utils/filePaths';
 
@@ -21,9 +21,9 @@ export function createStories(
   chromaticStorybookParams: ChromaticStorybookParameters
 ) {
   return {
-    title: title.replace(/[\r\n]+/g, ' '),
+    title: collapseNewlines(title),
     stories: Object.entries(domSnapshots).map(([name, { viewport }]) => ({
-      name,
+      name: collapseNewlines(name),
       // Viewport addon (Storybook 10+): `parameters.viewport.options` registers sizes; `globals.viewport`
       // selects the active one. See https://storybook.js.org/docs/essentials/viewport#defining-the-viewport-for-a-story
       // `defaultViewport` is not read by SB 10's types but our archive preview uses it as a fetch fallback.

--- a/packages/shared/src/write-archive/stories-files.ts
+++ b/packages/shared/src/write-archive/stories-files.ts
@@ -21,7 +21,7 @@ export function createStories(
   chromaticStorybookParams: ChromaticStorybookParameters
 ) {
   return {
-    title,
+    title: title.replace(/[\r\n]+/g, ' '),
     stories: Object.entries(domSnapshots).map(([name, { viewport }]) => ({
       name,
       // Viewport addon (Storybook 10+): `parameters.viewport.options` registers sizes; `globals.viewport`

--- a/packages/shared/src/write-archive/storybook-sanitize.ts
+++ b/packages/shared/src/write-archive/storybook-sanitize.ts
@@ -12,3 +12,6 @@ export const sanitize = (string: string) => {
       .replace(/-+$/, '')
   );
 };
+
+// Collapses CR/LF in a display title to a single space. Required for https://github.com/chromaui/chromatic-e2e/issues/369.
+export const collapseNewlines = (title: string) => title.replace(/[\r\n]+/g, ' ').trim();

--- a/packages/vitest/test/newline-test-names.test.ts
+++ b/packages/vitest/test/newline-test-names.test.ts
@@ -1,5 +1,6 @@
 import { describe } from 'vitest';
 import { test } from './utils/browser';
+import { configure, takeSnapshot } from '../dist';
 
 describe(`
 Test
@@ -9,4 +10,10 @@ newlines
   test.override({ url: '/test-server-root' });
 
   test('Are\n\rRemoved\r\nFrom\nFile\rNames\n\n\r\r', async () => {});
+
+  test('newlines in snapshot name', async () => {
+    configure({ disableAutoSnapshot: true });
+
+    await takeSnapshot('snapshot name\nwith newlines\r\nand carriage returns');
+  });
 });


### PR DESCRIPTION
Issue:
- Fixes https://github.com/chromaui/chromatic-e2e/issues/369

## What Changed

Please read the #369 for bug description too.

Story generated by this test fails to open on `main` branch's Storybook:

https://github.com/chromaui/chromatic-e2e/blob/16d2327dc209d6b505e6de928c98c99d8f65cc34/packages/playwright/tests/newline-test-names.spec.ts#L1-L11

- https://653fef099b8957739e7534a4-ezrmyiapvp.chromatic.com/?path=/story/newline-test-names-testnamenewlines-areremovedfromfilenames--snapshot-1


## How to test

Storybook of this PR opens same story fine:
- https://653fef099b8957739e7534a4-vjbetuaysv.chromatic.com/?path=/story/newline-test-names-test-name-newlines-are-removed-from-file-names--snapshot-1&globals=viewport.value:w1280h720
