### PR TITLE
feat(vitest): add test reporter

### DIFF
--- a/.changeset/forty-ends-sniff.md
+++ b/.changeset/forty-ends-sniff.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Feat: Add test reporter

--- a/packages/vitest/src/node/commands.browser.test.ts
+++ b/packages/vitest/src/node/commands.browser.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, inject } from 'vitest';
+import { test, expect } from 'vitest';
 import { commands } from 'vitest/browser';
 import { InternalTestContext } from '../types';
 
@@ -27,15 +27,16 @@ test('browser commands are available', () => {
 });
 
 test('getOptions', async () => {
-  const options = await commands.__chromatic_getOptions();
-  options.outputDirectory = options.outputDirectory.replace(inject('processCwd'), '<process-cwd>');
-
-  expect(options).toMatchInlineSnapshot(`
+  await expect(commands.__chromatic_getOptions()).resolves.toMatchInlineSnapshot(`
     {
       "assetDomains": [],
       "disableAutoSnapshot": false,
       "idleNetworkInterval": 100,
       "outputDirectory": ".vitest/chromatic",
+      "reporter": {
+        "enabled": true,
+        "verbose": true,
+      },
       "resourceArchiveTimeout": 10000,
     }
   `);

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -7,6 +7,7 @@ import { type serializedNodeWithId } from '@rrweb/types';
 import { ResourceArchiver, writeTestResult, type DOMSnapshots } from '@chromatic-com/shared-e2e';
 import { type ChromaticNamespace, type ConfigureOptions, type ResolvedOptions } from '../types';
 import { NetworkIdleTracker } from './NetworkIdleTracker';
+import { ChromaticReporter } from './reporter';
 
 type TestID = Task['id'];
 type SnapshotName = keyof DOMSnapshots;
@@ -46,6 +47,12 @@ export function createCommands(options: ResolvedOptions) {
       pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'],
       name?: string
     ) {
+      const entity = context.project.vitest.state.getReportedEntityById(id);
+      assert(
+        entity?.type === 'test',
+        `Expected entity with id ${id} to be a test, found ${entity?.type}`
+      );
+
       let sessionSnapshots = snapshots.get(id);
 
       if (!sessionSnapshots) {
@@ -62,6 +69,8 @@ export function createCommands(options: ResolvedOptions) {
       }));
 
       sessionSnapshots.set(name, { snapshot, viewport, pseudoClassIds });
+
+      ChromaticReporter.onSnapshot(context.project.vitest, entity);
     },
 
     /**

--- a/packages/vitest/src/node/plugin.ts
+++ b/packages/vitest/src/node/plugin.ts
@@ -5,6 +5,7 @@ import type { Vite } from 'vitest/node';
 import colors from 'tinyrainbow';
 import { DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS } from '@chromatic-com/shared-e2e';
 import { createCommands } from './commands';
+import { ChromaticReporter } from './reporter';
 import { DEFAULT_OUTPUT_DIR } from '../constants';
 import { type ResolvedOptions, type Options } from '../types';
 
@@ -21,6 +22,7 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
     resourceArchiveTimeout: DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS,
     idleNetworkInterval: 100,
     ...userOptions,
+    reporter: resolveReporterOptions(userOptions.reporter),
   };
 
   const isDist = import.meta.url.includes('dist/plugin.js');
@@ -53,6 +55,10 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
       // browser.name is instances[].browser, not instances[].name: https://github.com/vitest-dev/vitest/blob/d22b029ae056b9515033d75c1249e9db26612770/packages/vitest/src/node/projects/resolveProjects.ts#L307
       if (!browser.enabled || browser.name !== 'chromium') {
         return clean();
+      }
+
+      if (options.reporter.enabled) {
+        ChromaticReporter.apply(context.vitest, options);
       }
 
       // Ensure our setup file is registered first so that afterEach runs before any user-defined hooks.
@@ -109,5 +115,20 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
         });
       }
     },
+  };
+}
+
+function resolveReporterOptions(reporter: Options['reporter']): ResolvedOptions['reporter'] {
+  if (reporter == undefined || reporter === true) {
+    return { enabled: true, verbose: true };
+  }
+
+  if (reporter === false) {
+    return { enabled: false, verbose: false };
+  }
+
+  return {
+    enabled: reporter.enabled ?? true,
+    verbose: reporter.verbose ?? true,
   };
 }

--- a/packages/vitest/src/node/reporter.test.ts
+++ b/packages/vitest/src/node/reporter.test.ts
@@ -1,0 +1,228 @@
+import { existsSync, rmSync } from 'node:fs';
+import { normalize, resolve } from 'node:path';
+import { expect, onTestFinished, test, vi } from 'vitest';
+import * as shared from '@chromatic-com/shared-e2e';
+import { runFixture as baseRunFixture, StableTestFileOrderSorter } from '../../test/utils/node';
+import { DEFAULT_OUTPUT_DIR } from '../constants';
+
+vi.mock('@chromatic-com/shared-e2e');
+vi.mocked(shared.writeTestResult).mockImplementation(() => Promise.resolve());
+
+test('default reporter', async () => {
+  const { stdout } = await runFixture({ reporters: 'default' });
+
+  expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
+    " RUN  v[...] <process-cwd>/packages/vitest/test/fixtures
+
+     ✓  chromium  reporter-1.test.ts (3 tests) <time>
+                  (6 archives captured)
+     ✓  chromium  reporter-2.test.ts (4 tests) <time>
+                  (8 archives captured)
+     ✓  chromium  reporter-3.test.ts (5 tests) <time>
+                  (10 archives captured)
+    "
+  `);
+});
+
+test('tree reporter', async () => {
+  const { stdout } = await runFixture({ reporters: 'tree' });
+
+  expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
+    " RUN  v[...] <process-cwd>/packages/vitest/test/fixtures
+
+     ✓  chromium  reporter-1.test.ts (3 tests) <time>
+       ✓ test #1 <time>
+       ✓ test #2 <time>
+       ✓ test #3 <time>
+       (6 archives captured)
+     ✓  chromium  reporter-2.test.ts (4 tests) <time>
+       ✓ test #1 <time>
+       ✓ test #2 <time>
+       ✓ test #3 <time>
+       ✓ test #4 <time>
+       (8 archives captured)
+     ✓  chromium  reporter-3.test.ts (5 tests) <time>
+       ✓ test #1 <time>
+       ✓ test #2 <time>
+       ✓ test #3 <time>
+       ✓ test #4 <time>
+       ✓ test #5 <time>
+       (10 archives captured)
+    "
+  `);
+});
+
+test('verbose reporter', async () => {
+  const { stdout } = await runFixture({ reporters: 'verbose' });
+
+  expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
+    " RUN  v[...] <process-cwd>/packages/vitest/test/fixtures
+
+     ✓  chromium  reporter-1.test.ts > test #1 <time>
+                  (2 archives captured)
+     ✓  chromium  reporter-1.test.ts > test #2 <time>
+                  (2 archives captured)
+     ✓  chromium  reporter-1.test.ts > test #3 <time>
+                  (2 archives captured)
+     ✓  chromium  reporter-2.test.ts > test #1 <time>
+                  (2 archives captured)
+     ✓  chromium  reporter-2.test.ts > test #2 <time>
+                  (2 archives captured)
+     ✓  chromium  reporter-2.test.ts > test #3 <time>
+                  (2 archives captured)
+     ✓  chromium  reporter-2.test.ts > test #4 <time>
+                  (2 archives captured)
+     ✓  chromium  reporter-3.test.ts > test #1 <time>
+                  (2 archives captured)
+     ✓  chromium  reporter-3.test.ts > test #2 <time>
+                  (2 archives captured)
+     ✓  chromium  reporter-3.test.ts > test #3 <time>
+                  (2 archives captured)
+     ✓  chromium  reporter-3.test.ts > test #4 <time>
+                  (2 archives captured)
+     ✓  chromium  reporter-3.test.ts > test #5 <time>
+                  (2 archives captured)
+    "
+  `);
+});
+
+test.each(['default', 'tree', 'verbose'] as const)(
+  '%s reporter with { verbose: false }',
+  async (builtInReporter) => {
+    const { stdout } = await runFixture(
+      { reporters: builtInReporter },
+      { reporter: { verbose: false } }
+    );
+
+    const output = trimReporterOutput(stdout);
+
+    expect(output).not.toContain('archive');
+    expect(output).not.toContain('captured');
+  }
+);
+
+test('summary when default root', async () => {
+  onTestFinished(() => {
+    const reports = resolve(process.cwd(), DEFAULT_OUTPUT_DIR);
+
+    if (existsSync(reports)) {
+      rmSync(reports, { recursive: true, force: true });
+    }
+  });
+
+  const { stdout } = await runFixture({ reporters: 'default', root: process.cwd() });
+
+  expect(trimSummary(stdout)).toMatchInlineSnapshot(`
+    "Chromatic Visual Regression
+
+    ✓ 24 archives captured
+
+    Archives saved in <process-cwd>/.vitest/chromatic
+    To upload archives into Chromatic run chromatic --vitest --project-token=<TOKEN>"
+  `);
+});
+
+test('summary when custom root', async () => {
+  const { stdout } = await runFixture({ reporters: 'default' });
+
+  expect(trimSummary(stdout)).toMatchInlineSnapshot(`
+    "Chromatic Visual Regression
+
+    ✓ 24 archives captured
+
+    Archives saved in <process-cwd>/packages/vitest/test/fixtures/.vitest/chromatic
+    To upload archives into Chromatic run CHROMATIC_ARCHIVE_LOCATION=packages/vitest/test/fixtures/.vitest/chromatic chromatic --vitest --project-token=<TOKEN>"
+  `);
+});
+
+test('summary when custom output directory', async () => {
+  const outputDirectory = '.vitest/custom-output-directory';
+
+  onTestFinished(() => {
+    const reports = resolve(process.cwd(), outputDirectory);
+
+    if (existsSync(reports)) {
+      rmSync(reports, { recursive: true, force: true });
+    }
+  });
+
+  const { stdout } = await runFixture(
+    { reporters: 'default', root: process.cwd() },
+    { outputDirectory }
+  );
+
+  expect(trimSummary(stdout)).toMatchInlineSnapshot(`
+    "Chromatic Visual Regression
+
+    ✓ 24 archives captured
+
+    Archives saved in <process-cwd>/.vitest/custom-output-directory
+    To upload archives into Chromatic run CHROMATIC_ARCHIVE_LOCATION=.vitest/custom-output-directory chromatic --vitest --project-token=<TOKEN>"
+  `);
+});
+
+test('reporter can be disabled', async () => {
+  const { stdout } = await runFixture({ reporters: 'default' }, { reporter: false });
+
+  expect(trimReporterOutput(stdout, 0, Infinity)).toMatchInlineSnapshot(`
+    "
+     RUN  v[...] <process-cwd>/packages/vitest/test/fixtures
+
+     ✓  chromium  reporter-1.test.ts (3 tests) <time>
+     ✓  chromium  reporter-2.test.ts (4 tests) <time>
+     ✓  chromium  reporter-3.test.ts (5 tests) <time>
+
+     Test Files  3 passed (3)
+          Tests  12 passed (12)
+       Start at  <time>
+       Duration  <time> (transform <time>, setup <time>, import <time>, tests <time>, environment <time>)"
+  `);
+});
+
+function runFixture(
+  options: Parameters<typeof baseRunFixture>[0],
+  pluginOptions?: Parameters<typeof baseRunFixture>[1]
+) {
+  return baseRunFixture(
+    {
+      fileParallelism: false,
+      sequence: { sequencer: StableTestFileOrderSorter },
+      include: [
+        /** {@link file://./../../test/fixtures/reporter-1.test.ts} */
+        resolve(import.meta.dirname, '../../test/fixtures/reporter-1.test.ts'),
+        /** {@link file://./../../test/fixtures/reporter-2.test.ts} */
+        resolve(import.meta.dirname, '../../test/fixtures/reporter-2.test.ts'),
+        /** {@link file://./../../test/fixtures/reporter-3.test.ts} */
+        resolve(import.meta.dirname, '../../test/fixtures/reporter-3.test.ts'),
+      ],
+      ...options,
+    },
+    pluginOptions
+  );
+}
+
+function trimReporterOutput(report: string, start?: number, end?: number) {
+  const lines = report.split('\n');
+  const startIndex = start ?? lines.findIndex((line) => line.includes('RUN  v'));
+  const endIndex = end ?? lines.findIndex((line) => line.includes('Test Files'));
+
+  return lines
+    .slice(startIndex, endIndex)
+    .join('\n')
+    .replaceAll(/\d+ms/g, '<time>')
+    .replaceAll(/\d+\.\d+s/g, '<time>')
+    .replaceAll(normalize(process.cwd()), '<process-cwd>')
+    .replaceAll(/RUN {2}v([\w\-.]+) /g, 'RUN  v[...] ')
+    .replaceAll(/(Start at {1,2})\d+:\d+:\d+/g, '$1<time>');
+}
+
+function trimSummary(report: string) {
+  const lines = report.split('\n');
+  const start = lines.findIndex((line) => line.includes('Chromatic Visual Regression'));
+
+  return lines
+    .slice(start, -2)
+    .map((line) => line.trim())
+    .join('\n')
+    .replaceAll(normalize(process.cwd()), '<process-cwd>');
+}

