### PR TITLE
fix(playwright): snapshot script fails in `javaScriptEnabled: false`

### DIFF
--- a/.changeset/fine-trams-hang.md
+++ b/.changeset/fine-trams-hang.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/playwright': patch
+---
+
+Fix: Snapshot script fails when Javascript is disabled

--- a/packages/playwright/src/browser.ts
+++ b/packages/playwright/src/browser.ts
@@ -2,14 +2,7 @@ import { snapshot, createMirror } from '@chromaui/rrweb-snapshot';
 import { type DOMSnapshots } from '@chromatic-com/shared-e2e';
 import { type serializedNodeWithId } from '@rrweb/types';
 
-export type WindowContext = Window & {
-  __chromatic_takeSnapshot: typeof takeSnapshot;
-};
-
-/**
- * Expose a function that server side will call. See {@link file://./takeSnapshot.ts}
- */
-(window as unknown as WindowContext).__chromatic_takeSnapshot = takeSnapshot;
+export type { takeSnapshot };
 
 async function takeSnapshot() {
   const mirror = createMirror();
@@ -64,3 +57,6 @@ async function toDataURL(url: string): Promise<string> {
     reader.readAsDataURL(blob);
   });
 }
+
+// This is never used, but needed to mark takeSnapshot as used to avoid tree-shaking dropping it
+(window as any).__chromatic_takeSnapshot = takeSnapshot;

--- a/packages/playwright/src/takeSnapshot.test.ts
+++ b/packages/playwright/src/takeSnapshot.test.ts
@@ -11,8 +11,6 @@ const fakePage = {
   evaluate: () => JSON.stringify({ domSnapshot: {}, pseudoClassIds: {} }),
   viewportSize: () => ({ width: 100, height: 200 }),
   frames: () => [],
-  addScriptTag: () => {},
-  waitForFunction: () => {},
 } as Page;
 
 describe('Snapshot storage', () => {
@@ -90,8 +88,6 @@ describe('Snapshot storage', () => {
           },
           pseudoClassIds: {},
         }),
-      addScriptTag: () => {},
-      waitForFunction: () => {},
       viewportSize: () => ({ width: 100, height: 200 }),
       frames: () => [
         fakePage,
@@ -102,8 +98,6 @@ describe('Snapshot storage', () => {
               pseudoClassIds: { ':hover': [10] },
             }),
           url: () => iframes[0].attributes.src,
-          addScriptTag: () => {},
-          waitForFunction: () => {},
         },
         {
           evaluate: () =>
@@ -112,8 +106,6 @@ describe('Snapshot storage', () => {
               pseudoClassIds: { ':focus': [20] },
             }),
           url: () => iframes[1].attributes.src,
-          addScriptTag: () => {},
-          waitForFunction: () => {},
         },
       ],
     } as unknown as Page;

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -1,7 +1,11 @@
+import { readFileSync } from 'node:fs';
 import type { Frame, Page, TestInfo } from '@playwright/test';
 import { NodeType, type serializedNodeWithId } from '@rrweb/types';
 import { type DOMSnapshots, type SerializedIframeNode, logger } from '@chromatic-com/shared-e2e';
-import type { WindowContext } from './browser';
+import type { takeSnapshot as browserTakeSnapshot } from './browser';
+
+const browserEntry = require.resolve('@chromatic-com/playwright/browser');
+const browserScript = readFileSync(browserEntry, 'utf-8');
 
 type TestID = TestInfo['testId'];
 type SnapshotName = keyof DOMSnapshots;
@@ -79,24 +83,18 @@ async function takeSnapshot(
 }
 
 async function executeSnapshotScript(context: Page | Frame) {
-  await context.addScriptTag({
-    type: 'module',
-    path: require.resolve('@chromatic-com/playwright/browser'),
-  });
+  const snapshot = await context.evaluate<string>(
+    // Wrapper is needed to scope all inlined definitions of browser script, as
+    // it contains bundled rrweb-snapshot that inlines variables like "const node = ...".
+    `async function wrapper() {
+      ${browserScript}
 
-  // addScriptTag doesn't await load for inline (path/content) injection, and
-  // module scripts are deferred, so the module may not have run yet. Wait for
-  // the function to avoid `__chromatic_takeSnapshot is not a function`.
-  await context.waitForFunction(
-    () => typeof (window as unknown as WindowContext).__chromatic_takeSnapshot === 'function'
+      return JSON.stringify(await takeSnapshot());
+    }()`
   );
 
-  const snapshot = await context.evaluate(async () => {
-    // Additional JSON.stringify + parse needed for deeply nested DOMs: https://github.com/chromaui/chromatic-e2e/issues/307
-    return JSON.stringify(await (window as unknown as WindowContext).__chromatic_takeSnapshot());
-  });
-
-  return JSON.parse(snapshot) as ReturnType<WindowContext['__chromatic_takeSnapshot']>;
+  // Additional JSON.stringify + parse needed for deeply nested DOMs: https://github.com/chromaui/chromatic-e2e/issues/307
+  return JSON.parse(snapshot) as ReturnType<typeof browserTakeSnapshot>;
 }
 
 function findIframes(

--- a/packages/playwright/tests/javascript-disabled.spec.ts
+++ b/packages/playwright/tests/javascript-disabled.spec.ts
@@ -1,0 +1,11 @@
+import { takeSnapshot, test } from '../src';
+
+test.describe('', () => {
+  test.use({ javaScriptEnabled: false, disableAutoSnapshot: true });
+
+  test('visiting page while JavaScript disabled', async ({ page }, testInfo) => {
+    await page.goto('/');
+
+    await takeSnapshot(page, testInfo);
+  });
+});


### PR DESCRIPTION
Issue:
- Fixes https://github.com/chromaui/chromatic-e2e/issues/373

## What Changed

Switched Playwright package's snapshot execution to use just `page.evaluate` instead of `addScriptTag`.

## How to test

Added failing e2e test for Playwright. 
