### PR TITLE
fix(vitest): reporter output misaligned when `slowTestThreshold` logs test case

### DIFF
--- a/.changeset/major-games-strive.md
+++ b/.changeset/major-games-strive.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: Reporter output misaligned when Vitest reports slow tests

--- a/packages/vitest/src/node/reporter.test.ts
+++ b/packages/vitest/src/node/reporter.test.ts
@@ -24,6 +24,32 @@ test('default reporter', async () => {
   `);
 });
 
+test('default reporter with slow tests', { timeout: 10_000 }, async () => {
+  const { stdout } = await runFixture({
+    reporters: 'default',
+    provide: { delay: 500 },
+    slowTestThreshold: 499,
+  });
+
+  expect(trimReporterOutput(stdout)).toMatchInlineSnapshot(`
+    " RUN  v[...] <process-cwd>/packages/vitest/test/fixtures
+
+     ✓  chromium  reporter-1.test.ts (3 tests) <time>
+       ✓ test #3  <time>
+       (6 archives captured)
+     ✓  chromium  reporter-2.test.ts (4 tests) <time>
+       ✓ test #3  <time>
+       ✓ test #4  <time>
+       (8 archives captured)
+     ✓  chromium  reporter-3.test.ts (5 tests) <time>
+       ✓ test #3  <time>
+       ✓ test #4  <time>
+       ✓ test #5  <time>
+       (10 archives captured)
+    "
+  `);
+});
+
 test('tree reporter', async () => {
   const { stdout } = await runFixture({ reporters: 'tree' });
 

--- a/packages/vitest/src/node/reporter.ts
+++ b/packages/vitest/src/node/reporter.ts
@@ -79,9 +79,15 @@ export class ChromaticReporter implements Reporter {
       return;
     }
 
-    const noSlowTests = Array.from(testModule.children.allTests()).every(
-      (testCase) => testCase.diagnostic()?.slow !== true
-    );
+    let noSlowTests = true;
+
+    for (const testCase of testModule.children.allTests()) {
+      if (testCase.diagnostic()?.slow) {
+        noSlowTests = false;
+        break;
+      }
+    }
+
     const indentProjectName = noSlowTests && this.options.builtInReporter === 'default';
 
     this.logSnapshots({

--- a/packages/vitest/src/node/reporter.ts
+++ b/packages/vitest/src/node/reporter.ts
@@ -79,10 +79,15 @@ export class ChromaticReporter implements Reporter {
       return;
     }
 
+    const noSlowTests = Array.from(testModule.children.allTests()).every(
+      (testCase) => testCase.diagnostic()?.slow !== true
+    );
+    const indentProjectName = noSlowTests && this.options.builtInReporter === 'default';
+
     this.logSnapshots({
       count: this.snapshotCountPerEntity.get(testModule.id) ?? 0,
-      indentation: this.options.builtInReporter === 'default' ? 3 : 2,
-      projectName: this.options.builtInReporter === 'default' && testModule.project.name,
+      indentation: indentProjectName ? 3 : 2,
+      projectName: indentProjectName && testModule.project.name,
     });
   }
 

--- a/packages/vitest/test/fixtures/reporter-1.test.ts
+++ b/packages/vitest/test/fixtures/reporter-1.test.ts
@@ -1,6 +1,12 @@
-import { test } from 'vitest';
+import { inject, test } from 'vitest';
 import { takeSnapshot } from '../../src';
 
-test.each([1, 2, 3])('test #%i', async () => {
+const delay = inject('delay');
+
+test.each([1, 2, 3])('test #%i', async (index) => {
+  if (delay && index > 2) {
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+
   await takeSnapshot();
 });

--- a/packages/vitest/test/fixtures/reporter-2.test.ts
+++ b/packages/vitest/test/fixtures/reporter-2.test.ts
@@ -1,6 +1,12 @@
-import { test } from 'vitest';
+import { inject, test } from 'vitest';
 import { takeSnapshot } from '../../src';
 
-test.each([1, 2, 3, 4])('test #%i', async () => {
+const delay = inject('delay');
+
+test.each([1, 2, 3, 4])('test #%i', async (index) => {
+  if (delay && index > 2) {
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+
   await takeSnapshot();
 });

--- a/packages/vitest/test/fixtures/reporter-3.test.ts
+++ b/packages/vitest/test/fixtures/reporter-3.test.ts
@@ -1,6 +1,12 @@
-import { test } from 'vitest';
+import { inject, test } from 'vitest';
 import { takeSnapshot } from '../../src';
 
-test.each([1, 2, 3, 4, 5])('test #%i', async () => {
+const delay = inject('delay');
+
+test.each([1, 2, 3, 4, 5])('test #%i', async (index) => {
+  if (delay && index > 2) {
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+
   await takeSnapshot();
 });

--- a/packages/vitest/vitest.config.browser.ts
+++ b/packages/vitest/vitest.config.browser.ts
@@ -40,6 +40,7 @@ declare module 'vitest' {
   export interface ProvidedContext {
     processCwd: string;
     testName?: string;
+    delay?: number;
     disableAutoSnapshot: 'module' | 'describe' | 'describe-nested' | 'test' | 'test-second';
     configureScope: 'module' | 'describe' | 'describe-nested' | 'test' | 'test-second';
     configureOptions: ConfigureOptions;


### PR DESCRIPTION
Issue: CAP-4605

## What Changed

When Vitest's `default` reporter logs slow test cases, align reporter output to the top level instead of aligning it with the project name.

```diff
 RUN  v4.0.0 x/packages/vitest/test/fixtures

 ✓  chromium  reporter-1.test.ts (3 tests) 2.1s
   ✓ test #3  1.1s
-             (6 archives captured)
+  (6 archives captured)
 ✓  chromium  reporter-2.test.ts (4 tests) 3.2s
   ✓ test #3  1.1s
   ✓ test #4  1.2s
-             (8 archives captured)
+  (8 archives captured)
 ✓  chromium  reporter-3.test.ts (5 tests) 50ms
              (10 archives captured)
```

So final log looks like:

```
 RUN  v4.0.0 x/packages/vitest/test/fixtures

 ✓  chromium  reporter-1.test.ts (3 tests) 2.1s
   ✓ test #3  1.1s
   (6 archives captured)
 ✓  chromium  reporter-2.test.ts (4 tests) 3.2s
   ✓ test #3  1.1s
   ✓ test #4  1.2s
   (8 archives captured)
 ✓  chromium  reporter-3.test.ts (5 tests) 50ms
              (10 archives captured)
```

## How to test

- Added test case that fails without the fix
- @jonniebigodes to verify preview build