--- a/packages/vitest/src/node/reporter.ts
+++ b/packages/vitest/src/node/reporter.ts
@@ -1,0 +1,160 @@
+import { relative, resolve } from 'node:path';
+import { TestCase, TestModule, Vitest } from 'vitest/node';
+import { Reporter } from 'vitest/reporters';
+import colors from 'tinyrainbow';
+import { DEFAULT_OUTPUT_DIR } from '../constants';
+import { type ResolvedOptions } from '../types';
+
+const REPORTER_NAME = 'chromatic-reporter';
+
+interface Options
+  extends Pick<ResolvedOptions, 'outputDirectory'>, Pick<ResolvedOptions['reporter'], 'verbose'> {
+  /** User's Vitest built-in reporter */
+  builtInReporter: 'default' | 'verbose' | 'tree';
+}
+
+export class ChromaticReporter implements Reporter {
+  public name = REPORTER_NAME;
+
+  private constructor(
+    private ctx: Vitest,
+    private options: Options,
+    private snapshotCountPerEntity = new Map<TestCase['id'] | TestModule['id'], number>()
+  ) {}
+
+  /**
+   * Add `ChromaticReporter` to Vitest reporters unless it's already included.
+   */
+  static apply(ctx: Vitest, pluginOptions: ResolvedOptions) {
+    const options: Options = {
+      verbose: pluginOptions.reporter.verbose,
+      outputDirectory: pluginOptions.outputDirectory,
+      builtInReporter: 'default',
+    };
+
+    for (const reporter of ctx.config.reporters) {
+      // Apply ChromaticReporter just once
+      if (isChromaticReporter(reporter)) {
+        return;
+      }
+
+      // Inline reporter
+      if (!Array.isArray(reporter)) {
+        continue;
+      }
+
+      const reporterName = reporter[0];
+
+      if (reporterName === 'tree' || reporterName === 'default' || reporterName === 'verbose') {
+        options.builtInReporter = reporterName as Exclude<typeof reporterName, string>;
+      }
+    }
+
+    ctx.config.reporters.push(new ChromaticReporter(ctx, options));
+  }
+
+  /**
+   * Custom reporter life-cycle called when `takeSnapshot()` is called.
+   */
+  static onSnapshot(ctx: Vitest, test: TestCase) {
+    const reporter = ctx.config.reporters.find(isChromaticReporter);
+
+    reporter?._onSnapshot(test);
+  }
+
+  onTestCaseResult(testCase: TestCase) {
+    if (this.options.builtInReporter !== 'verbose') {
+      return;
+    }
+
+    this.logSnapshots({
+      count: this.snapshotCountPerEntity.get(testCase.id) ?? 0,
+      indentation: 3,
+      projectName: testCase.project.name,
+    });
+  }
+
+  onTestModuleEnd(testModule: TestModule) {
+    if (this.options.builtInReporter !== 'default' && this.options.builtInReporter !== 'tree') {
+      return;
+    }
+
+    this.logSnapshots({
+      count: this.snapshotCountPerEntity.get(testModule.id) ?? 0,
+      indentation: this.options.builtInReporter === 'default' ? 3 : 2,
+      projectName: this.options.builtInReporter === 'default' && testModule.project.name,
+    });
+  }
+
+  onTestRunEnd() {
+    const snapshotCount = [...this.snapshotCountPerEntity.values()].reduce((a, b) => a + b, 0);
+    this.snapshotCountPerEntity.clear();
+
+    if (snapshotCount === 0) {
+      return;
+    }
+
+    const output = resolve(this.ctx.config.root, this.options.outputDirectory);
+    const separator = colors.dim('─'.repeat(this.ctx.logger.getColumns()));
+
+    let uploadCommand = 'chromatic --vitest --project-token=<TOKEN>';
+
+    // If user changed the output directory or Vitest root,
+    // they'll need to define custom CHROMATIC_ARCHIVE_LOCATION when uploading archives:
+    if (
+      this.options.outputDirectory !== DEFAULT_OUTPUT_DIR ||
+      this.ctx.config.root !== process.cwd()
+    ) {
+      uploadCommand = `CHROMATIC_ARCHIVE_LOCATION=${relative(process.cwd(), output)} ${uploadCommand}`;
+    }
+
+    this.ctx.logger.log(
+      `${separator}`,
+
+      `\n${colors.inverse(' Chromatic Visual Regression ')}`,
+
+      `\n\n${colors.green('✓')} ${snapshotCount} ${pluralize(snapshotCount, 'archive')} captured`,
+
+      `\n\nArchives saved in ${colors.dim(output)}`,
+      `\nTo upload archives into Chromatic run ${colors.green(uploadCommand)}`,
+
+      `\n\n${separator}\n`
+    );
+  }
+
+  private logSnapshots(options: {
+    count: number;
+    indentation: number;
+    projectName: string | false;
+  }) {
+    if (!this.options.verbose || options.count === 0) {
+      return;
+    }
+
+    const snapshots = `(${options.count} ${pluralize(options.count, 'archive')} captured)`;
+
+    if (options.projectName) {
+      options.indentation += options.projectName.length + 2;
+    }
+
+    this.ctx.logger.log(`${' '.repeat(options.indentation)} ${colors.dim(snapshots)}`);
+  }
+
+  private _onSnapshot(test: TestCase) {
+    // Vitest's verbose reporter logs outputs of each test case, others after each test module:
+    const key = this.options.builtInReporter === 'verbose' ? test.id : test.module.id;
+
+    const previousCount = this.snapshotCountPerEntity.get(key) ?? 0;
+    this.snapshotCountPerEntity.set(key, previousCount + 1);
+  }
+}
+
+function isChromaticReporter(
+  reporter: Vitest['config']['reporters'][number]
+): reporter is ChromaticReporter {
+  return 'name' in reporter && reporter.name === REPORTER_NAME;
+}
+
+function pluralize(count: number, text: string) {
+  return count === 1 ? text : `${text}s`;
+}

