### PR TITLE
fix(vitest): first asset request not archived

### DIFF
--- a/.changeset/salty-bags-repeat.md
+++ b/.changeset/salty-bags-repeat.md
@@ -1,0 +1,6 @@
+---
+'@chromatic-com/shared-e2e': patch
+'@chromatic-com/vitest': patch
+---
+
+Fix: First request's assets not archived

--- a/packages/shared/src/resource-archiver/index.ts
+++ b/packages/shared/src/resource-archiver/index.ts
@@ -56,9 +56,18 @@ export class ResourceArchiver {
    */
   private pendingRequests = new Set<Protocol.Fetch.requestPausedPayload['requestId']>();
 
-  constructor(cdpClient: CDPClient, allowedDomains?: string[], httpCredentials?: HttpCredentials) {
+  constructor(
+    cdpClient: CDPClient,
+    allowedDomains?: string[],
+    httpCredentials?: HttpCredentials,
+    firstUrl?: URL
+  ) {
     this.client = cdpClient;
     this.httpCredentials = httpCredentials;
+
+    // Initialize firstUrl when it's provided before any navigation happens.
+    // In test runners like Vitest, archiver is started during test run, when runner has already page open.
+    this.firstUrl = firstUrl;
 
     // tack on the protocol so we can properly check if requests are cross-origin
     this.assetDomains = (allowedDomains || []).map((domain) => {

--- a/packages/shared/src/resource-archiver/index.ts
+++ b/packages/shared/src/resource-archiver/index.ts
@@ -226,12 +226,26 @@ export class ResourceArchiver {
     // No need to capture the response of the top level page request
     const isFirstRequest = requestUrl.toString() === this.firstUrl.toString();
     if (isRequestFromAllowedDomain && !isFirstRequest) {
+      logger.log('Archiving request', {
+        url: request.url,
+        statusCode: responseStatusCode,
+        statusText: responseStatusText,
+        contentType: contentTypeHeader?.value,
+      });
+
       this.archive[request.url] = {
         statusCode: responseStatusCode,
         statusText: responseStatusText,
         body: Buffer.from(body, base64Encoded ? 'base64' : 'utf8'),
         contentType: contentTypeHeader?.value,
       };
+    } else {
+      logger.log('Skipping archiving of request', {
+        url: request.url,
+        firstUrl: this.firstUrl.toString(),
+        isFirstRequest,
+        isRequestFromAllowedDomain,
+      });
     }
 
     await this.clientSend(request, 'Fetch.continueRequest', { requestId });

--- a/packages/vitest/src/node/commands.test.ts
+++ b/packages/vitest/src/node/commands.test.ts
@@ -2,7 +2,7 @@ import { expect, test, vi } from 'vitest';
 import * as shared from '@chromatic-com/shared-e2e';
 import { runFixture } from '../../test/utils/node';
 
-vi.mock('@chromatic-com/shared-e2e');
+vi.mock('@chromatic-com/shared-e2e/write-archive/index');
 vi.mocked(shared.writeTestResult).mockImplementation(() => Promise.resolve());
 
 test('writes test results with full test name', async () => {
@@ -147,5 +147,34 @@ test('writes test results with custom parameters', async () => {
         "test": "test #6",
       },
     ]
+  `);
+});
+
+test('writes archived assets even from first URL archiver sees', async () => {
+  /** See {@link file://./../../test/fixtures/external-assets.test.ts} */
+  await runFixture({ include: ['external-assets.test.ts'] });
+
+  const assets = vi.mocked(shared.writeTestResult).mock.calls[0][2];
+
+  const url = Object.keys(assets)[0];
+
+  expect(url, 'Expected to archive assets.external.css').toBeDefined();
+  expect(url).toMatch(/assets\/external.css$/);
+
+  const { body, ...properties } = assets[url] as any;
+
+  expect(properties).toMatchInlineSnapshot(`
+    {
+      "contentType": "text/css",
+      "statusCode": 200,
+      "statusText": "OK",
+    }
+  `);
+
+  expect(body.toString()).toMatchInlineSnapshot(`
+    "body {
+      background-color: red;
+    }
+    "
   `);
 });

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -102,7 +102,8 @@ export function createCommands(options: ResolvedOptions) {
       const resourceArchiver = new ResourceArchiver(
         cdp,
         options.assetDomains,
-        contextOptions?.httpCredentials
+        contextOptions?.httpCredentials,
+        new URL(context.page.url())
       );
       resourceArchivers.set(id, resourceArchiver);
 

--- a/packages/vitest/test/fixtures/assets/external.css
+++ b/packages/vitest/test/fixtures/assets/external.css
@@ -1,0 +1,3 @@
+body {
+  background-color: red;
+}

--- a/packages/vitest/test/fixtures/external-assets.test.ts
+++ b/packages/vitest/test/fixtures/external-assets.test.ts
@@ -1,0 +1,25 @@
+/// <reference types="vite/client" />
+import { expect, test, vi } from 'vitest';
+import css from './assets/external.css?url';
+import { takeSnapshot, configure } from '../../src';
+
+configure({ disableAutoSnapshot: true });
+
+test('external css is loaded', async () => {
+  expect(getBackgroundColor()).not.toBe('rgb(255, 0, 0)');
+
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = css;
+  document.head.appendChild(link);
+
+  await vi.waitFor(() => {
+    expect(getBackgroundColor()).toBe('rgb(255, 0, 0)');
+  });
+
+  await takeSnapshot('external-css');
+});
+
+function getBackgroundColor() {
+  return document.body.computedStyleMap().get('background-color').toString();
+}


### PR DESCRIPTION
Issue: QA part of https://github.com/chromaui/chromatic-e2e/issues/353

## What Changed

In Vitest test run we create `ResourceArchiver` during the test run. Vitest has already created us a browser page - there is no navigation happening.

https://github.com/chromaui/chromatic-e2e/blob/621771b7c797df906bf1ff7a5f0ffd62cc661bc4/packages/vitest/src/browser/setupFile.ts#L29

https://github.com/chromaui/chromatic-e2e/blob/621771b7c797df906bf1ff7a5f0ffd62cc661bc4/packages/vitest/src/node/commands.ts#L92-L109

By design, `ResourceArchiver` skips archiving the first HTTP request it sees. This is ideal for Playwright and Cypress where it's always from `page.go()`, pointing at `.html` file. In Vitest's case this "first request" can be anything that happened during the test run - font loading, CSS loading, etc. Resource archiver incorrectly identifies these requests as "first request" and skips archiving them here:

https://github.com/chromaui/chromatic-e2e/blob/621771b7c797df906bf1ff7a5f0ffd62cc661bc4/packages/shared/src/resource-archiver/index.ts#L217-L219

As fix, we'll pass the actual page URL from Vitest to `ResourceArchiver` constructor.

## How to test

- Added test case that fails without the fix: https://github.com/chromaui/chromatic-e2e/actions/runs/26944574801/job/79494215619?pr=384