### PR TITLE
fix(vitest): browser session scoped `ResourceArchiver` to work-around browser cache

### DIFF
--- a/.changeset/lucky-jeans-hide.md
+++ b/.changeset/lucky-jeans-hide.md
@@ -1,0 +1,6 @@
+---
+'@chromatic-com/shared-e2e': patch
+'@chromatic-com/vitest': patch
+---
+
+Fix: Browser session scoped ResourceArchiver to work-around browser caching

--- a/packages/shared/src/resource-archiver/index.ts
+++ b/packages/shared/src/resource-archiver/index.ts
@@ -160,6 +160,7 @@ export class ResourceArchiver {
     );
 
     // Pausing at response stage with an error, simply ignore
+    // This can be for example when browser network cache serves the request
     if (responseErrorReason) {
       logger.log(`Got response error: ${responseErrorReason}`);
       await this.clientSend(request, 'Fetch.continueRequest', { requestId });

--- a/packages/shared/src/write-archive/index.ts
+++ b/packages/shared/src/write-archive/index.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import { existsSync } from 'node:fs';
 import { outputFile, ensureDir, outputJSONFile } from '../utils/filePaths';
 import { logger } from '../utils/logger';
 import { ArchiveFile } from './archive-file';
@@ -66,12 +67,15 @@ export async function writeTestResult(
       const archiveFile = new ArchiveFile(url, response, pageUrl);
       const origSrcPath = archiveFile.originalSrc();
       const fileSystemPath = archiveFile.toFileSystemPath();
+      const responsePath = join(archiveDir, fileSystemPath);
 
       if (origSrcPath !== fileSystemPath) {
         sourceMap.set(origSrcPath, fileSystemPath);
       }
 
-      await outputFile(join(archiveDir, fileSystemPath), response.body);
+      if (!existsSync(responsePath)) {
+        await outputFile(responsePath, response.body);
+      }
     })
   );
 

--- a/packages/vitest/src/browser/public/waitForIdleNetwork.ts
+++ b/packages/vitest/src/browser/public/waitForIdleNetwork.ts
@@ -34,5 +34,5 @@ export async function waitForIdleNetwork(timeout: number) {
     );
   }
 
-  return await commands.__chromatic_waitForIdleNetwork(test.id, timeout);
+  return await commands.__chromatic_waitForIdleNetwork(timeout);
 }

