### PR TITLE
fix(vitest): `resourceArchiveTimeout` not awaited if auto snapshot is disabled

### DIFF
--- a/packages/vitest/src/browser/setupFile.ts
+++ b/packages/vitest/src/browser/setupFile.ts
@@ -25,6 +25,7 @@ beforeEach<InternalTestContext>(async ({ task }) => {
   // disableAutoSnapshot may already be defined by module or suite level configure()
   task.meta.__chromatic_options ||= {};
   task.meta.__chromatic_options.disableAutoSnapshot ??= options.disableAutoSnapshot;
+  task.meta.__chromatic_options.resourceArchiveTimeout ??= options.resourceArchiveTimeout;
 
   await commands.__chromatic_interceptFetch();
 
@@ -75,6 +76,7 @@ afterEach<InternalTestContext>(async ({ task }) => {
     __chromatic_options: options,
     __chromatic_pendingTakeSnapshots: pendingTakeSnapshots,
     __chromatic_isRegistered: isRegistered,
+    __chromatic_options: testOptions,
   } = task.meta;
 
   if (!isRegistered) {
@@ -85,21 +87,15 @@ afterEach<InternalTestContext>(async ({ task }) => {
     throw new PendingSnapshotsError(pendingTakeSnapshots);
   }
 
-  if (options.disableAutoSnapshot) {
-    return;
-  }
-
-  const globals = await commands.__chromatic_getOptions();
-
-  // Per-test configure() can override the global resourceArchiveTimeout
-  const resourceArchiveTimeout = options.resourceArchiveTimeout ?? globals.resourceArchiveTimeout;
-
-  if (resourceArchiveTimeout !== 0) {
-    await waitForIdleNetwork(resourceArchiveTimeout);
+  if (testOptions.resourceArchiveTimeout !== 0) {
+    await document.fonts.ready;
+    await waitForIdleNetwork(testOptions.resourceArchiveTimeout);
   }
 
   // Take automatic snapshot
-  await takeSnapshot(undefined, { ignoreUnawaited: true });
+  if (!options.disableAutoSnapshot) {
+    await takeSnapshot(undefined, { ignoreUnawaited: true });
+  }
 });
 
 class PendingSnapshotsError extends AggregateError {

--- a/packages/vitest/src/node/NetworkIdleTracker.ts
+++ b/packages/vitest/src/node/NetworkIdleTracker.ts
@@ -36,6 +36,8 @@ export class NetworkIdleTracker {
     this.cdp.off('Network.loadingFailed', this.onComplete);
 
     this.clearTimer();
+    this.pending.clear();
+    this.idleResolvers.splice(0).forEach((fn) => fn());
     await this.cdp.send('Network.disable');
   }
 

--- a/packages/vitest/test/archiving-assets.test.ts
+++ b/packages/vitest/test/archiving-assets.test.ts
@@ -1,5 +1,8 @@
 import { test } from './utils/browser';
-import { configure } from '../dist';
+
+test('picture captures fallback image', async ({ goTo }) => {
+  await goTo('/asset-paths/picture-no-matching-source');
+});
 
 test('query params determine which asset is served', async ({ goTo }) => {
   await goTo('/asset-paths/query-params');
@@ -58,14 +61,7 @@ test('picture source is captured, single source with srcset', async ({ goTo }) =
   await goTo('/asset-paths/picture-multiple-srcset');
 });
 
-test('picture captures fallback image', async ({ goTo }) => {
-  await goTo('/asset-paths/picture-no-matching-source');
-});
-
 test('external CSS files are inlined', async ({ goTo }) => {
-  // Flaky CSS loading
-  configure({ delay: 1_000 });
-
   await goTo('/asset-paths/external-css-files');
 });
 

--- a/packages/vitest/test/utils/browser.ts
+++ b/packages/vitest/test/utils/browser.ts
@@ -51,7 +51,9 @@ async function goTo(url: string): Promise<void> {
   if (document.head.querySelector('script[src*="tailwind"]')) {
     await vi.waitUntil(() => {
       // Tailwind uses MutationObserver, we need to trigger it so that it mounts the style tag
-      document.body.appendChild(document.createElement('div'));
+      const div = document.createElement('div');
+      document.body.appendChild(div);
+      document.body.removeChild(div);
 
       return document.head.querySelector('style');
     });


### PR DESCRIPTION
Issue: QA part of #353

## What Changed

Always wait `resourceArchiveTimeout` amount of time until network is idle. To be honest, I thought this was only useful for auto snapshots. But it does make sense even when it's disabled.

Also clear full state of `NetworkIdleTracker` between test runs.

## How to test

- [Vuetify fork](https://github.com/AriPerkkio/vuetify/tree/test/add-chromatic)
  - `pnpm run test`
  - `pnpm exec archive-storybook`
  - Notice how some stories fail to load some fonts
  - Apply this PR [preview build](https://github.com/chromaui/chromatic-e2e/pull/388#issuecomment-4631751841)
  - Fonts always load fine
