### PR TITLE
fix(vitest): prevent `storybook build` from using user's `.browserslistrc`

### DIFF
--- a/.changeset/hip-books-study.md
+++ b/.changeset/hip-books-study.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: Prevent `storybook build` from using user's `.browserslistrc`

--- a/packages/vitest/.browserslistrc
+++ b/packages/vitest/.browserslistrc
@@ -1,0 +1,16 @@
+# This file should be ignored, https://github.com/chromaui/chromatic-e2e/pull/409
+
+# When 'build-archive-storybook' pulls this file, 'storybook build' fails with:
+# Error: For the selected environment is no default script chunk format available:
+# │  Module ('module') can be chosen when ES modules are available (please set
+# │  'experiments.outputModule' and 'output.module' to `true`)
+# │  JSONP Array push ('array-push') can be chosen when 'document' or 'importScripts'
+# │  is available.
+# │  CommonJs exports ('commonjs') can be chosen when 'require' or node builtins are
+# │  available.
+# │  Make sure that your 'browserslist' includes only platforms that support these
+# │  features or select an appropriate 'target' to allow selecting a chunk format by
+# │  default. Alternatively specify the 'output.chunkFormat' directly.
+
+[stable]
+and_chr 117

--- a/packages/vitest/src/storybook-config/main.ts
+++ b/packages/vitest/src/storybook-config/main.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import type { StorybookConfig } from '@storybook/server-webpack5';
 import { archivesDir } from '@chromatic-com/shared-e2e/utils/filePaths';
 import { DEFAULT_OUTPUT_DIR } from '../constants';
 
@@ -10,8 +11,7 @@ const __dirname = path.dirname(__filename);
 const packageRoot = path.resolve(__dirname, '..', '..');
 const embeddedDir = path.join(packageRoot, 'embedded', 'node_modules');
 
-/** @type {import('@storybook/server-webpack5').StorybookConfig} */
-export default {
+export default <StorybookConfig>{
   stories: [path.resolve(archivesDir(DEFAULT_OUTPUT_DIR), '*.stories.json')],
   managerEntries: [path.resolve(__dirname, 'manager.js')],
   previewAnnotations: [path.resolve(__dirname, 'preview.js')],
@@ -21,11 +21,20 @@ export default {
   },
   core: {
     // ESM does not support directory imports; point to the package entry file.
-    builder: pathToFileURL(path.join(embeddedDir, '@storybook', 'builder-webpack5', 'dist', 'index.js')).href,
+    builder: pathToFileURL(
+      path.join(embeddedDir, '@storybook', 'builder-webpack5', 'dist', 'index.js')
+    ).href,
     renderer: pathToFileURL(path.join(embeddedDir, '@storybook', 'server', 'preset.js')).href,
   },
   staticDirs: [path.resolve(archivesDir(DEFAULT_OUTPUT_DIR), 'archive')],
   features: {
     sidebarOnboardingChecklist: false,
+  },
+  webpackFinal: async (config) => {
+    // Webpack defaults to `target: 'browserslist'`, which makes 'storybook build' transform
+    // files based on the user's `.browserslistrc`: https://webpack.js.org/configuration/target/
+    config.target = ['web'];
+
+    return config;
   },
 };


### PR DESCRIPTION
Issue: QA part of #353 

## What Changed

Set `target` to webpack build so that it doesn't look for `.browserslistrc` from end-user's project.

https://webpack.js.org/configuration/target/

> Defaults to 'browserslist' or to 'web' when no browserslist configuration was found.

## How to test

- Added `.browserslistrc` that makes `packages/vitest/test` fail without the fix: https://github.com/chromaui/chromatic-e2e/actions/runs/28090515046/job/83167081245?pr=409