### PR TITLE
fix(playwright): wait for browser module before takeSnapshot

### DIFF
--- a/.changeset/wait-for-snapshot-module.md
+++ b/.changeset/wait-for-snapshot-module.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/playwright': patch
+---
+
+Fix: Wait for browser module to define `__chromatic_takeSnapshot` before invoking it

--- a/packages/playwright/src/takeSnapshot.test.ts
+++ b/packages/playwright/src/takeSnapshot.test.ts
@@ -12,6 +12,7 @@ const fakePage = {
   viewportSize: () => ({ width: 100, height: 200 }),
   frames: () => [],
   addScriptTag: () => {},
+  waitForFunction: () => {},
 } as Page;
 
 describe('Snapshot storage', () => {
@@ -90,6 +91,7 @@ describe('Snapshot storage', () => {
           pseudoClassIds: {},
         }),
       addScriptTag: () => {},
+      waitForFunction: () => {},
       viewportSize: () => ({ width: 100, height: 200 }),
       frames: () => [
         fakePage,
@@ -101,6 +103,7 @@ describe('Snapshot storage', () => {
             }),
           url: () => iframes[0].attributes.src,
           addScriptTag: () => {},
+          waitForFunction: () => {},
         },
         {
           evaluate: () =>
@@ -110,6 +113,7 @@ describe('Snapshot storage', () => {
             }),
           url: () => iframes[1].attributes.src,
           addScriptTag: () => {},
+          waitForFunction: () => {},
         },
       ],
     } as unknown as Page;

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -84,6 +84,13 @@ async function executeSnapshotScript(context: Page | Frame) {
     path: require.resolve('@chromatic-com/playwright/browser'),
   });
 
+  // addScriptTag doesn't await load for inline (path/content) injection, and
+  // module scripts are deferred, so the module may not have run yet. Wait for
+  // the function to avoid `__chromatic_takeSnapshot is not a function`.
+  await context.waitForFunction(
+    () => typeof (window as unknown as WindowContext).__chromatic_takeSnapshot === 'function'
+  );
+
   const snapshot = await context.evaluate(async () => {
     // Additional JSON.stringify + parse needed for deeply nested DOMs: https://github.com/chromaui/chromatic-e2e/issues/307
     return JSON.stringify(await (window as unknown as WindowContext).__chromatic_takeSnapshot());


### PR DESCRIPTION
## What Changed

Snapshots intermittently fail with `__chromatic_takeSnapshot is not a function` under parallel load.

Since 0.14.x the snapshot helper is injected as an ES module via `addScriptTag({ type: "module" })`. For `path`/`content` injection `addScriptTag` doesn't await load, and module scripts are deferred, so `evaluate()` can run before the module defines `window.__chromatic_takeSnapshot`.

Wait for the function to exist before invoking it.

## How to test

Run multiple e2e tests in parallel within a GitHub Action