### PR TITLE
fix(vitest): title auto-infer should ignore all file extensions

### DIFF
--- a/.changeset/bumpy-ideas-boil.md
+++ b/.changeset/bumpy-ideas-boil.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': minor
+---
+
+Fix: title auto-infer should ignore all file extensions

--- a/packages/vitest/src/node/commands.test.ts
+++ b/packages/vitest/src/node/commands.test.ts
@@ -16,17 +16,35 @@ test('writes test results with full test name', async () => {
   expect(tests).toMatchInlineSnapshot(`
     [
       [
-        "test-names.test.ts",
+        "test-names",
         "test #1 / Snapshot #1",
       ],
       [
-        "test-names.test.ts",
+        "test-names",
         "suite #2 / test #2 / Snapshot #1",
       ],
       [
-        "test-names.test.ts",
+        "test-names",
         "suite #3 / nested suite #3 / test #3 / Snapshot #1",
       ],
+    ]
+  `);
+});
+
+test('writes test title without extensions', async () => {
+  /** See {@link file://./../../test/fixtures/nested/directories/expected-name.this-should-be-ignored.and-this.test.ts} */
+  await runFixture({
+    include: ['nested/directories/expected-name.this-should-be-ignored.and-this.test.ts'],
+  });
+
+  expect(shared.writeTestResult).toHaveBeenCalledTimes(1);
+
+  const call = vi.mocked(shared.writeTestResult).mock.calls[0];
+  const titlePath = call[0].titlePath;
+
+  expect(titlePath).toMatchInlineSnapshot(`
+    [
+      "nested/directories/expected-name",
     ]
   `);
 });

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -215,7 +215,7 @@ export function createCommands(options: ResolvedOptions) {
 }
 
 function getTitle(test: TestCase): string[] {
-  const names = [test.module.relativeModuleId];
+  const names = [removeFileExtensions(test.module.relativeModuleId)];
 
   // If Vitest was configured with multiple projects, namespace the results with project name
   const hasManyProjects =
@@ -261,6 +261,18 @@ function getSuiteNames(test: TestCase): string[] {
   }
 
   return names;
+}
+
+function removeFileExtensions(filepath: string) {
+  const parts = filepath.split('/');
+  const filename = parts.pop() || '';
+
+  return parts
+    .concat(
+      // Trim filenames like "src/components/accordion/Accordion.browser.spec.tsx" -> "src/components/accordion/Accordion"
+      filename.split('.')[0]
+    )
+    .join('/');
 }
 
 /** @internal */

--- a/packages/vitest/test/fixtures/nested/directories/expected-name.this-should-be-ignored.and-this.test.ts
+++ b/packages/vitest/test/fixtures/nested/directories/expected-name.this-should-be-ignored.and-this.test.ts
@@ -1,0 +1,3 @@
+import { test } from 'vitest';
+
+test('test #1', () => {});


### PR DESCRIPTION
Issue: Follow-up from https://github.com/chromaui/chromatic-e2e/pull/364

This fix was discussed before #364 was implemented, but it was never part of the PR.

## What Changed

The `@chromatic-com/shared-e2e` has always been removing just the file extension for Playwright and Cypress. In Vitest's case it's common for users to use multiple "extensions", like `Accordion.browser.test.tsx`. Currently this leads to web app showing `browser` as the last title.

https://github.com/chromaui/chromatic-e2e/blob/3e0365542cc9accddbff3b25b08b7eb6d2893b7f/packages/shared/src/write-archive/index.ts#L35-L44

| Before | After |
| ------ | ----- |
| <img width="646" height="467" alt="image" src="https://github.com/user-attachments/assets/afbae3a0-a987-46b2-bb2c-e8338d6062c7" /> | <img width="646" height="467" alt="image" src="https://github.com/user-attachments/assets/c1d9f631-0262-458f-9aa7-fcfeadc78170" /> |

```diff
{
- "title": "components/VAlert/__tests__/VAlert.spec.browser",
+ "title": "components/VAlert/__tests__/VAlert",
  "stories": [
    {
      "name": "VAlert / Showcase / light mobile / light-mobile-VAlert",
      "globals": { "viewport": "w600h800" },
      "parameters": {
-       "__id": "components-valert-tests-valert-spec-browser--v-alert-showcase-light-mobile-light-mobile-v-alert",
+       "__id": "components-valert-tests-valert--v-alert-showcase-light-mobile-light-mobile-v-alert",
        "server": {
-         "id": "components-valert-tests-valert-spec-browser-valert-showcase-light-mobile-light-mobile-valert"
+         "id": "components-valert-tests-valert-valert-showcase-light-mobile-light-mobile-valert"
        },
        "chromatic": { "modes": { "w600h800": { "viewport": "w600h800" } } },
        "viewport": {
          "options": {
            "w600h800": {
              "name": "w600h800",
              "type": "tablet",
              "styles": { "width": "600px", "height": "800px" }
            }
          },
          "defaultViewport": "w600h800"
        }
      }
    }
  ]
}
```

## How to test

- Preview build https://github.com/chromaui/chromatic-e2e/pull/382#issuecomment-4610004183
- Added tests to cover filenames with multiple parts/extensions
- Chromatic build [before](https://www.chromatic.com/build?appId=69e0ebf13e54194a8fbb6024&number=12#components) vs [after](https://www.chromatic.com/build?appId=69e0ebf13e54194a8fbb6024&number=13)
