### PR TITLE
fix: hide unrelevant Storybook options

### DIFF
--- a/.changeset/free-hairs-find.md
+++ b/.changeset/free-hairs-find.md
@@ -1,0 +1,8 @@
+---
+'@chromatic-com/playwright': patch
+'@chromatic-com/cypress': patch
+'@chromatic-com/shared-e2e': patch
+'@chromatic-com/vitest': patch
+---
+
+Fix: Hide unrelevant Storybook options

--- a/packages/cypress/src/storybook-config/main.ts
+++ b/packages/cypress/src/storybook-config/main.ts
@@ -25,4 +25,7 @@ export default {
     renderer: pathToFileURL(path.join(embeddedDir, '@storybook', 'server', 'preset.js')).href,
   },
   staticDirs: [path.resolve(archivesDir(DEFAULT_OUTPUT_DIR), 'archive')],
+  features: {
+    sidebarOnboardingChecklist: false,
+  },
 };

--- a/packages/playwright/src/storybook-config/main.ts
+++ b/packages/playwright/src/storybook-config/main.ts
@@ -25,4 +25,7 @@ export default {
     renderer: pathToFileURL(path.join(embeddedDir, '@storybook', 'server', 'preset.js')).href,
   },
   staticDirs: [path.resolve(archivesDir(DEFAULT_OUTPUT_DIR), 'archive')],
+  features: {
+    sidebarOnboardingChecklist: false,
+  },
 };

--- a/packages/shared/storybook-config/manager.ts
+++ b/packages/shared/storybook-config/manager.ts
@@ -2,7 +2,15 @@ import { addons } from 'storybook/manager-api';
 
 addons.setConfig({
   sidebar: {
-    // this ensures we use folders at the root-level instead of categories
+    // Ensures we use folders at the root-level instead of categories
     showRoots: false,
+  },
+
+  layoutCustomisations: {
+    // Hide toolbar options that don't make sense in e2e setup
+    showToolbar: () => false,
+
+    // Hide bottom panel that's empty in e2e setup
+    showPanel: () => false,
   },
 });

--- a/packages/vitest/src/storybook-config/main.ts
+++ b/packages/vitest/src/storybook-config/main.ts
@@ -10,7 +10,7 @@ const __dirname = path.dirname(__filename);
 const packageRoot = path.resolve(__dirname, '..', '..');
 const embeddedDir = path.join(packageRoot, 'embedded', 'node_modules');
 
-/** @type { import('@storybook/server-webpack5').StorybookConfig } */
+/** @type {import('@storybook/server-webpack5').StorybookConfig} */
 export default {
   stories: [path.resolve(archivesDir(DEFAULT_OUTPUT_DIR), '*.stories.json')],
   managerEntries: [path.resolve(__dirname, 'manager.js')],
@@ -25,4 +25,7 @@ export default {
     renderer: pathToFileURL(path.join(embeddedDir, '@storybook', 'server', 'preset.js')).href,
   },
   staticDirs: [path.resolve(archivesDir(DEFAULT_OUTPUT_DIR), 'archive')],
+  features: {
+    sidebarOnboardingChecklist: false,
+  },
 };


### PR DESCRIPTION
Issue: SB-1672

## What Changed

Hide toolbar, addons panel and getting started box.

## How to test

CI published Storybook at:  https://69aa98655596f48823e883c7-zipbwdupuu.chromatic.com