--- a/packages/vitest/src/types.test-d.ts
+++ b/packages/vitest/src/types.test-d.ts
@@ -1,4 +1,4 @@
-import { expectTypeOf, test } from 'vitest';
+import { assertType, expectTypeOf, test } from 'vitest';
 
 import { takeSnapshot, waitForIdleNetwork, configure } from '../dist';
 import { chromaticPlugin } from '../dist/plugin';
@@ -32,6 +32,7 @@ test('configure', () => {
   expectTypeOf(configure).parameter(0).not.toHaveProperty('tags');
   expectTypeOf(configure).parameter(0).not.toHaveProperty('outputDirectory');
   expectTypeOf(configure).parameter(0).not.toHaveProperty('idleNetworkInterval');
+  expectTypeOf(configure).parameter(0).not.toHaveProperty('reporter');
 });
 
 test('chromaticPlugin', () => {
@@ -42,6 +43,7 @@ test('chromaticPlugin', () => {
   expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('tags');
   expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('outputDirectory');
   expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('idleNetworkInterval');
+  expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('reporter');
 
   expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('delay');
   expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('diffIncludeAntiAliasing');
@@ -54,4 +56,15 @@ test('chromaticPlugin', () => {
   expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('assetDomains');
   expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('cropToViewport');
   expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('ignoreSelectors');
+});
+
+test('chromaticPlugin({ reporter })', () => {
+  type Reporter = Parameters<typeof chromaticPlugin>[0]['reporter'];
+
+  assertType<Reporter>(true);
+  assertType<Reporter>(false);
+  assertType<Reporter>({ verbose: false });
+  assertType<Reporter>({ enabled: true });
+  assertType<Reporter>({ verbose: true, enabled: true });
+  assertType<Reporter>({ verbose: false, enabled: false });
 });

--- a/packages/vitest/src/types.ts
+++ b/packages/vitest/src/types.ts
@@ -36,6 +36,29 @@ export interface Options extends ChromaticConfig {
    * @default 100
    */
   idleNetworkInterval?: number;
+
+  /**
+   * Logger used to report status of captured archives.
+   *
+   * @default true
+   */
+  reporter?:
+    | boolean
+    | {
+        /**
+         * Whether the reporter is enabled.
+         *
+         * @default true
+         */
+        enabled?: boolean;
+
+        /**
+         * Log information about captured archives during test run.
+         *
+         * @default true
+         */
+        verbose?: boolean;
+      };
 }
 
 /** Options that don't have internal default values */
@@ -46,7 +69,12 @@ type ResolvedOptionKeys = Exclude<keyof Options, UnresolvedOptionKeys>;
 
 /** @internal */
 export interface ResolvedOptions
-  extends Required<Pick<Options, ResolvedOptionKeys>>, Pick<Options, UnresolvedOptionKeys> {}
+  extends
+    Required<Pick<Options, ResolvedOptionKeys>>,
+    Pick<Options, UnresolvedOptionKeys | 'reporter'> {
+  //
+  reporter: Required<Exclude<Options['reporter'], boolean>>;
+}
 
 /**
  * Options that can be set per test, suite or module via `configure()`

--- a/packages/vitest/test/fixtures/reporter-1.test.ts
+++ b/packages/vitest/test/fixtures/reporter-1.test.ts
@@ -1,0 +1,6 @@
+import { test } from 'vitest';
+import { takeSnapshot } from '../../src';
+
+test.each([1, 2, 3])('test #%i', async () => {
+  await takeSnapshot();
+});

--- a/packages/vitest/test/fixtures/reporter-2.test.ts
+++ b/packages/vitest/test/fixtures/reporter-2.test.ts
@@ -1,0 +1,6 @@
+import { test } from 'vitest';
+import { takeSnapshot } from '../../src';
+
+test.each([1, 2, 3, 4])('test #%i', async () => {
+  await takeSnapshot();
+});

--- a/packages/vitest/test/fixtures/reporter-3.test.ts
+++ b/packages/vitest/test/fixtures/reporter-3.test.ts
@@ -1,0 +1,6 @@
+import { test } from 'vitest';
+import { takeSnapshot } from '../../src';
+
+test.each([1, 2, 3, 4, 5])('test #%i', async () => {
+  await takeSnapshot();
+});

--- a/packages/vitest/test/utils/node.ts
+++ b/packages/vitest/test/utils/node.ts
@@ -4,7 +4,14 @@ import { resolve } from 'node:path';
 import { Writable } from 'node:stream';
 import { stripVTControlCharacters } from 'node:util';
 import { type Mock, vi } from 'vitest';
-import { type CliOptions, createVitest, type InlineConfig, startVitest } from 'vitest/node';
+import {
+  type CliOptions,
+  createVitest,
+  type InlineConfig,
+  startVitest,
+  TestSequencer,
+  type TestSpecification,
+} from 'vitest/node';
 import { playwright } from '@vitest/browser-playwright';
 import { chromaticPlugin } from '../../src/node/plugin';
 
@@ -71,4 +78,15 @@ export function createOutputStreams() {
 
 function formatStreamCalls({ mock }: Mock) {
   return stripVTControlCharacters(mock.calls.map(([chunk]) => chunk).join('')).trimEnd();
+}
+
+/** Run test files in stable order */
+export class StableTestFileOrderSorter implements TestSequencer {
+  sort(files: TestSpecification[]) {
+    return files.sort((a, b) => a.moduleId.localeCompare(b.moduleId));
+  }
+
+  shard(files: TestSpecification[]) {
+    return files;
+  }
 }


### PR DESCRIPTION
Issue: Milestone 3 of https://github.com/chromaui/chromatic-e2e/issues/353

## What Changed

Adds custom test reporter that logs information about archives during test run. Also outputs a summary below Vitest's test summary.

| Default `reporter` options | `reporter: false` (so just Vitest reporter output for comparison) |
| -- | -- |
| <img width="400" src="https://github.com/user-attachments/assets/d66e6547-dffb-4ac8-855c-3b33b186c277" /> | <img width="655" height="246" alt="image" src="https://github.com/user-attachments/assets/521cb8d5-2236-4970-a869-bbe92115caeb" /> |

The `reporter.verbose` option controls whether count of captured archives is logged during test run. It automatically detects which Vitest's built-in reporter user is using, and aligns its output to fit that:

| `default` | `tree` | `verbose` |
| -- | -- | -- |
| <img width="379" height="117" alt="image" src="https://github.com/user-attachments/assets/9eaa0415-0155-4aae-bfbd-03721afa0a84" /> |  <img width="359" height="230" alt="image" src="https://github.com/user-attachments/assets/8257f135-37aa-4f81-b26c-44afe591f5ea" /> | <img width="575" height="201" alt="image" src="https://github.com/user-attachments/assets/fe86bd8a-5bc0-42c4-9d13-2d1152ba46e0" /> |

Below Vitest's built-in test summary there is `Chromatic Visual Regression` summary that shows count of captured archives, their location and command how to upload the results. The command is aware of Vitest's `test.root`, Chromatic plugin's `outputDirectory` and Node's `process.cwd()`, and detects whether user will need to set custom `CHROMATIC_ARCHIVE_LOCATION` when running `chromatic --vitest` CLI.

| Default `outputDirectory` and `test.root` | Custom `outputDirectory` or `test.root` |
| -- | -- |
| <img width="575" height="147" alt="image" src="https://github.com/user-attachments/assets/ed03dbd8-f76b-4260-8793-2f0ce0da4e61" /> | <img width="854" height="147" alt="image" src="https://github.com/user-attachments/assets/9690e5f0-989c-48b4-9fc5-19056697b360" /> |

## How to test

- Use preview build https://github.com/chromaui/chromatic-e2e/pull/377#issuecomment-4590900570 and change `reporter` option in plugin options.
- Added tests to verify reporter output