--- a/packages/vitest/src/browser/setupFile.ts
+++ b/packages/vitest/src/browser/setupFile.ts
@@ -26,7 +26,7 @@ beforeEach<InternalTestContext>(async ({ task }) => {
   task.meta.__chromatic_options ||= {};
   task.meta.__chromatic_options.disableAutoSnapshot ??= options.disableAutoSnapshot;
 
-  await commands.__chromatic_interceptFetch(task.id);
+  await commands.__chromatic_interceptFetch();
 
   // This runs after any user-defined afterEach hooks
   return async function beforeEachCleanup() {

--- a/packages/vitest/src/node/NetworkIdleTracker.ts
+++ b/packages/vitest/src/node/NetworkIdleTracker.ts
@@ -19,11 +19,10 @@ export class NetworkIdleTracker {
 
   static async create(cdp: CDPSession, idleTimeout: number) {
     const tracker = new NetworkIdleTracker(cdp, idleTimeout);
-    await tracker.watch();
     return tracker;
   }
 
-  private async watch() {
+  async watch() {
     this.cdp.on('Network.requestWillBeSent', this.onRequest);
     this.cdp.on('Network.loadingFinished', this.onComplete);
     this.cdp.on('Network.loadingFailed', this.onComplete);
@@ -31,7 +30,7 @@ export class NetworkIdleTracker {
     await this.cdp.send('Network.enable');
   }
 
-  async off() {
+  async unwatch() {
     this.cdp.off('Network.requestWillBeSent', this.onRequest);
     this.cdp.off('Network.loadingFinished', this.onComplete);
     this.cdp.off('Network.loadingFailed', this.onComplete);

--- a/packages/vitest/src/node/commands.test.ts
+++ b/packages/vitest/src/node/commands.test.ts
@@ -155,26 +155,102 @@ test('writes archived assets even from first URL archiver sees', async () => {
   await runFixture({ include: ['external-assets.test.ts'] });
 
   const assets = vi.mocked(shared.writeTestResult).mock.calls[0][2];
-
   const url = Object.keys(assets)[0];
 
   expect(url, 'Expected to archive assets.external.css').toBeDefined();
   expect(url).toMatch(/assets\/external.css$/);
 
-  const { body, ...properties } = assets[url] as any;
-
-  expect(properties).toMatchInlineSnapshot(`
+  expect(parseArchive(assets[url])).toMatchInlineSnapshot(`
     {
+      "body": "body { background-color: red; }",
       "contentType": "text/css",
       "statusCode": 200,
       "statusText": "OK",
     }
   `);
-
-  expect(body.toString()).toMatchInlineSnapshot(`
-    "body {
-      background-color: red;
-    }
-    "
-  `);
 });
+
+test('writes archived assets even when browser cached them', { timeout: 30_000 }, async () => {
+  await runFixture({
+    include: [
+      /** See {@link file://./../../test/fixtures/external-assets.test.ts} */
+      'external-assets.test.ts',
+
+      /** See {@link file://./../../test/fixtures/external-assets-caching-1.test.ts} */
+      'external-assets-caching-1.test.ts',
+      'external-assets-caching-2.test.ts',
+      'external-assets-caching-3.test.ts',
+      'external-assets-caching-4.test.ts',
+      'external-assets-caching-5.test.ts',
+    ],
+    provide: { testName: 'both' },
+
+    // Run 2 browser contexts parallel, 3 test files in each.
+    // This triggers complex caching case where 3 files share same cache, but the other 3 don't.
+    maxWorkers: 2,
+    fileParallelism: true,
+  });
+
+  const titles = vi
+    .mocked(shared.writeTestResult)
+    .mock.calls.map((call) => call[0].titlePath[0])
+    .sort();
+
+  // Expected files executed
+  expect([...new Set(titles)]).toMatchInlineSnapshot(`
+    [
+      "external-assets",
+      "external-assets-caching-1",
+      "external-assets-caching-2",
+      "external-assets-caching-3",
+      "external-assets-caching-4",
+      "external-assets-caching-5",
+    ]
+  `);
+
+  // Each 6 files should take 2 snapshots
+  expect(shared.writeTestResult).toHaveBeenCalledTimes(2 * 6);
+
+  const assets = vi
+    .mocked(shared.writeTestResult)
+    .mock.calls.map((call) => call[2])
+    .filter((assets) => Object.keys(assets).length > 0);
+
+  expect(
+    assets,
+    `Expected to archive 12 assets, got ${formatResourceArchives(assets)}`
+  ).toHaveLength(2 * 6);
+
+  for (const [index, asset] of assets.entries()) {
+    const url = Object.keys(asset)[0];
+
+    expect(url, `Expected to archive assets.external.css in test #${index + 1}`).toBeDefined();
+    expect(url).toMatch(/assets\/external.css$/);
+
+    expect(parseArchive(asset[url])).toMatchObject({
+      contentType: 'text/css',
+      statusCode: 200,
+      statusText: 'OK',
+      body: 'body { background-color: red; }',
+    });
+  }
+});
+
+function formatResourceArchives(archives: shared.ResourceArchive[]) {
+  return JSON.stringify(
+    archives.map((archive) => Object.keys(archive).map((url) => parseArchive(archive[url]))),
+    null,
+    2
+  );
+}
+
+function parseArchive(asset: shared.ArchiveResponse) {
+  if ('error' in asset) {
+    return asset;
+  }
+
+  return {
+    ...asset,
+    body: Buffer.from(asset.body).toString().trim().replace(/\s+/g, ' '),
+  };
+}

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -1,6 +1,12 @@
 import assert from 'node:assert';
 import { resolve } from 'node:path';
-import type { TestCase, TestModule, TestSuite, BrowserCommand } from 'vitest/node';
+import type {
+  TestCase,
+  TestModule,
+  TestSuite,
+  BrowserCommand,
+  BrowserCommandContext,
+} from 'vitest/node';
 import { type PlaywrightProviderOptions } from '@vitest/browser-playwright';
 import { type Task } from '@vitest/runner/types';
 import { type serializedNodeWithId } from '@rrweb/types';
@@ -15,11 +21,12 @@ import { NetworkIdleTracker } from './NetworkIdleTracker';
 import { ChromaticReporter } from './reporter';
 
 type TestID = Task['id'];
+type SessionId = BrowserCommandContext['sessionId'];
 type SnapshotName = keyof DOMSnapshots;
 
 export function createCommands(options: ResolvedOptions) {
-  const resourceArchivers = new Map<TestID, ResourceArchiver>();
-  const networkIdleTrackers = new Map<TestID, NetworkIdleTracker>();
+  const resourceArchivers = new Map<SessionId, ResourceArchiver>();
+  const networkIdleTrackers = new Map<SessionId, NetworkIdleTracker>();
   const snapshots = new Map<
     TestID,
     Map<
@@ -82,9 +89,9 @@ export function createCommands(options: ResolvedOptions) {
      * Wait for network to be idle, meaning no new network requests for at least `idleNetworkInterval` ms.
      * Use `timeout` argument to reject if network doesn't become idle within given time.
      */
-    async __chromatic_waitForIdleNetwork(_, id: TestID, timeout: number): Promise<void> {
-      const networkIdleTracker = networkIdleTrackers.get(id);
-      assert(networkIdleTracker, `No network idle tracker found for test ${id}`);
+    async __chromatic_waitForIdleNetwork(context, timeout: number): Promise<void> {
+      const networkIdleTracker = networkIdleTrackers.get(context.sessionId);
+      assert(networkIdleTracker, `No network idle tracker found for session ${context.sessionId}`);
 
       await networkIdleTracker.waitForIdle(timeout);
     },
@@ -92,27 +99,39 @@ export function createCommands(options: ResolvedOptions) {
     /**
      * Start recording HTTP resources and network activity for given test.
      */
-    async __chromatic_interceptFetch(context, id: TestID) {
-      const cdp = await context.provider.getCDPSession?.(context.sessionId);
-      assert(cdp, `Unable to get CDP session for session ${context.sessionId}`);
+    async __chromatic_interceptFetch(context) {
+      // Network intercetion is shared per browser context as browser cache
+      // is shared between test cases and test files that run in same browser context.
+      let resourceArchiver = resourceArchivers.get(context.sessionId);
+      let networkIdleTracker = networkIdleTrackers.get(context.sessionId);
+      let cdp;
 
-      const { contextOptions }: PlaywrightProviderOptions =
-        context.project.config.browser.provider?.options ?? {};
+      if (!resourceArchiver || !networkIdleTracker) {
+        cdp = await context.provider.getCDPSession?.(context.sessionId);
+        assert(cdp, `Unable to get CDP session for session ${context.sessionId}`);
+      }
 
-      const resourceArchiver = new ResourceArchiver(
-        cdp,
-        options.assetDomains,
-        contextOptions?.httpCredentials,
-        new URL(context.page.url())
-      );
-      resourceArchivers.set(id, resourceArchiver);
+      if (!resourceArchiver) {
+        const { contextOptions }: PlaywrightProviderOptions =
+          context.project.config.browser.provider?.options ?? {};
 
+        resourceArchiver = new ResourceArchiver(
+          cdp,
+          options.assetDomains,
+          contextOptions?.httpCredentials,
+          new URL(context.page.url())
+        );
+
+        resourceArchivers.set(context.sessionId, resourceArchiver);
+      }
+
+      if (!networkIdleTracker) {
+        networkIdleTracker = await NetworkIdleTracker.create(cdp, options.idleNetworkInterval);
+        networkIdleTrackers.set(context.sessionId, networkIdleTracker);
+      }
+
+      await networkIdleTracker.watch();
       await resourceArchiver.watch();
-
-      networkIdleTrackers.set(
-        id,
-        await NetworkIdleTracker.create(cdp, options.idleNetworkInterval)
-      );
     },
 
     /**
@@ -126,7 +145,7 @@ export function createCommands(options: ResolvedOptions) {
         `Expected entity with id ${id} to be a test, found ${entity?.type}`
       );
 
-      const { archive, sessionSnapshots } = await onTestCleanup(id);
+      const { archive, sessionSnapshots } = await onTestCleanup(context, id);
       assert(sessionSnapshots, `No snapshots found for test ${id}`);
 
       const snapshotBuffers: DOMSnapshots = {};
@@ -175,14 +194,18 @@ export function createCommands(options: ResolvedOptions) {
     /**
      * Clear test state without writing test results.
      */
-    async __chromatic_stopWithoutSnapshots(_, id: TestID) {
-      await onTestCleanup(id);
+    async __chromatic_stopWithoutSnapshots(context, id: TestID) {
+      await onTestCleanup(context, id);
     },
 
     /**
      * Reset all state of the plugin. Should be called between test runs.
      */
     async __chromatic_reset() {
+      for (const resourceArchiver of resourceArchivers.values()) {
+        resourceArchiver.archive = {};
+      }
+
       resourceArchivers.clear();
       networkIdleTrackers.clear();
       snapshots.clear();
@@ -197,17 +220,19 @@ export function createCommands(options: ResolvedOptions) {
     },
   } satisfies Record<ChromaticNamespace, BrowserCommand<any>>;
 
-  async function onTestCleanup(id: TestID) {
-    const resourceArchiver = resourceArchivers.get(id);
+  async function onTestCleanup(context: BrowserCommandContext, id: TestID) {
+    const resourceArchiver = resourceArchivers.get(context.sessionId);
     assert(resourceArchiver, `No resource archiver found for test ${id}`);
 
-    resourceArchivers.delete(id);
+    const networkIdleTracker = networkIdleTrackers.get(context.sessionId);
+    assert(networkIdleTracker, `No network idle tracker found for test ${id}`);
+
+    // Between test runs we only unwatch. Resources are still kept in memory, as same session
+    // shares browser cache between test cases and test files.
     await resourceArchiver.unwatch();
+    await networkIdleTracker.unwatch();
 
-    const networkIdleTracker = networkIdleTrackers.get(id);
-    networkIdleTrackers.delete(id);
-    await networkIdleTracker?.off();
-
+    // Snapshots are per test case:
     const sessionSnapshots = snapshots.get(id);
     snapshots.delete(id);
 

--- a/packages/vitest/test/fixtures/external-assets-caching-1.test.ts
+++ b/packages/vitest/test/fixtures/external-assets-caching-1.test.ts
@@ -1,0 +1,1 @@
+import './external-assets.test';

--- a/packages/vitest/test/fixtures/external-assets-caching-2.test.ts
+++ b/packages/vitest/test/fixtures/external-assets-caching-2.test.ts
@@ -1,0 +1,1 @@
+import './external-assets.test';

--- a/packages/vitest/test/fixtures/external-assets-caching-3.test.ts
+++ b/packages/vitest/test/fixtures/external-assets-caching-3.test.ts
@@ -1,0 +1,1 @@
+import './external-assets.test';

--- a/packages/vitest/test/fixtures/external-assets-caching-4.test.ts
+++ b/packages/vitest/test/fixtures/external-assets-caching-4.test.ts
@@ -1,0 +1,1 @@
+import './external-assets.test';

--- a/packages/vitest/test/fixtures/external-assets-caching-5.test.ts
+++ b/packages/vitest/test/fixtures/external-assets-caching-5.test.ts
@@ -1,0 +1,1 @@
+import './external-assets.test';

--- a/packages/vitest/test/fixtures/external-assets.test.ts
+++ b/packages/vitest/test/fixtures/external-assets.test.ts
@@ -1,5 +1,5 @@
 /// <reference types="vite/client" />
-import { expect, test, vi } from 'vitest';
+import { expect, inject, onTestFinished, test, vi } from 'vitest';
 import css from './assets/external.css?url';
 import { takeSnapshot, configure } from '../../src';
 
@@ -8,10 +8,7 @@ configure({ disableAutoSnapshot: true });
 test('external css is loaded', async () => {
   expect(getBackgroundColor()).not.toBe('rgb(255, 0, 0)');
 
-  const link = document.createElement('link');
-  link.rel = 'stylesheet';
-  link.href = css;
-  document.head.appendChild(link);
+  injectStyleTag();
 
   await vi.waitFor(() => {
     expect(getBackgroundColor()).toBe('rgb(255, 0, 0)');
@@ -19,6 +16,29 @@ test('external css is loaded', async () => {
 
   await takeSnapshot('external-css');
 });
+
+test.runIf(inject('testName') === 'both')('external css loads from cache', async () => {
+  expect(getBackgroundColor()).not.toBe('rgb(255, 0, 0)');
+
+  injectStyleTag();
+
+  await vi.waitFor(() => {
+    expect(getBackgroundColor()).toBe('rgb(255, 0, 0)');
+  });
+
+  await takeSnapshot('external-css-cached');
+});
+
+function injectStyleTag() {
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = css;
+  document.head.appendChild(link);
+
+  onTestFinished(() => {
+    document.head.removeChild(link);
+  });
+}
 
 function getBackgroundColor() {
   return document.body.computedStyleMap().get('background-color').toString();

--- a/packages/vitest/test/utils/node.ts
+++ b/packages/vitest/test/utils/node.ts
@@ -26,7 +26,7 @@ export function getBrowserConfig(name = 'chromium') {
 }
 
 export async function runFixture(
-  options: CliOptions,
+  { stdout, ...options }: CliOptions & { stdout?: 'inherit' },
   pluginOptions: Parameters<typeof chromaticPlugin>[0] | { disabled: true } = {}
 ) {
   const { streams, getOutput } = createOutputStreams();
@@ -44,7 +44,7 @@ export async function runFixture(
         ...options,
       },
     },
-    streams
+    stdout === 'inherit' ? {} : streams
   );
   await vitest.close();
 

--- a/packages/vitest/vitest.config.browser.ts
+++ b/packages/vitest/vitest.config.browser.ts
@@ -3,6 +3,8 @@ import { playwright } from '@vitest/browser-playwright';
 import { chromaticPlugin } from './src/node/plugin';
 import { type ConfigureOptions } from './src/types';
 
+const isWatch = process.argv.includes('--watch');
+
 export default defineProject({
   resolve: { tsconfigPaths: true },
   plugins: [chromaticPlugin()],
@@ -18,7 +20,7 @@ export default defineProject({
     // Isolate project into it's own group as we are running multiple projects with browsers
     sequence: { groupOrder: 3 },
     fileParallelism: false,
-    retry: 2,
+    retry: isWatch ? 0 : 2,
 
     browser: {
       enabled: true,

--- a/packages/vitest/vitest.config.unit.ts
+++ b/packages/vitest/vitest.config.unit.ts
@@ -1,5 +1,7 @@
 import { defineProject } from 'vitest/config';
 
+const isWatch = process.argv.includes('--watch');
+
 export default defineProject({
   resolve: { tsconfigPaths: true },
   test: {
@@ -12,7 +14,7 @@ export default defineProject({
     // Isolate project into it's own group as we are spawning browser runners during tests
     sequence: { groupOrder: 2 },
     fileParallelism: false,
-    retry: 2,
+    retry: isWatch ? 0 : 2,
 
     typecheck: {
       enabled: true,


### PR DESCRIPTION
Issue: QA part of #353

Currently `ResourceArchiver`'s are created for each test case. Each of them hold their own set of archives. Network is intercepted using [`Fetch.requestPaused`](https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#event-requestPaused).

When browser serves the requested resource from browser cache, `Fetch.requestPaused` cannot intercept the request - as there is none. Instead we see error in `ResourceArchiver` and test case ends up without the requested resource.

In Vitest each worker creates their own Playwright browser context. Each of those Playwright browser contexts have their own network cache:

<img width="2162" height="1527" alt="image" src="https://github.com/user-attachments/assets/2b3797d8-29c9-46e0-bed8-b5411997c563" />

As `ResourceArchiver` needs to see whole network (including cache), we need to lift it from being test case scoped, to being Playwright browser context scoped. In Vitest's terms this means that we use browser's `sessionId` as unique identifier when resolving `ResourceArchiver`'s.

## What Changed

Use shared `ResourceArchiver`'s between all test cases and test files that run in the same Playwright browser context. Store `ResourceArchiver`'s based on browser session id. The `ResourceArchiver.archives` are shared between all test cases and test files that run in the same Playwright browser context.

## How to test

- [Vuetify fork](https://github.com/AriPerkkio/vuetify/tree/test/add-chromatic) with the [preview build](https://github.com/chromaui/chromatic-e2e/pull/386#issuecomment-4621929679)
  - `pnpm run test autocomplete`
  - `pnpm exec archive-storybook`
  - Notice how some stories fail to load some fonts 
- Added test case fails here without the fix: https://github.com/chromaui/chromatic-e2e/actions/runs/27000782164/job/79680497220?pr=386