### PR TITLE
fix(vitest): prevent duplicate story names error when test name is identical in same file

### DIFF
--- a/.changeset/little-states-laugh.md
+++ b/.changeset/little-states-laugh.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: Prevent duplicate story names error when test name is identical in same file

--- a/packages/cypress/tests/cypress/e2e/duplicate-test-names.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/duplicate-test-names.cy.ts
@@ -1,0 +1,16 @@
+describe('duplicate test names', () => {
+  it('example', () => {
+    cy.visit('/');
+  });
+
+  it('example', () => {
+    cy.visit('/');
+  });
+});
+
+it('duplicate snapshot names', { env: { disableAutoSnapshot: true } }, () => {
+  cy.visit('/');
+
+  cy.takeSnapshot('example');
+  cy.takeSnapshot('example');
+});

--- a/packages/playwright/tests/duplicate-test-names.spec.ts
+++ b/packages/playwright/tests/duplicate-test-names.spec.ts
@@ -1,0 +1,17 @@
+/*
+ * Playwright does not support identical test names. It throws error:
+ * - `Error: duplicate test title "duplicate test names › example", first declared in duplicate-test-names.spec.ts:4`
+ *
+ * So let's only test duplicate snapshot names.
+ */
+
+import { takeSnapshot, test } from '../src';
+
+test.use({ disableAutoSnapshot: true });
+
+test('duplicate snapshot names', async ({ page }, testInfo) => {
+  await page.goto('/');
+
+  await takeSnapshot(page, 'example', testInfo);
+  await takeSnapshot(page, 'example', testInfo);
+});

