### PR TITLE
feat: add `colorScheme` option

### DIFF
--- a/.changeset/social-worms-enjoy.md
+++ b/.changeset/social-worms-enjoy.md
@@ -1,0 +1,8 @@
+---
+'@chromatic-com/playwright': patch
+'@chromatic-com/cypress': patch
+'@chromatic-com/shared-e2e': patch
+'@chromatic-com/vitest': patch
+---
+
+Feat: add support for setting `colorScheme`

--- a/packages/cypress/src/commands.ts
+++ b/packages/cypress/src/commands.ts
@@ -24,11 +24,12 @@ Cypress.Commands.add('takeSnapshot', (name?: string) => {
 
   cy.window().then((win) => {
     const viewport = { width: win.innerWidth, height: win.innerHeight };
+    const colorScheme = win.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 
     cy.document().then((doc) => {
       // here, handle the source map
 
-      cy.wrap(takeChromaticSnapshot(doc, viewport, true)).then(
+      cy.wrap(takeChromaticSnapshot(doc, viewport, colorScheme, true)).then(
         (manualSnapshot: CypressSnapshot) => {
           // reassign manualSnapshots so it includes this new snapshot
           cy.get('@manualSnapshots')

--- a/packages/cypress/src/index.ts
+++ b/packages/cypress/src/index.ts
@@ -31,9 +31,9 @@ const writeArchives = async ({
 }: WriteArchivesParams) => {
   const allSnapshots = Object.fromEntries(
     // manual snapshots can be given a name; otherwise, just use the snapshot's place in line as the name
-    domSnapshots.map(({ name, snapshot, viewport, pseudoClassIds }, index) => [
+    domSnapshots.map(({ name, snapshot, viewport, colorScheme, pseudoClassIds }, index) => [
       name ?? `Snapshot #${index + 1}`,
-      { snapshot: Buffer.from(JSON.stringify(snapshot)), viewport, pseudoClassIds },
+      { snapshot: Buffer.from(JSON.stringify(snapshot)), viewport, colorScheme, pseudoClassIds },
     ])
   );
 

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -51,32 +51,36 @@ afterEach(() => {
   }
   cy.window().then((win) => {
     const viewport = { width: win.innerWidth, height: win.innerHeight };
+    const colorScheme = win.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+
     // can we be sure this always fires after all the requests are back?
     cy.document().then((doc) => {
-      cy.wrap(takeSnapshot(doc, viewport)).then((automaticSnapshot: CypressSnapshot) => {
-        cy.get('@manualSnapshots').then((manualSnapshots = []) => {
-          cy.url().then((url) => {
-            // pass the snapshot to the server to write to disk
-            cy.task('prepareArchives', {
-              action: 'save-archives',
-              payload: {
-                testTitlePath: [
-                  // @ts-expect-error relativeToCommonRoot is on spec (but undocumented)
-                  Cypress.spec.relativeToCommonRoot,
-                  ...Cypress.currentTest.titlePath,
-                ],
-                domSnapshots: [
-                  ...manualSnapshots,
-                  ...(automaticSnapshot ? [automaticSnapshot] : []),
-                ],
-                chromaticStorybookParams: buildChromaticParams(Cypress.expose),
-                pageUrl: url,
-                outputDir: Cypress.config('downloadsFolder'),
-              },
+      cy.wrap(takeSnapshot(doc, viewport, colorScheme)).then(
+        (automaticSnapshot: CypressSnapshot) => {
+          cy.get('@manualSnapshots').then((manualSnapshots = []) => {
+            cy.url().then((url) => {
+              // pass the snapshot to the server to write to disk
+              cy.task('prepareArchives', {
+                action: 'save-archives',
+                payload: {
+                  testTitlePath: [
+                    // @ts-expect-error relativeToCommonRoot is on spec (but undocumented)
+                    Cypress.spec.relativeToCommonRoot,
+                    ...Cypress.currentTest.titlePath,
+                  ],
+                  domSnapshots: [
+                    ...manualSnapshots,
+                    ...(automaticSnapshot ? [automaticSnapshot] : []),
+                  ],
+                  chromaticStorybookParams: buildChromaticParams(Cypress.expose),
+                  pageUrl: url,
+                  outputDir: Cypress.config('downloadsFolder'),
+                },
+              });
             });
           });
-        });
-      });
+        }
+      );
     });
   });
 });

--- a/packages/cypress/src/takeSnapshot.ts
+++ b/packages/cypress/src/takeSnapshot.ts
@@ -5,6 +5,7 @@ import type { serializedNodeWithId } from '@rrweb/types';
 export const takeSnapshot = (
   doc: Document,
   viewport: { width: number; height: number },
+  colorScheme: 'light' | 'dark',
   isManualSnapshot?: boolean
 ): Promise<CypressSnapshot | null> => {
   return new Promise((resolve) => {
@@ -17,7 +18,7 @@ export const takeSnapshot = (
 
     const pseudoClassIds: CypressSnapshot['pseudoClassIds'] = {};
 
-    for (const className of [':hover', ':focus', ':focus-visible', ':active']) {
+    for (const className of [':hover', ':focus', ':focus-visible', ':active'] as const) {
       const elements = doc.querySelectorAll(className);
       const ids = Array.from(elements, (el) => mirror.getId(el)).filter((id) => id !== -1);
       pseudoClassIds[className] = ids;
@@ -54,7 +55,7 @@ export const takeSnapshot = (
     };
 
     replaceBlobUrls(domSnapshot).then(() => {
-      resolve({ snapshot: domSnapshot, viewport, pseudoClassIds });
+      resolve({ snapshot: domSnapshot, viewport, colorScheme, pseudoClassIds });
     });
   });
 };

--- a/packages/cypress/src/types.ts
+++ b/packages/cypress/src/types.ts
@@ -7,5 +7,6 @@ export interface CypressSnapshot {
   // the DOM snapshot
   snapshot: serializedNodeWithId;
   viewport: DOMSnapshots[string]['viewport'];
+  colorScheme: DOMSnapshots[string]['colorScheme'];
   pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'];
 }

--- a/packages/cypress/tests/cypress/e2e/color-scheme.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/color-scheme.cy.ts
@@ -1,0 +1,51 @@
+afterEach(() => {
+  // Reset the emulation so it doesn't leak into other spec files
+  cy.wrap(null).then(() =>
+    Cypress.automation('remote:debugger:protocol', {
+      command: 'Emulation.setEmulatedMedia',
+      params: { features: [] },
+    })
+  );
+});
+
+describe('light color scheme', () => {
+  it('renders the light-only content', () => {
+    cy.wrap(null).then(() => setColorScheme('light'));
+    cy.visit('/color-scheme');
+
+    cy.contains('Only visible in LIGHT mode').should('be.visible');
+    cy.contains('Only visible in DARK mode').should('not.be.visible');
+  });
+});
+
+describe('dark color scheme', () => {
+  it('renders the dark-only content', () => {
+    cy.wrap(null).then(() => setColorScheme('dark'));
+    cy.visit('/color-scheme');
+
+    cy.contains('Only visible in DARK mode').should('be.visible');
+    cy.contains('Only visible in LIGHT mode').should('not.be.visible');
+  });
+});
+
+it(
+  'captures both color schemes inside a single test case',
+  { expose: { disableAutoSnapshot: true } },
+  () => {
+    cy.wrap(null).then(() => setColorScheme('dark'));
+    cy.visit('/color-scheme');
+    cy.contains('Only visible in DARK mode').should('be.visible');
+    cy.takeSnapshot('dark');
+
+    cy.wrap(null).then(() => setColorScheme('light'));
+    cy.contains('Only visible in LIGHT mode').should('be.visible');
+    cy.takeSnapshot('light');
+  }
+);
+
+function setColorScheme(value: 'light' | 'dark') {
+  return Cypress.automation('remote:debugger:protocol', {
+    command: 'Emulation.setEmulatedMedia',
+    params: { features: [{ name: 'prefers-color-scheme', value }] },
+  });
+}

--- a/packages/playwright/src/browser.ts
+++ b/packages/playwright/src/browser.ts
@@ -8,6 +8,8 @@ async function takeSnapshot() {
   const mirror = createMirror();
   const domSnapshot = snapshot(document, { recordCanvas: true, mirror });
 
+  const colorScheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+
   const pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'] = {};
 
   for (const className of [':hover', ':focus', ':focus-visible', ':active'] as const) {
@@ -18,7 +20,7 @@ async function takeSnapshot() {
 
   await replaceBlobUrls(domSnapshot);
 
-  return { domSnapshot, pseudoClassIds };
+  return { domSnapshot, pseudoClassIds, colorScheme } as const;
 }
 
 async function replaceBlobUrls(node: serializedNodeWithId) {

--- a/packages/playwright/src/takeSnapshot.ts
+++ b/packages/playwright/src/takeSnapshot.ts
@@ -38,7 +38,7 @@ async function takeSnapshot(
   });
 
   // Serialize and capture the DOM
-  const { domSnapshot, pseudoClassIds } = await executeSnapshotScript(page);
+  const { domSnapshot, pseudoClassIds, colorScheme } = await executeSnapshotScript(page);
 
   // First iframe is the main document, skip it.
   // This returns all iframes, even the nested ones.
@@ -78,6 +78,7 @@ async function takeSnapshot(
   chromaticSnapshots.get(testId).set(name, {
     snapshot: bufferedSnapshot,
     viewport: page.viewportSize() || { width: 1280, height: 720 },
+    colorScheme,
     pseudoClassIds,
   });
 }

--- a/packages/playwright/tests/color-scheme.spec.ts
+++ b/packages/playwright/tests/color-scheme.spec.ts
@@ -22,13 +22,17 @@ test.describe('dark color scheme', () => {
   });
 });
 
-test('captures both color schemes inside a single test case', async ({ page }, testInfo) => {
-  await page.emulateMedia({ colorScheme: 'light' });
-  await page.goto('/color-scheme');
-  await expect(page.getByText('Only visible in LIGHT mode')).toBeVisible();
-  await takeSnapshot(page, 'light', testInfo);
+test.describe(() => {
+  test.use({ disableAutoSnapshot: true });
 
-  await page.emulateMedia({ colorScheme: 'dark' });
-  await expect(page.getByText('Only visible in DARK mode')).toBeVisible();
-  await takeSnapshot(page, 'dark', testInfo);
+  test('captures both color schemes inside a single test case', async ({ page }, testInfo) => {
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.goto('/color-scheme');
+    await expect(page.getByText('Only visible in DARK mode')).toBeVisible();
+    await takeSnapshot(page, 'dark', testInfo);
+
+    await page.emulateMedia({ colorScheme: 'light' });
+    await expect(page.getByText('Only visible in LIGHT mode')).toBeVisible();
+    await takeSnapshot(page, 'light', testInfo);
+  });
 });

--- a/packages/playwright/tests/color-scheme.spec.ts
+++ b/packages/playwright/tests/color-scheme.spec.ts
@@ -1,0 +1,34 @@
+import { expect, takeSnapshot, test } from '../src';
+
+test.describe('light color scheme', () => {
+  test.use({ colorScheme: 'light' });
+
+  test('renders the light-only content', async ({ page }) => {
+    await page.goto('/color-scheme');
+
+    await expect(page.getByText('Only visible in LIGHT mode')).toBeVisible();
+    await expect(page.getByText('Only visible in DARK mode')).toBeHidden();
+  });
+});
+
+test.describe('dark color scheme', () => {
+  test.use({ colorScheme: 'dark' });
+
+  test('renders the dark-only content', async ({ page }) => {
+    await page.goto('/color-scheme');
+
+    await expect(page.getByText('Only visible in DARK mode')).toBeVisible();
+    await expect(page.getByText('Only visible in LIGHT mode')).toBeHidden();
+  });
+});
+
+test('captures both color schemes inside a single test case', async ({ page }, testInfo) => {
+  await page.emulateMedia({ colorScheme: 'light' });
+  await page.goto('/color-scheme');
+  await expect(page.getByText('Only visible in LIGHT mode')).toBeVisible();
+  await takeSnapshot(page, 'light', testInfo);
+
+  await page.emulateMedia({ colorScheme: 'dark' });
+  await expect(page.getByText('Only visible in DARK mode')).toBeVisible();
+  await takeSnapshot(page, 'dark', testInfo);
+});

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -57,6 +57,9 @@ export type DOMSnapshots = Record<
     /** Viewport dimensions from the exact time the snapshot was taken */
     viewport: Viewport;
 
+    /** Color scheme from the exact time the snapshot was taken */
+    colorScheme: 'light' | 'dark';
+
     /** Mapping of pseudo-class names to their corresponding rrweb-snapshot element IDs */
     pseudoClassIds: Partial<
       Record<':active' | ':focus' | ':focus-visible' | ':hover', serializedNodeWithId['id'][]>

--- a/packages/shared/src/write-archive/stories-files.ts
+++ b/packages/shared/src/write-archive/stories-files.ts
@@ -35,8 +35,10 @@ export function createStories(
 
   return {
     title,
-    stories: Object.entries(domSnapshots).map(([snapshotName, { viewport, parameters }]) => {
+    stories: Object.entries(domSnapshots).map(([snapshotName, snapshotOptions]) => {
       const name = collapseNewlines(snapshotName);
+
+      const { parameters, viewport, colorScheme } = snapshotOptions;
       const { chromatic: chromaticParams, ...restParameters } = parameters || {};
 
       return {
@@ -53,6 +55,7 @@ export function createStories(
           chromatic: {
             ...chromaticStorybookParams,
             ...chromaticParams,
+            colorScheme,
             modes: buildStoryModesConfig([viewport]),
           },
           viewport: {

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -36,6 +36,7 @@ export function createCommands(options: ResolvedOptions) {
       {
         snapshot: serializedNodeWithId;
         viewport: DOMSnapshots[string]['viewport'];
+        colorScheme: DOMSnapshots[string]['colorScheme'];
         pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'];
       }
     >
@@ -77,12 +78,17 @@ export function createCommands(options: ResolvedOptions) {
       name ||= `Snapshot #${sessionSnapshots.size + 1}`;
 
       const frame = await context.frame();
-      const viewport = await frame.evaluate(() => ({
-        width: window.innerWidth,
-        height: window.innerHeight,
-      }));
+      const { viewport, colorScheme } = await frame.evaluate(
+        () =>
+          ({
+            viewport: { width: window.innerWidth, height: window.innerHeight },
+            colorScheme: window.matchMedia('(prefers-color-scheme: dark)').matches
+              ? 'dark'
+              : 'light',
+          }) as const
+      );
 
-      sessionSnapshots.set(name, { snapshot, viewport, pseudoClassIds });
+      sessionSnapshots.set(name, { snapshot, viewport, colorScheme, pseudoClassIds });
 
       ChromaticReporter.onSnapshot(context.project.vitest, entity);
     },
@@ -153,7 +159,7 @@ export function createCommands(options: ResolvedOptions) {
       const snapshotBuffers: DOMSnapshots = {};
       const titlePath = testOptions.title ? [testOptions.title] : getTitle(entity);
 
-      for (const [name, { snapshot, viewport, pseudoClassIds }] of sessionSnapshots) {
+      for (const [name, { snapshot, viewport, colorScheme, pseudoClassIds }] of sessionSnapshots) {
         const names = generateUniqueSnapshotName({
           snapshotName: getSnapshotPrefix(entity).concat(name),
           titlePath,
@@ -162,6 +168,7 @@ export function createCommands(options: ResolvedOptions) {
         snapshotBuffers[names] = {
           snapshot: Buffer.from(JSON.stringify(snapshot)),
           viewport,
+          colorScheme,
           pseudoClassIds,
           parameters: {
             chromatic: {

--- a/packages/vitest/test/color-scheme.test.ts
+++ b/packages/vitest/test/color-scheme.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect } from 'vitest';
+import { commands, page } from 'vitest/browser';
+import { test } from './utils/browser';
+import { takeSnapshot } from '../src';
+
+beforeEach(async () => {
+  await emulateColorScheme('no-preference');
+});
+
+describe('light color scheme', () => {
+  test('renders the light-only content', async ({ goTo }) => {
+    await emulateColorScheme('light');
+    await goTo('/color-scheme');
+
+    await expect.element(page.getByText('Only visible in LIGHT mode')).toBeVisible();
+    await expect.element(page.getByText('Only visible in DARK mode')).not.toBeVisible();
+  });
+});
+
+describe('dark color scheme', () => {
+  test('renders the dark-only content', async ({ goTo }) => {
+    await emulateColorScheme('dark');
+    await goTo('/color-scheme');
+
+    await expect.element(page.getByText('Only visible in DARK mode')).toBeVisible();
+    await expect.element(page.getByText('Only visible in LIGHT mode')).not.toBeVisible();
+  });
+});
+
+test('captures both color schemes inside a single test case', async ({ goTo }) => {
+  await emulateColorScheme('dark');
+  await goTo('/color-scheme');
+  await expect.element(page.getByText('Only visible in DARK mode')).toBeVisible();
+  await takeSnapshot('dark');
+
+  await emulateColorScheme('light');
+  await expect.element(page.getByText('Only visible in LIGHT mode')).toBeVisible();
+  await takeSnapshot('light');
+});
+
+const emulateColorScheme = (commands as any).emulateColorScheme as (
+  colorScheme: 'light' | 'dark' | 'no-preference'
+) => Promise<void>;

--- a/packages/vitest/test/vitest.config.e2e.ts
+++ b/packages/vitest/test/vitest.config.e2e.ts
@@ -26,6 +26,10 @@ export default defineConfig({
       viewport: { width: 1280, height: 720 },
 
       commands: {
+        async emulateColorScheme(context, colorScheme: 'light' | 'dark' | 'no-preference') {
+          await context.page.emulateMedia({ colorScheme });
+        },
+
         async mousedown(context, selector: string) {
           const frame = await context.frame();
           const box = await frame.locator(selector).boundingBox();
@@ -83,6 +87,7 @@ function testServerProxy() {
     'canvas',
     'amd',
     'css-pseudo-states',
+    'color-scheme',
     '@fz',
     'embeds',
   ];

--- a/test-server/fixtures/color-scheme.html
+++ b/test-server/fixtures/color-scheme.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html>
+  <head>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+
+      body {
+        font-family: sans-serif;
+        padding: 20px;
+        background: white;
+        color: black;
+      }
+
+      .badge {
+        display: block;
+        padding: 20px;
+        margin: 10px 0;
+        font-size: 24px;
+        font-weight: bold;
+        border: 4px solid;
+      }
+
+      /* Visible in both, but restyled per scheme */
+      #always {
+        background: #eee;
+        color: #111;
+        border-color: #999;
+      }
+
+      /* Hidden by default (dark), revealed in light */
+      #light-only {
+        display: none;
+        background: #fffae6;
+        color: #5a4b00;
+        border-color: #e0c200;
+      }
+
+      /* Hidden by default (light), revealed in dark */
+      #dark-only {
+        display: none;
+        background: #1b1b2f;
+        color: #9ad0ff;
+        border-color: #3a6ea5;
+      }
+
+      @media (prefers-color-scheme: light) {
+        #light-only {
+          display: block;
+        }
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #111;
+          color: #eee;
+        }
+
+        #always {
+          background: #222;
+          color: #eee;
+          border-color: #555;
+        }
+
+        #dark-only {
+          display: block;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="always" class="badge">Always visible (restyled per scheme)</div>
+    <div id="light-only" class="badge">Only visible in LIGHT mode</div>
+    <div id="dark-only" class="badge">Only visible in DARK mode</div>
+  </body>
+</html>

--- a/test-server/server.js
+++ b/test-server/server.js
@@ -175,6 +175,10 @@ app.get('/canvas', (req, res) => {
   res.sendFile(path.join(__dirname, 'fixtures/canvas.html'));
 });
 
+app.get('/color-scheme', (req, res) => {
+  res.sendFile(path.join(__dirname, 'fixtures/color-scheme.html'));
+});
+
 const server = app.listen(port, () => {
   console.log(`Example app port http://localhost:${port}`);
 });


### PR DESCRIPTION
Issue: 

- Resolves #403 
- Requires CAP-4663 (done) ✅ 

## What Changed

Adds `parameters.chromatic.colorScheme: 'light' | 'dark'`. Value is resolved during runtime from `window.matchMedia` when `takeSnapshot()` is called - similarly as viewport is resolved during runtime. This allows a single test case to have multiple snapshot specific `colorScheme` values.

## How to test

Added E2E tests that are all currently rendering with `'light'`, as Capture support for `parameters.chromatic.colorScheme` is required.
