### PR TITLE
feat(vitest): add suites, test and snapshot name in Story JSON `parameters`

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -63,7 +63,7 @@ export type DOMSnapshots = Record<
     >;
 
     /** Optional parameters for the Story JSON */
-    parameters?: Record<string, unknown>;
+    parameters?: Record<string, unknown> & { chromatic?: Record<string, unknown> };
   }
 >;
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -61,6 +61,9 @@ export type DOMSnapshots = Record<
     pseudoClassIds: Partial<
       Record<':active' | ':focus' | ':focus-visible' | ':hover', serializedNodeWithId['id'][]>
     >;
+
+    /** Optional parameters for the Story JSON */
+    parameters?: Record<string, unknown>;
   }
 >;
 

--- a/packages/shared/src/write-archive/stories-files.ts
+++ b/packages/shared/src/write-archive/stories-files.ts
@@ -27,7 +27,7 @@ export function createStories(
 
   return {
     title,
-    stories: Object.entries(domSnapshots).map(([snapshotName, { viewport }]) => {
+    stories: Object.entries(domSnapshots).map(([snapshotName, { viewport, parameters }]) => {
       const name = collapseNewlines(snapshotName);
 
       return {
@@ -49,6 +49,8 @@ export function createStories(
             options: buildStoryViewportsConfig([viewport]),
             defaultViewport: viewportToString(findDefaultViewport([viewport])),
           },
+
+          ...parameters,
         },
       };
     }),

--- a/packages/shared/src/write-archive/stories-files.ts
+++ b/packages/shared/src/write-archive/stories-files.ts
@@ -29,6 +29,7 @@ export function createStories(
     title,
     stories: Object.entries(domSnapshots).map(([snapshotName, { viewport, parameters }]) => {
       const name = collapseNewlines(snapshotName);
+      const { chromatic: chromaticParams, ...restParameters } = parameters || {};
 
       return {
         name,
@@ -43,6 +44,7 @@ export function createStories(
           server: { id: snapshotId(title, name) },
           chromatic: {
             ...chromaticStorybookParams,
+            ...chromaticParams,
             modes: buildStoryModesConfig([viewport]),
           },
           viewport: {
@@ -50,7 +52,7 @@ export function createStories(
             defaultViewport: viewportToString(findDefaultViewport([viewport])),
           },
 
-          ...parameters,
+          ...restParameters,
         },
       };
     }),

--- a/packages/vitest/src/node/commands.test.ts
+++ b/packages/vitest/src/node/commands.test.ts
@@ -73,3 +73,61 @@ test('writes test results with DOM snapshot', async () => {
     ]
   `);
 });
+
+test('writes test results with custom parameters', async () => {
+  /** See {@link file://./../../test/fixtures/take-snapshot.test.ts} */
+  await runFixture({ include: ['take-snapshot.test.ts'], provide: { testName: 'five' } });
+
+  const snapshots = vi.mocked(shared.writeTestResult).mock.calls.map((call) => call[1]);
+  const parameters = snapshots
+    .map((snapshot) => Object.values(snapshot).map((s) => s.parameters.vitest))
+    .flat();
+
+  expect(parameters).toMatchInlineSnapshot(`
+    [
+      {
+        "snapshot": "Named snapshot #1",
+        "suites": [
+          "suite #2",
+          "suite #3",
+          "suite #4",
+        ],
+        "test": "test #5",
+      },
+      {
+        "snapshot": "Named snapshot #2",
+        "suites": [
+          "suite #2",
+          "suite #3",
+          "suite #4",
+        ],
+        "test": "test #5",
+      },
+      {
+        "snapshot": "Snapshot #3",
+        "suites": [
+          "suite #2",
+          "suite #3",
+          "suite #4",
+        ],
+        "test": "test #5",
+      },
+      {
+        "snapshot": "Snapshot #1",
+        "suites": [
+          "suite #2",
+          "suite #3",
+        ],
+        "test": "test #6",
+      },
+      {
+        "snapshot": "Snapshot #2",
+        "suites": [
+          "suite #2",
+          "suite #3",
+        ],
+        "test": "test #6",
+      },
+    ]
+  `);
+});

--- a/packages/vitest/src/node/commands.test.ts
+++ b/packages/vitest/src/node/commands.test.ts
@@ -80,7 +80,7 @@ test('writes test results with custom parameters', async () => {
 
   const snapshots = vi.mocked(shared.writeTestResult).mock.calls.map((call) => call[1]);
   const parameters = snapshots
-    .map((snapshot) => Object.values(snapshot).map((s) => s.parameters.vitest))
+    .map((snapshot) => Object.values(snapshot).map((s) => s.parameters.chromatic.vitest))
     .flat();
 
   expect(parameters).toMatchInlineSnapshot(`

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -5,7 +5,12 @@ import { type PlaywrightProviderOptions } from '@vitest/browser-playwright';
 import { type Task } from '@vitest/runner/types';
 import { type serializedNodeWithId } from '@rrweb/types';
 import { ResourceArchiver, writeTestResult, type DOMSnapshots } from '@chromatic-com/shared-e2e';
-import { type ChromaticNamespace, type ConfigureOptions, type ResolvedOptions } from '../types';
+import {
+  type StoryParameters,
+  type ChromaticNamespace,
+  type ConfigureOptions,
+  type ResolvedOptions,
+} from '../types';
 import { NetworkIdleTracker } from './NetworkIdleTracker';
 import { ChromaticReporter } from './reporter';
 
@@ -133,12 +138,14 @@ export function createCommands(options: ResolvedOptions) {
           viewport,
           pseudoClassIds,
           parameters: {
-            vitest: {
-              suites: getSuiteNames(entity),
-              test: entity.name,
-              snapshot: name,
+            chromatic: {
+              vitest: {
+                suites: getSuiteNames(entity),
+                test: entity.name,
+                snapshot: name,
+              },
             },
-          },
+          } satisfies StoryParameters,
         };
       }
 

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -132,6 +132,13 @@ export function createCommands(options: ResolvedOptions) {
           snapshot: Buffer.from(JSON.stringify(snapshot)),
           viewport,
           pseudoClassIds,
+          parameters: {
+            vitest: {
+              suites: getSuiteNames(entity),
+              test: entity.name,
+              snapshot: name,
+            },
+          },
         };
       }
 
@@ -223,6 +230,25 @@ function getSnapshotPrefix(test: TestCase): string[] {
     current = current.parent;
 
     if ('name' in current && current.name) {
+      names.unshift(current.name);
+    }
+  }
+
+  return names;
+}
+
+function getSuiteNames(test: TestCase): string[] {
+  if (test.parent.type !== 'suite') {
+    return [];
+  }
+
+  const names = [];
+  let current: TestCase | TestSuite | TestModule = test;
+
+  while ('parent' in current && current.parent) {
+    current = current.parent;
+
+    if (current.type === 'suite') {
       names.unshift(current.name);
     }
   }

--- a/packages/vitest/src/types.ts
+++ b/packages/vitest/src/types.ts
@@ -61,6 +61,20 @@ export interface Options extends ChromaticConfig {
       };
 }
 
+/** Additional `parameters` added into the Story JSON file. */
+export interface StoryParameters {
+  vitest: {
+    /** Names of all `describe()` blocks, if any */
+    suites: string[];
+
+    /** Name of the `test()` */
+    test: string;
+
+    /** Name of the snapshot */
+    snapshot: string;
+  };
+}
+
 /** Options that don't have internal default values */
 type UnresolvedOptionKeys = 'tags' | Exclude<keyof ChromaticConfig, 'resourceArchiveTimeout'>;
 

--- a/packages/vitest/src/types.ts
+++ b/packages/vitest/src/types.ts
@@ -63,15 +63,17 @@ export interface Options extends ChromaticConfig {
 
 /** Additional `parameters` added into the Story JSON file. */
 export interface StoryParameters {
-  vitest: {
-    /** Names of all `describe()` blocks, if any */
-    suites: string[];
+  chromatic: {
+    vitest: {
+      /** Names of all `describe()` blocks, if any */
+      suites: string[];
 
-    /** Name of the `test()` */
-    test: string;
+      /** Name of the `test()` */
+      test: string;
 
-    /** Name of the snapshot */
-    snapshot: string;
+      /** Name of the snapshot */
+      snapshot: string;
+    };
   };
 }
 

--- a/packages/vitest/test/fixtures/take-snapshot.test.ts
+++ b/packages/vitest/test/fixtures/take-snapshot.test.ts
@@ -29,3 +29,19 @@ test.runIf(inject('testName') === 'three')('test #3', async () => {
 test.runIf(inject('testName') === 'four')('test #4', async () => {
   document.body.innerHTML = '<h1>Example heading</h1>';
 });
+
+describe.runIf(inject('testName') === 'five')('suite #2', async () => {
+  describe('suite #3', () => {
+    describe('suite #4', () => {
+      test('test #5', async () => {
+        document.body.innerHTML = '<h1>Example heading</h1>';
+        await takeSnapshot('Named snapshot #1');
+        await takeSnapshot('Named snapshot #2');
+      });
+    });
+
+    test('test #6', async () => {
+      await takeSnapshot();
+    });
+  });
+});

--- a/packages/vitest/test/snapshot-names.test.ts
+++ b/packages/vitest/test/snapshot-names.test.ts
@@ -16,6 +16,31 @@ test('in test case name あ', async () => {
   await takeSnapshot();
 });
 
+describe('interactive', () => {
+  configure({ disableAutoSnapshot: false });
+
+  describe('keyboard', () => {
+    configure({ disableAutoSnapshot: true });
+
+    test('opens and closes', async () => {
+      await takeSnapshot('default');
+      await takeSnapshot('open');
+      await takeSnapshot('close');
+    });
+
+    test('toggled via space and enter', async () => {
+      await takeSnapshot('default');
+      await takeSnapshot('toggle with space');
+      await takeSnapshot('toggle with enter');
+    });
+  });
+
+  describe('mouse', () => {
+    test('opens and closes', async () => {});
+    test('can be dragged', async () => {});
+  });
+});
+
 describe('', () => {
   configure({ title: 'Components/Button', disableAutoSnapshot: false });
 


### PR DESCRIPTION
Issue: Milestone 1 of https://github.com/chromaui/chromatic-e2e/issues/353.

## What Changed

Adds new `parameters.chromatic.vitest` into the Story JSON file:

```diff
{
  "title": "test/Accordion",
  "stories": [
    {
      "name": "interactive / mouse / can be dragged / Snapshot #1",
      "globals": { "viewport": "w1280h720" },
      "parameters": {
        "__id": "test-accordion-interactive-mouse-can-be-dragged--snapshot-1",
        "server": { "id": "test-accordion-interactive-mouse-can-be-dragged-snapshot-1" },
        "chromatic": { 
          "modes": { "w1280h720": { "viewport": "w1280h720" } },
+         "vitest": {
+           "suites": ["interactive", "mouse"],
+           "test": "can be dragged",
+           "snapshot": "Snapshot #1"
+         }
        },
        "viewport": { ... },
      }
    }
  ]
}
```

- `parameters.chromatic.vitest.suites: string[]`: contains the names of `describe()` calls of the test case where the snapshot originated from. Can be an empty array if no `describe()` was used.
- `parameters.chromatic.vitest.test: string`: contains the name of `test()` call of the test case where the snapshot originated from.
- `parameters.chromatic.vitest.snapshot: string`: contains the name of `takeSnapshot()` or `Snapshot #<running-number>` if no name was passed.


```js
describe("one", () => {
  describe("two", () => {
    test("three", async () => {
      await takeSnapshot("four");
    });
  });
});

test("example of autosnapshot", () => {});
```

```json
{
  "suites": ["one", "two"],
  "test": "three",
  "snapshot": "four"
},
{
  "suites": [],
  "test": "example of autosnapshot",
  "snapshot": "Snapshot #1"
}
```

Note: Screenshot below is using old implementation with `parameters.vitest`. All parameters are in `parameters.chromatic.vitest` now. 
<img width="881" height="1059" alt="image" src="https://github.com/user-attachments/assets/8b229062-a7e0-4a20-92f4-d6b863d2e1b7" />


## How to test

- Added test cases to verify `parameters` content
- Preview build: https://github.com/chromaui/chromatic-e2e/pull/376#issuecomment-4574373945