--- a/packages/vitest/src/node/commands.test.ts
+++ b/packages/vitest/src/node/commands.test.ts
@@ -33,12 +33,27 @@ test('writes test results with full test name', async () => {
       ],
       [
         "test-names",
-        "duplicate test name / Snapshot #1",
+        "duplicate test name / Snapshot #1 (2)",
+      ],
+      [
+        "test-names",
+        "duplicate test name / Snapshot #1 (3)",
+      ],
+      [
+        "test-names",
+        "duplicate test name with special character @ / Snapshot #1",
+      ],
+      [
+        "test-names",
+        "duplicate test name with special character * / Snapshot #1 (2)",
+      ],
+      [
+        "test-names",
+        "duplicate test name with special character # / Snapshot #1 (3)",
       ],
       [
         "test-names",
         "duplicate snapshot names / example",
-        "duplicate snapshot names / Snapshot #2",
       ],
     ]
   `);

--- a/packages/vitest/src/node/commands.test.ts
+++ b/packages/vitest/src/node/commands.test.ts
@@ -27,6 +27,19 @@ test('writes test results with full test name', async () => {
         "test-names",
         "suite #3 / nested suite #3 / test #3 / Snapshot #1",
       ],
+      [
+        "test-names",
+        "duplicate test name / Snapshot #1",
+      ],
+      [
+        "test-names",
+        "duplicate test name / Snapshot #1",
+      ],
+      [
+        "test-names",
+        "duplicate snapshot names / example",
+        "duplicate snapshot names / Snapshot #2",
+      ],
     ]
   `);
 });

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import { resolve } from 'node:path';
+import { storyNameFromExport, toId } from 'storybook/internal/csf';
 import type {
   TestCase,
   TestModule,
@@ -27,6 +28,7 @@ type SnapshotName = keyof DOMSnapshots;
 export function createCommands(options: ResolvedOptions) {
   const resourceArchivers = new Map<SessionId, ResourceArchiver>();
   const networkIdleTrackers = new Map<SessionId, NetworkIdleTracker>();
+  const savedResults = new Set<string>();
   const snapshots = new Map<
     TestID,
     Map<
@@ -149,9 +151,13 @@ export function createCommands(options: ResolvedOptions) {
       assert(sessionSnapshots, `No snapshots found for test ${id}`);
 
       const snapshotBuffers: DOMSnapshots = {};
+      const titlePath = testOptions.title ? [testOptions.title] : getTitle(entity);
 
       for (const [name, { snapshot, viewport, pseudoClassIds }] of sessionSnapshots) {
-        const names = getSnapshotPrefix(entity).concat(name).join(' / ');
+        const names = generateUniqueSnapshotName({
+          snapshotName: getSnapshotPrefix(entity).concat(name),
+          titlePath,
+        });
 
         snapshotBuffers[names] = {
           snapshot: Buffer.from(JSON.stringify(snapshot)),
@@ -173,7 +179,7 @@ export function createCommands(options: ResolvedOptions) {
         {
           outputDir: resolve(context.project.vitest.config.root, options.outputDirectory),
           pageUrl: context.page.url(),
-          titlePath: testOptions.title ? [testOptions.title] : getTitle(entity),
+          titlePath,
         },
         snapshotBuffers,
         archive,
@@ -210,6 +216,7 @@ export function createCommands(options: ResolvedOptions) {
       resourceArchivers.clear();
       networkIdleTrackers.clear();
       snapshots.clear();
+      savedResults.clear();
     },
 
     /**
@@ -238,6 +245,25 @@ export function createCommands(options: ResolvedOptions) {
     snapshots.delete(id);
 
     return { archive: resourceArchiver.archive, sessionSnapshots };
+  }
+
+  function generateUniqueSnapshotName(options: { snapshotName: string[]; titlePath: string[] }) {
+    const names = options.snapshotName.join(' / ');
+    const base = toId(options.titlePath.join(' / '), storyNameFromExport(names));
+
+    let key = base;
+    let count = 1;
+
+    while (savedResults.has(key)) {
+      key = `${base} (${count++})`;
+    }
+    savedResults.add(key);
+
+    if (count > 1) {
+      return `${names} (${count})`;
+    }
+
+    return names;
   }
 }
 

--- a/packages/vitest/test/duplicate-test-names.test.ts
+++ b/packages/vitest/test/duplicate-test-names.test.ts
@@ -1,0 +1,15 @@
+import { configure, takeSnapshot } from '../dist';
+import { test } from './utils/browser';
+
+test.each(['one', 'two'])('duplicate test name', async (label) => {
+  document.body.innerHTML = `<button>${label}</button>`;
+});
+
+test('duplicate snapshot names', async () => {
+  configure({ disableAutoSnapshot: true });
+
+  document.body.innerHTML = `<button>Example</button>`;
+
+  await takeSnapshot('example');
+  await takeSnapshot('example');
+});

--- a/packages/vitest/test/fixtures/test-names.test.ts
+++ b/packages/vitest/test/fixtures/test-names.test.ts
@@ -1,5 +1,5 @@
 import { describe, test } from 'vitest';
-import { takeSnapshot } from '../../src';
+import { configure, takeSnapshot } from '../../src';
 
 test('test #1', () => {});
 
@@ -15,8 +15,16 @@ describe('suite #3', () => {
 
 test('duplicate test name', () => {});
 test('duplicate test name', () => {});
+test('duplicate test name', () => {});
+
+test('duplicate test name with special character @', () => {});
+test('duplicate test name with special character *', () => {});
+test('duplicate test name with special character #', () => {});
 
 test('duplicate snapshot names', async () => {
+  configure({ disableAutoSnapshot: true });
+
+  // Duplicate snapshot names override each other
   await takeSnapshot('example');
   await takeSnapshot('example');
 });

--- a/packages/vitest/test/fixtures/test-names.test.ts
+++ b/packages/vitest/test/fixtures/test-names.test.ts
@@ -1,4 +1,5 @@
 import { describe, test } from 'vitest';
+import { takeSnapshot } from '../../src';
 
 test('test #1', () => {});
 
@@ -10,4 +11,12 @@ describe('suite #3', () => {
   describe('nested suite #3', () => {
     test('test #3', () => {});
   });
+});
+
+test('duplicate test name', () => {});
+test('duplicate test name', () => {});
+
+test('duplicate snapshot names', async () => {
+  await takeSnapshot('example');
+  await takeSnapshot('example');
 });


### PR DESCRIPTION
Issue: https://github.com/chromaui/chromatic-e2e/issues/407

## What Changed

Store keys of the written snapshots on module level scope to make sure duplicate test names don't cause duplicate Story IDs in Storybook build.

## How to test

Added failing test cases.
