### PR TITLE
fix(playwright): prevent duplicate story ids by allowing multiple projects to overwrite each others results like before

### DIFF
--- a/.changeset/khaki-dogs-think.md
+++ b/.changeset/khaki-dogs-think.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/playwright': patch
+---
+
+Fix: Prevent duplicate story ids by allowing multiple projects to overwrite each others results like before

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -45,7 +45,8 @@ const writeArchives = async ({
     },
     allSnapshots,
     resourceArchive,
-    chromaticStorybookParams
+    chromaticStorybookParams,
+    'cypress'
   );
 };
 

--- a/packages/playwright/src/makeTest.ts
+++ b/packages/playwright/src/makeTest.ts
@@ -83,7 +83,8 @@ export const performChromaticSnapshot = async (
         prefersReducedMotion,
         cropToViewport,
         ignoreSelectors,
-      }
+      },
+      'playwright'
     );
 
     trackComplete();

--- a/packages/shared/src/write-archive/index.test.ts
+++ b/packages/shared/src/write-archive/index.test.ts
@@ -59,7 +59,7 @@ describe('writeTestResult', () => {
     expect(filePaths.outputFile).toHaveBeenCalledTimes(2);
     expect(filePaths.outputJSONFile).toHaveBeenCalledTimes(1);
     expect(filePaths.outputJSONFile).toHaveBeenCalledWith(
-      resolve('./test-results/chromatic-archives/file-test-story-1.stories.json'),
+      resolve('./test-results/chromatic-archives/file-test-story.stories.json'),
       {
         stories: [
           {
@@ -168,9 +168,7 @@ describe('writeTestResult', () => {
     expect(filePaths.outputFile).toHaveBeenCalledTimes(2);
     expect(filePaths.outputJSONFile).toHaveBeenCalledTimes(1);
     expect(filePaths.outputJSONFile).toHaveBeenCalledWith(
-      resolve(
-        './some-custom-directory/directory/chromatic-archives/file-test-story-1.stories.json'
-      ),
+      resolve('./some-custom-directory/directory/chromatic-archives/file-test-story.stories.json'),
       expect.anything()
     );
   });

--- a/packages/shared/src/write-archive/index.ts
+++ b/packages/shared/src/write-archive/index.ts
@@ -29,7 +29,8 @@ export async function writeTestResult(
   e2eTestInfo: E2ETestInfo,
   domSnapshots: DOMSnapshots,
   archive: ResourceArchive,
-  chromaticStorybookParams: RequiredButOptional<ChromaticStorybookParameters>
+  chromaticStorybookParams: RequiredButOptional<ChromaticStorybookParameters>,
+  testRunner?: 'cypress' | 'playwright' | 'vitest'
 ) {
   const { titlePath, outputDir, pageUrl } = e2eTestInfo;
   // remove the test file extensions (.spec.ts|ts, .cy.ts|js), preserving other periods in directory, file name, or test titles
@@ -91,7 +92,7 @@ export async function writeTestResult(
     })
   );
 
-  const storiesFile = storiesFileName(title);
+  const storiesFile = storiesFileName(title, testRunner !== 'vitest');
   const storiesJson = createStories(title, domSnapshots, chromaticStorybookParams);
   await outputJSONFile(join(finalOutputDir, storiesFile), storiesJson);
 

--- a/packages/shared/src/write-archive/stories-files.test.ts
+++ b/packages/shared/src/write-archive/stories-files.test.ts
@@ -12,13 +12,12 @@ const vports = [
 
 beforeEach(() => {
   vi.resetAllMocks();
-  storiesFiles.uniqueId.value = 1;
 });
 
 describe('storiesFileName', () => {
   it('sanitizes the file name', () => {
     const fileName = storiesFiles.storiesFileName('--a title *() with $%& chars---');
-    expect(fileName).toEqual(`a-title-with-chars-1.stories.json`);
+    expect(fileName).toEqual(`a-title-with-chars.stories.json`);
   });
 
   it('truncates long file names', () => {
@@ -35,7 +34,7 @@ describe('storiesFileName', () => {
     const title = '\n\n\r\rThere\nShould\rBe\r\nNo\n\rNewlines\r\r\n\n';
 
     const filename = storiesFiles.storiesFileName(title);
-    expect(filename).toEqual('there-should-be-no-newlines-1.stories.json');
+    expect(filename).toEqual('there-should-be-no-newlines.stories.json');
   });
 });
 

--- a/packages/shared/src/write-archive/stories-files.ts
+++ b/packages/shared/src/write-archive/stories-files.ts
@@ -10,8 +10,16 @@ const STORIES_FILE_EXT = 'stories.json';
 export const uniqueId = { value: 1 };
 
 // Generates a file-system-safe file name from a story title
-export function storiesFileName(testTitle: string) {
-  const fileName = [sanitize(testTitle) + '-' + uniqueId.value++, STORIES_FILE_EXT].join('.');
+export function storiesFileName(testTitle: string, overwriteDuplicateNames = true) {
+  let title = sanitize(testTitle);
+
+  // If multiple test runner project generate the same name, it's random which one ends up on file system
+  if (!overwriteDuplicateNames) {
+    title += '-' + uniqueId.value++;
+  }
+
+  const fileName = [title, STORIES_FILE_EXT].join('.');
+
   // Leave room for built storybook extensions that may be added (like `-stories.iframe.bundle.js`)
   const maxByteLength = MAX_FILE_NAME_BYTE_LENGTH - 25;
   return truncateFileName(fileName, maxByteLength);

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -187,7 +187,8 @@ export function createCommands(options: ResolvedOptions) {
           prefersReducedMotion: testOptions.prefersReducedMotion ?? options.prefersReducedMotion,
           cropToViewport: testOptions.cropToViewport ?? options.cropToViewport,
           ignoreSelectors: testOptions.ignoreSelectors ?? options.ignoreSelectors,
-        }
+        },
+        'vitest'
       );
     },
 


### PR DESCRIPTION
Issue:
- Fixes https://github.com/chromaui/chromatic-e2e/issues/397

## What Changed

Don't create unique filenames in Playwright (and Cypress), so that multiple projects will silently overwrite each other's results, and we don't end up with duplicate story ids on file system.

Proper fix would be to use project name or index as prefix in title, but that's breaking change. 

## How to test

- [x] Post preview release in bug report and see if users are unblocked