### PR TITLE
breaking: Migrate Cypress.env() → Cypress.expose() for non-sensitive config

### DIFF
--- a/.changeset/migrate-cypress-expose.md
+++ b/.changeset/migrate-cypress-expose.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/cypress': minor
+---
+
+Migrate from `Cypress.env()` to `Cypress.expose()` for reading non-sensitive Chromatic config (snapshot options, `assetDomains`, `disableAutoSnapshot`). `Cypress.expose()` was introduced in Cypress 15.10.0 and replaces `Cypress.env()`, which is slated for removal in Cypress v16. This fixes runs silently breaking for projects that have migrated their own config to `Cypress.expose()`. The package now declares a `cypress` peer dependency of `>=15.10.0`.

--- a/.changeset/migrate-cypress-expose.md
+++ b/.changeset/migrate-cypress-expose.md
@@ -1,5 +1,5 @@
 ---
-'@chromatic-com/cypress': minor
+'@chromatic-com/cypress': major
 ---
 
 Migrate from `Cypress.env()` to `Cypress.expose()` for reading non-sensitive Chromatic config (snapshot options, `assetDomains`, `disableAutoSnapshot`). `Cypress.expose()` was introduced in Cypress 15.10.0 and replaces `Cypress.env()`, which is slated for removal in Cypress v16. This fixes runs silently breaking for projects that have migrated their own config to `Cypress.expose()`. The package now declares a `cypress` peer dependency of `>=15.10.0`.

--- a/.changeset/migrate-cypress-expose.md
+++ b/.changeset/migrate-cypress-expose.md
@@ -1,5 +1,5 @@
 ---
-'@chromatic-com/cypress': major
+'@chromatic-com/cypress': minor
 ---
 
 Migrate from `Cypress.env()` to `Cypress.expose()` for reading non-sensitive Chromatic config (snapshot options, `assetDomains`, `disableAutoSnapshot`). `Cypress.expose()` was introduced in Cypress 15.10.0 and replaces `Cypress.env()`, which is slated for removal in Cypress v16. This fixes runs silently breaking for projects that have migrated their own config to `Cypress.expose()`. The package now declares a `cypress` peer dependency of `>=15.10.0`.

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -68,8 +68,11 @@
     "@storybook/builder-webpack5": "10.2.13",
     "@storybook/server": "10.2.13",
     "@storybook/server-webpack5": "10.2.13",
-    "cypress": "^15.11.0",
+    "cypress": "^15.18.0",
     "start-server-and-test": "^2.0.3"
+  },
+  "peerDependencies": {
+    "cypress": ">=15.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cypress/src/commands.ts
+++ b/packages/cypress/src/commands.ts
@@ -32,7 +32,6 @@ Cypress.Commands.add('takeSnapshot', (name?: string) => {
         (manualSnapshot: CypressSnapshot) => {
           // reassign manualSnapshots so it includes this new snapshot
           cy.get('@manualSnapshots')
-            // @ts-expect-error will fix when Cypress has its own package
             .then((snapshots: CypressSnapshot[]) => {
               return [...snapshots, { ...manualSnapshot, name }];
             })

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -54,7 +54,6 @@ afterEach(() => {
     // can we be sure this always fires after all the requests are back?
     cy.document().then((doc) => {
       cy.wrap(takeSnapshot(doc, viewport)).then((automaticSnapshot: CypressSnapshot) => {
-        // @ts-expect-error will fix when Cypress has its own package
         cy.get('@manualSnapshots').then((manualSnapshots = []) => {
           cy.url().then((url) => {
             // pass the snapshot to the server to write to disk

--- a/packages/cypress/src/support.ts
+++ b/packages/cypress/src/support.ts
@@ -2,29 +2,29 @@ import './commands';
 import { takeSnapshot } from './takeSnapshot';
 import { CypressSnapshot } from './types';
 
-const buildChromaticParams = (env: Cypress.Cypress['env']) => ({
-  ...(env('diffThreshold') && {
-    diffThreshold: env('diffThreshold'),
+const buildChromaticParams = (expose: Cypress.Cypress['expose']) => ({
+  ...(expose('diffThreshold') && {
+    diffThreshold: expose('diffThreshold'),
   }),
-  ...(env('delay') && { delay: env('delay') }),
-  ...(env('diffIncludeAntiAliasing') && {
-    diffIncludeAntiAliasing: env('diffIncludeAntiAliasing'),
+  ...(expose('delay') && { delay: expose('delay') }),
+  ...(expose('diffIncludeAntiAliasing') && {
+    diffIncludeAntiAliasing: expose('diffIncludeAntiAliasing'),
   }),
-  ...(env('diffThreshold') && {
-    diffThreshold: env('diffThreshold'),
+  ...(expose('diffThreshold') && {
+    diffThreshold: expose('diffThreshold'),
   }),
-  ...(env('forcedColors') && { forcedColors: env('forcedColors') }),
-  ...(env('pauseAnimationAtEnd') && {
-    pauseAnimationAtEnd: env('pauseAnimationAtEnd'),
+  ...(expose('forcedColors') && { forcedColors: expose('forcedColors') }),
+  ...(expose('pauseAnimationAtEnd') && {
+    pauseAnimationAtEnd: expose('pauseAnimationAtEnd'),
   }),
-  ...(env('prefersReducedMotion') && {
-    prefersReducedMotion: env('prefersReducedMotion'),
+  ...(expose('prefersReducedMotion') && {
+    prefersReducedMotion: expose('prefersReducedMotion'),
   }),
-  ...(env('cropToViewport') && {
-    cropToViewport: env('cropToViewport'),
+  ...(expose('cropToViewport') && {
+    cropToViewport: expose('cropToViewport'),
   }),
-  ...(env('ignoreSelectors') && {
-    ignoreSelectors: env('ignoreSelectors'),
+  ...(expose('ignoreSelectors') && {
+    ignoreSelectors: expose('ignoreSelectors'),
   }),
 });
 
@@ -40,7 +40,7 @@ beforeEach(() => {
   cy.wrap([]).as('manualSnapshots');
   cy.task('prepareArchives', {
     action: 'setup-network-listener',
-    payload: { allowedDomains: Cypress.env('assetDomains') },
+    payload: { allowedDomains: Cypress.expose('assetDomains') },
   });
 });
 
@@ -70,7 +70,7 @@ afterEach(() => {
                   ...manualSnapshots,
                   ...(automaticSnapshot ? [automaticSnapshot] : []),
                 ],
-                chromaticStorybookParams: buildChromaticParams(Cypress.env),
+                chromaticStorybookParams: buildChromaticParams(Cypress.expose),
                 pageUrl: url,
                 outputDir: Cypress.config('downloadsFolder'),
               },

--- a/packages/cypress/src/takeSnapshot.ts
+++ b/packages/cypress/src/takeSnapshot.ts
@@ -8,7 +8,7 @@ export const takeSnapshot = (
   isManualSnapshot?: boolean
 ): Promise<CypressSnapshot | null> => {
   return new Promise((resolve) => {
-    if (!isManualSnapshot && Cypress.env('disableAutoSnapshot')) {
+    if (!isManualSnapshot && Cypress.expose('disableAutoSnapshot')) {
       resolve(null);
     }
 

--- a/packages/cypress/tests/cypress/e2e/blob-urls.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/blob-urls.cy.ts
@@ -1,4 +1,4 @@
-it('Upload a Single file and Assert blob', { env: { ignoreSelectors: ['#objectUrl'] } }, () => {
+it('Upload a Single file and Assert blob', { expose: { ignoreSelectors: ['#objectUrl'] } }, () => {
   cy.visit('/createObjectUrl');
 
   cy.get('#fileInput').selectFile('../../../test-server/fixtures/blue.png');
@@ -21,7 +21,7 @@ it('Fetch data for blob', () => {
 
 it(
   'Captures blob contents for manual snapshots',
-  { env: { ignoreSelectors: ['#objectUrl'] } },
+  { expose: { ignoreSelectors: ['#objectUrl'] } },
   () => {
     cy.visit('/createObjectUrl');
 

--- a/packages/cypress/tests/cypress/e2e/css-pseudo-states.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/css-pseudo-states.cy.ts
@@ -1,6 +1,6 @@
 type Point = { x: number; y: number };
 
-it('captures :hover state', { env: { disableAutoSnapshot: true } }, () => {
+it('captures :hover state', { expose: { disableAutoSnapshot: true } }, () => {
   cy.visit('/css-pseudo-states');
   withElementCenter('button#target', mouseMove);
 
@@ -8,7 +8,7 @@ it('captures :hover state', { env: { disableAutoSnapshot: true } }, () => {
   cy.takeSnapshot('hover');
 });
 
-it('captures :focus state', { env: { disableAutoSnapshot: true } }, () => {
+it('captures :focus state', { expose: { disableAutoSnapshot: true } }, () => {
   cy.visit('/css-pseudo-states');
 
   withElementCenter('button#target', (point) =>
@@ -21,7 +21,7 @@ it('captures :focus state', { env: { disableAutoSnapshot: true } }, () => {
   cy.takeSnapshot('focus');
 });
 
-it('captures :active state', { env: { disableAutoSnapshot: true } }, () => {
+it('captures :active state', { expose: { disableAutoSnapshot: true } }, () => {
   cy.visit('/css-pseudo-states');
 
   let pressedCoords: Point = { x: 0, y: 0 };
@@ -40,7 +40,7 @@ it('captures :active state', { env: { disableAutoSnapshot: true } }, () => {
   cy.then(() => mouseUp(pressedCoords));
 });
 
-it('captures :focus-visible state', { env: { disableAutoSnapshot: true } }, () => {
+it('captures :focus-visible state', { expose: { disableAutoSnapshot: true } }, () => {
   cy.visit('/css-pseudo-states');
   cy.get('button#tab-cycle').focus();
 

--- a/packages/cypress/tests/cypress/e2e/custom-downloads-directory.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/custom-downloads-directory.cy.ts
@@ -2,7 +2,7 @@
 // not testing anything visual
 it(
   'downloads archives to the user-specified folder',
-  { env: { disableAutoSnapshot: true } },
+  { expose: { disableAutoSnapshot: true } },
   () => {
     cy.visit('/asset-paths/query-params');
     const chromaticArchivesDir = `${Cypress.config('downloadsFolder')}/chromatic-archives`;

--- a/packages/cypress/tests/cypress/e2e/duplicate-test-names.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/duplicate-test-names.cy.ts
@@ -8,7 +8,7 @@ describe('duplicate test names', () => {
   });
 });
 
-it('duplicate snapshot names', { env: { disableAutoSnapshot: true } }, () => {
+it('duplicate snapshot names', { expose: { disableAutoSnapshot: true } }, () => {
   cy.visit('/');
 
   cy.takeSnapshot('example');

--- a/packages/cypress/tests/cypress/e2e/embeds.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/embeds.cy.ts
@@ -14,7 +14,7 @@ it('cross-origin embed page loads', () => {
   cy.request('http://localhost:3001/').its('body').should('include', 'Embedded page');
 });
 
-it('embedded page background color can be changed', { env: { disableAutoSnapshot: true } }, () => {
+it('embedded page background color can be changed', { expose: { disableAutoSnapshot: true } }, () => {
   /** Re-query each time; wait until iframe document + body exist (load can lag after parent paint). */
   const inEmbeddedBody = (fn: () => void) => {
     cy.get('iframe[title="Same-origin iframe"]')

--- a/packages/cypress/tests/cypress/e2e/ignored-regions.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/ignored-regions.cy.ts
@@ -1,6 +1,6 @@
 // NOTE: This is a test that is meant to be run through Chromatic, so it doesn't actually work
 //       with the automated test suite.
-it('ignored regions work with chromatic', { env: { ignoreSelectors: ['.custom-ignore'] } }, () => {
+it('ignored regions work with chromatic', { expose: { ignoreSelectors: ['.custom-ignore'] } }, () => {
   cy.visit('/ignore');
   cy.wait(1000);
 });

--- a/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/manual-snapshots.cy.ts
@@ -11,7 +11,7 @@ it('multiple snapshots are taken', () => {
 
 it(
   'manual snapshot is taken even when automatic snapshots are turned off',
-  { env: { disableAutoSnapshot: true } },
+  { expose: { disableAutoSnapshot: true } },
   () => {
     cy.visit('/manual-snapshots');
     cy.contains("I'm an accordion, click me!").click();

--- a/packages/cypress/tests/cypress/e2e/newline-test-names.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/newline-test-names.cy.ts
@@ -7,7 +7,7 @@ newlines
     cy.visit('/');
   });
 
-  it('newlines in snapshot name', { env: { disableAutoSnapshot: true } }, () => {
+  it('newlines in snapshot name', { expose: { disableAutoSnapshot: true } }, () => {
     cy.visit('/');
     cy.takeSnapshot('snapshot name\nwith newlines\r\nand carriage returns');
   });

--- a/packages/cypress/tests/cypress/e2e/options.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/options.cy.ts
@@ -1,24 +1,24 @@
-it('delay', { env: { delay: 2500 } }, () => {
+it('delay', { expose: { delay: 2500 } }, () => {
   cy.visit('/options/delay');
 });
 
-it('diff threshold', { env: { diffThreshold: 1 } }, () => {
+it('diff threshold', { expose: { diffThreshold: 1 } }, () => {
   cy.visit('/options/diff-threshold');
 });
 
-it('pause animation at end', { env: { pauseAnimationAtEnd: true } }, () => {
+it('pause animation at end', { expose: { pauseAnimationAtEnd: true } }, () => {
   cy.visit('/options/pause-animation-at-end');
 });
 
-it('force high-contrast', { env: { forcedColors: 'active' } }, () => {
+it('force high-contrast', { expose: { forcedColors: 'active' } }, () => {
   cy.visit('/options/forced-colors');
 });
 
-it('prefers reduced motion', { env: { prefersReducedMotion: 'reduce' } }, () => {
+it('prefers reduced motion', { expose: { prefersReducedMotion: 'reduce' } }, () => {
   cy.visit('/options/prefers-reduced-motion');
 });
 
-it('crops to viewport', { env: { cropToViewport: true } }, () => {
+it('crops to viewport', { expose: { cropToViewport: true } }, () => {
   cy.visit('/options/crop-to-viewport');
 });
 

--- a/packages/cypress/tests/cypress/e2e/snapshot-names.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/snapshot-names.cy.ts
@@ -1,10 +1,10 @@
-it('in snapshot name', { env: { disableAutoSnapshot: true } }, () => {
+it('in snapshot name', { expose: { disableAutoSnapshot: true } }, () => {
   cy.visit('/');
 
   cy.takeSnapshot('あ');
 });
 
-it('in test case name あ', { env: { disableAutoSnapshot: true } }, () => {
+it('in test case name あ', { expose: { disableAutoSnapshot: true } }, () => {
   cy.visit('/');
 
   cy.takeSnapshot();

--- a/packages/cypress/tests/cypress/e2e/viewports.cy.ts
+++ b/packages/cypress/tests/cypress/e2e/viewports.cy.ts
@@ -10,14 +10,6 @@ context('mobile', { viewportWidth: 500, viewportHeight: 500 }, () => {
   });
 });
 
-context('using Cypress.config', () => {
-  it('does correctly set the viewport for Chromatic snapshots', () => {
-    Cypress.config('viewportWidth', 1150);
-    Cypress.config('viewportHeight', 500);
-    cy.visit('/viewports');
-  });
-});
-
 context('using cy.viewport', () => {
   it('does correctly set the viewport for Chromatic snapshots', () => {
     cy.viewport(800, 700);
@@ -43,5 +35,13 @@ context('using cy.viewport', () => {
     cy.contains('Window width: 1050').should('be.visible');
     cy.contains("I'm rendered when the page width is between 1100-1000").should('be.visible');
     cy.takeSnapshot('1050 x 1080');
+  });
+});
+
+context('using Cypress.config', () => {
+  it('does correctly set the viewport for Chromatic snapshots', () => {
+    Cypress.config('viewportWidth', 1150);
+    Cypress.config('viewportHeight', 500);
+    cy.visit('/viewports');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,9 +443,11 @@ __metadata:
     "@storybook/server": "npm:10.2.13"
     "@storybook/server-webpack5": "npm:10.2.13"
     chrome-remote-interface: "npm:^0.33.0"
-    cypress: "npm:^15.11.0"
+    cypress: "npm:^15.18.0"
     start-server-and-test: "npm:^2.0.3"
     storybook: "npm:10.2.13"
+  peerDependencies:
+    cypress: ">=15.10.0"
   bin:
     archive-storybook: dist/bin/archive-storybook.js
     build-archive-storybook: dist/bin/build-archive-storybook.js
@@ -585,9 +587,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cypress/request@npm:^3.0.10":
-  version: 3.0.10
-  resolution: "@cypress/request@npm:3.0.10"
+"@cypress/request@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "@cypress/request@npm:4.0.1"
   dependencies:
     aws-sign2: "npm:~0.7.0"
     aws4: "npm:^1.8.0"
@@ -602,12 +604,11 @@ __metadata:
     json-stringify-safe: "npm:~5.0.1"
     mime-types: "npm:~2.1.19"
     performance-now: "npm:^2.1.0"
-    qs: "npm:~6.14.1"
+    qs: "npm:^6.15.2"
     safe-buffer: "npm:^5.1.2"
     tough-cookie: "npm:^5.0.0"
     tunnel-agent: "npm:^0.6.0"
-    uuid: "npm:^8.3.2"
-  checksum: 93da9754315261474deeefff235ed0397811d49f03f2dfcebd01aff12b75fd58e104b0c7fd3d720e1ebc51d73059e1f540db68c58bbda4612493610227ade710
+  checksum: 266648f03ebf3645ccfb3f17dceb1e8ce95a456a79e7f958ee2165ef84ce5bfdbea2904fdd5b21d6301e7abeb72e35b5dec33393502501758cd20df86eb2e943
   languageName: node
   linkType: hard
 
@@ -2557,15 +2558,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yauzl@npm:^2.9.1":
-  version: 2.10.3
-  resolution: "@types/yauzl@npm:2.10.3"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: f1b7c1b99fef9f2fe7f1985ef7426d0cebe48cd031f1780fcdc7451eec7e31ac97028f16f50121a59bcf53086a1fc8c856fd5b7d3e00970e43d92ae27d6b43dc
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/eslint-plugin@npm:8.56.1":
   version: 8.56.1
   resolution: "@typescript-eslint/eslint-plugin@npm:8.56.1"
@@ -3118,16 +3110,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aggregate-error@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "aggregate-error@npm:3.1.0"
-  dependencies:
-    clean-stack: "npm:^2.0.0"
-    indent-string: "npm:^4.0.0"
-  checksum: a42f67faa79e3e6687a4923050e7c9807db3848a037076f791d10e092677d65c1d2d863b7848560699f40fc0502c19f40963fb1cd1fb3d338a7423df8e45e039
-  languageName: node
-  linkType: hard
-
 "ajv-formats@npm:^2.1.1":
   version: 2.1.1
   resolution: "ajv-formats@npm:2.1.1"
@@ -3193,7 +3175,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^4.2.1, ansi-escapes@npm:^4.3.0":
+"ansi-escapes@npm:^4.2.1":
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
   dependencies:
@@ -3430,13 +3412,6 @@ __metadata:
     estree-walker: "npm:^3.0.3"
     js-tokens: "npm:^10.0.0"
   checksum: 35e57b754ba63287358094d4f7ae8de2de27286fb4e76a1fbf28b2e67e3b670b59c3f511882473d0fd2cdbaa260062e3cd4f216b724c70032e2b09e5cebbd618
-  languageName: node
-  linkType: hard
-
-"astral-regex@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "astral-regex@npm:2.0.0"
-  checksum: f63d439cc383db1b9c5c6080d1e240bd14dae745f15d11ec5da863e182bbeca70df6c8191cffef5deba0b566ef98834610a68be79ac6379c95eeb26e1b310e25
   languageName: node
   linkType: hard
 
@@ -3707,13 +3682,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-crc32@npm:~0.2.3":
-  version: 0.2.13
-  resolution: "buffer-crc32@npm:0.2.13"
-  checksum: cb0a8ddf5cf4f766466db63279e47761eb825693eeba6a5a95ee4ec8cb8f81ede70aa7f9d8aeec083e781d47154290eb5d4d26b3f7a465ec57fb9e7d59c47150
-  languageName: node
-  linkType: hard
-
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
@@ -3794,7 +3762,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cachedir@npm:^2.3.0":
+"cachedir@npm:^2.4.0":
   version: 2.4.0
   resolution: "cachedir@npm:2.4.0"
   checksum: 76bff9009f2c446cd3777a4aede99af634a89670a67012b8041f65e951d3d36cefe8940341ea80c72219ee9913fa1f6146824cd9dfe9874a4bded728af7e6d76
@@ -4010,22 +3978,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clean-stack@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "clean-stack@npm:2.2.0"
-  checksum: 1f90262d5f6230a17e27d0c190b09d47ebe7efdd76a03b5a1127863f7b3c9aec4c3e6c8bb3a7bbf81d553d56a1fd35728f5a8ef4c63f867ac8d690109742a8c1
-  languageName: node
-  linkType: hard
-
-"cli-cursor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "cli-cursor@npm:3.1.0"
-  dependencies:
-    restore-cursor: "npm:^3.1.0"
-  checksum: 92a2f98ff9037d09be3dfe1f0d749664797fb674bf388375a2207a1203b69d41847abf16434203e0089212479e47a358b13a0222ab9fccfe8e2644a7ccebd111
-  languageName: node
-  linkType: hard
-
 "cli-cursor@npm:^5.0.0":
   version: 5.0.0
   resolution: "cli-cursor@npm:5.0.0"
@@ -4045,16 +3997,6 @@ __metadata:
     colors:
       optional: true
   checksum: 19ab1bb14bd11b3ca3557ce5ad37ef73e489ea814b99f803171e6ac0a3f2ae5fffb6dbc8864e33cdcf2a3644ebc31b488b8e624fd74af44a1c77cc365c143db4
-  languageName: node
-  linkType: hard
-
-"cli-truncate@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "cli-truncate@npm:2.1.0"
-  dependencies:
-    slice-ansi: "npm:^3.0.0"
-    string-width: "npm:^4.2.0"
-  checksum: dfaa3df675bcef7a3254773de768712b590250420345a4c7ac151f041a4bacb4c25864b1377bee54a39b5925a030c00eabf014e312e3a4ac130952ed3b3879e9
   languageName: node
   linkType: hard
 
@@ -4118,7 +4060,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colorette@npm:^2.0.10, colorette@npm:^2.0.16, colorette@npm:^2.0.20":
+"colorette@npm:^2.0.10, colorette@npm:^2.0.20":
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
   checksum: e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
@@ -4396,11 +4338,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress@npm:^15.11.0":
-  version: 15.11.0
-  resolution: "cypress@npm:15.11.0"
+"cypress@npm:^15.18.0":
+  version: 15.18.0
+  resolution: "cypress@npm:15.18.0"
   dependencies:
-    "@cypress/request": "npm:^3.0.10"
+    "@cypress/request": "npm:^4.0.0"
     "@cypress/xvfb": "npm:^1.2.4"
     "@types/sinonjs__fake-timers": "npm:8.1.1"
     "@types/sizzle": "npm:^2.3.2"
@@ -4409,25 +4351,21 @@ __metadata:
     blob-util: "npm:^2.0.2"
     bluebird: "npm:^3.7.2"
     buffer: "npm:^5.7.1"
-    cachedir: "npm:^2.3.0"
+    cachedir: "npm:^2.4.0"
     chalk: "npm:^4.1.0"
     ci-info: "npm:^4.1.0"
-    cli-cursor: "npm:^3.1.0"
     cli-table3: "npm:0.6.1"
     commander: "npm:^6.2.1"
     common-tags: "npm:^1.8.0"
     dayjs: "npm:^1.10.4"
     debug: "npm:^4.3.4"
-    enquirer: "npm:^2.3.6"
     eventemitter2: "npm:6.4.7"
     execa: "npm:4.1.0"
     executable: "npm:^4.1.1"
-    extract-zip: "npm:2.0.1"
-    figures: "npm:^3.2.0"
     fs-extra: "npm:^9.1.0"
     hasha: "npm:5.2.2"
     is-installed-globally: "npm:~0.4.0"
-    listr2: "npm:^3.8.3"
+    listr2: "npm:^9.0.5"
     lodash: "npm:^4.17.23"
     log-symbols: "npm:^4.0.0"
     minimist: "npm:^1.2.8"
@@ -4442,10 +4380,10 @@ __metadata:
     tree-kill: "npm:1.2.2"
     tslib: "npm:1.14.1"
     untildify: "npm:^4.0.0"
-    yauzl: "npm:^2.10.0"
+    yauzl: "npm:^3.3.1"
   bin:
     cypress: bin/cypress
-  checksum: 6e3e31954bf46802d3f48f84301b224daadfc800ad65c0e297f0c1292f347a0a2385c0db6ecc4215c0aaf991363859db03f0a6e0fba249aee39dbc0dfca7673f
+  checksum: 948782e11ece8c5f3c3945308d807fb52f0ee8708d23b3a9bae3f112834ce1627f44c2cd457506e499f29782bdcb2513021489afcb11885e576c012d58115aab
   languageName: node
   linkType: hard
 
@@ -4861,7 +4799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enquirer@npm:^2.3.4, enquirer@npm:^2.3.6, enquirer@npm:^2.4.1":
+"enquirer@npm:^2.3.4, enquirer@npm:^2.4.1":
   version: 2.4.1
   resolution: "enquirer@npm:2.4.1"
   dependencies:
@@ -5507,23 +5445,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extract-zip@npm:2.0.1":
-  version: 2.0.1
-  resolution: "extract-zip@npm:2.0.1"
-  dependencies:
-    "@types/yauzl": "npm:^2.9.1"
-    debug: "npm:^4.1.1"
-    get-stream: "npm:^5.1.0"
-    yauzl: "npm:^2.10.0"
-  dependenciesMeta:
-    "@types/yauzl":
-      optional: true
-  bin:
-    extract-zip: cli.js
-  checksum: 9afbd46854aa15a857ae0341a63a92743a7b89c8779102c3b4ffc207516b2019337353962309f85c66ee3d9092202a83cdc26dbf449a11981272038443974aee
-  languageName: node
-  linkType: hard
-
 "extsprintf@npm:1.3.0":
   version: 1.3.0
   resolution: "extsprintf@npm:1.3.0"
@@ -5595,15 +5516,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fd-slicer@npm:~1.1.0":
-  version: 1.1.0
-  resolution: "fd-slicer@npm:1.1.0"
-  dependencies:
-    pend: "npm:~1.2.0"
-  checksum: 304dd70270298e3ffe3bcc05e6f7ade2511acc278bc52d025f8918b48b6aa3b77f10361bddfadfe2a28163f7af7adbdce96f4d22c31b2f648ba2901f0c5fc20e
-  languageName: node
-  linkType: hard
-
 "fdir@npm:^6.5.0":
   version: 6.5.0
   resolution: "fdir@npm:6.5.0"
@@ -5622,15 +5534,6 @@ __metadata:
   dependencies:
     escape-string-regexp: "npm:^1.0.5"
   checksum: 5dc5a75fec3e7e04ae65d6ce51d28b3e70d4656c51b06996b6fdb2cb5b542df512e3b3c04482f5193a964edddafa5521479ff948fa84e12ff556e53e094ab4ce
-  languageName: node
-  linkType: hard
-
-"figures@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "figures@npm:3.2.0"
-  dependencies:
-    escape-string-regexp: "npm:^1.0.5"
-  checksum: 9c421646ede432829a50bc4e55c7a4eb4bcb7cc07b5bab2f471ef1ab9a344595bbebb6c5c21470093fbb730cd81bbca119624c40473a125293f656f49cb47629
   languageName: node
   linkType: hard
 
@@ -6001,7 +5904,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stream@npm:^5.0.0, get-stream@npm:^5.1.0":
+"get-stream@npm:^5.0.0":
   version: 5.2.0
   resolution: "get-stream@npm:5.2.0"
   dependencies:
@@ -7298,27 +7201,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"listr2@npm:^3.8.3":
-  version: 3.14.0
-  resolution: "listr2@npm:3.14.0"
-  dependencies:
-    cli-truncate: "npm:^2.1.0"
-    colorette: "npm:^2.0.16"
-    log-update: "npm:^4.0.0"
-    p-map: "npm:^4.0.0"
-    rfdc: "npm:^1.3.0"
-    rxjs: "npm:^7.5.1"
-    through: "npm:^2.3.8"
-    wrap-ansi: "npm:^7.0.0"
-  peerDependencies:
-    enquirer: ">= 2.3.0 < 3"
-  peerDependenciesMeta:
-    enquirer:
-      optional: true
-  checksum: 8301703876ad6bf50cd769e9c1169c2aa435951d69d4f54fc202a13c1b6006a9b3afbcf9842440eb22f08beec4d311d365e31d4ed2e0fcabf198d8085b06a421
-  languageName: node
-  linkType: hard
-
 "listr2@npm:^9.0.5":
   version: 9.0.5
   resolution: "listr2@npm:9.0.5"
@@ -7461,18 +7343,6 @@ __metadata:
     chalk: "npm:^4.1.0"
     is-unicode-supported: "npm:^0.1.0"
   checksum: 67f445a9ffa76db1989d0fa98586e5bc2fd5247260dafb8ad93d9f0ccd5896d53fb830b0e54dade5ad838b9de2006c826831a3c528913093af20dff8bd24aca6
-  languageName: node
-  linkType: hard
-
-"log-update@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "log-update@npm:4.0.0"
-  dependencies:
-    ansi-escapes: "npm:^4.3.0"
-    cli-cursor: "npm:^3.1.0"
-    slice-ansi: "npm:^4.0.0"
-    wrap-ansi: "npm:^6.2.0"
-  checksum: 18b299e230432a156f2535660776406d15ba8bb7817dd3eaadd58004b363756d4ecaabcd658f9949f90b62ea7d3354423be3fdeb7a201ab951ec0e8d6139af86
   languageName: node
   linkType: hard
 
@@ -8052,7 +7922,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object-inspect@npm:^1.13.3":
+"object-inspect@npm:^1.13.3, object-inspect@npm:^1.13.4":
   version: 1.13.4
   resolution: "object-inspect@npm:1.13.4"
   checksum: d7f8711e803b96ea3191c745d6f8056ce1f2496e530e6a19a0e92d89b0fa3c76d910c31f0aa270432db6bd3b2f85500a376a83aaba849a8d518c8845b3211692
@@ -8261,15 +8131,6 @@ __metadata:
   version: 2.1.0
   resolution: "p-map@npm:2.1.0"
   checksum: 735dae87badd4737a2dd582b6d8f93e49a1b79eabbc9815a4d63a528d5e3523e978e127a21d784cccb637010e32103a40d2aaa3ab23ae60250b1a820ca752043
-  languageName: node
-  linkType: hard
-
-"p-map@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "p-map@npm:4.0.0"
-  dependencies:
-    aggregate-error: "npm:^3.0.0"
-  checksum: 592c05bd6262c466ce269ff172bb8de7c6975afca9b50c975135b974e9bdaafbfe80e61aaaf5be6d1200ba08b30ead04b88cfa7e25ff1e3b93ab28c9f62a2c75
   languageName: node
   linkType: hard
 
@@ -8830,7 +8691,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:~6.14.0, qs@npm:~6.14.1":
+"qs@npm:^6.15.2":
+  version: 6.15.3
+  resolution: "qs@npm:6.15.3"
+  dependencies:
+    es-define-property: "npm:^1.0.1"
+    side-channel: "npm:^1.1.1"
+  checksum: 8f3f6e45ece255347d57696628401cde29e9ec649fff698b53bd3150dea7cefdf33036e1bc1826b9f110bfa7cb0ec4ab9f5297eca628ce216c55af82c304e08e
+  languageName: node
+  linkType: hard
+
+"qs@npm:~6.14.0":
   version: 6.14.2
   resolution: "qs@npm:6.14.2"
   dependencies:
@@ -9067,16 +8938,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"restore-cursor@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "restore-cursor@npm:3.1.0"
-  dependencies:
-    onetime: "npm:^5.1.0"
-    signal-exit: "npm:^3.0.2"
-  checksum: 8051a371d6aa67ff21625fa94e2357bd81ffdc96267f3fb0fc4aaf4534028343836548ef34c240ffa8c25b280ca35eb36be00b3cb2133fa4f51896d7e73c6b4f
-  languageName: node
-  linkType: hard
-
 "restore-cursor@npm:^5.0.0":
   version: 5.1.0
   resolution: "restore-cursor@npm:5.1.0"
@@ -9108,7 +8969,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rfdc@npm:^1.3.0, rfdc@npm:^1.4.1":
+"rfdc@npm:^1.4.1":
   version: 1.4.1
   resolution: "rfdc@npm:1.4.1"
   checksum: 4614e4292356cafade0b6031527eea9bc90f2372a22c012313be1dcc69a3b90c7338158b414539be863fa95bfcb2ddcd0587be696841af4e6679d85e62c060c7
@@ -9290,7 +9151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^7.5.1, rxjs@npm:^7.8.2":
+"rxjs@npm:^7.8.2":
   version: 7.8.2
   resolution: "rxjs@npm:7.8.2"
   dependencies:
@@ -9462,6 +9323,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"side-channel-list@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-list@npm:1.0.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.4"
+  checksum: d346c787fd2f9f1c2fdea14f00e8250118db0e7596d85a6cb9faa75f105d31a73a8f7a341c93d7df2a2429098c3d37a77bd3be9e88c37094b8c01807bc77c7a2
+  languageName: node
+  linkType: hard
+
 "side-channel-map@npm:^1.0.1":
   version: 1.0.1
   resolution: "side-channel-map@npm:1.0.1"
@@ -9497,6 +9368,19 @@ __metadata:
     side-channel-map: "npm:^1.0.1"
     side-channel-weakmap: "npm:^1.0.2"
   checksum: cb20dad41eb032e6c24c0982e1e5a24963a28aa6122b4f05b3f3d6bf8ae7fd5474ef382c8f54a6a3ab86e0cac4d41a23bd64ede3970e5bfb50326ba02a7996e6
+  languageName: node
+  linkType: hard
+
+"side-channel@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "side-channel@npm:1.1.1"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    object-inspect: "npm:^1.13.4"
+    side-channel-list: "npm:^1.0.1"
+    side-channel-map: "npm:^1.0.1"
+    side-channel-weakmap: "npm:^1.0.2"
+  checksum: dc0ab81d67f61bda9247d053ce93f41c3fd8ad2bdcb9cf9d8d2f8540d488f26d87a5e99ebfc07eea49ec025867b2452b705442d974b1478f0395e69f6bfb3270
   languageName: node
   linkType: hard
 
@@ -9561,28 +9445,6 @@ __metadata:
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
   checksum: e18488c6a42bdfd4ac5be85b2ced3ccd0224773baae6ad42cfbb9ec74fc07f9fa8396bd35ee638084ead7a2a0818eb5e7151111544d4731ce843019dab4be47b
-  languageName: node
-  linkType: hard
-
-"slice-ansi@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "slice-ansi@npm:3.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.0.0"
-    astral-regex: "npm:^2.0.0"
-    is-fullwidth-code-point: "npm:^3.0.0"
-  checksum: 88083c9d0ca67d09f8b4c78f68833d69cabbb7236b74df5d741ad572bbf022deaf243fa54009cd434350622a1174ab267710fcc80a214ecc7689797fe00cb27c
-  languageName: node
-  linkType: hard
-
-"slice-ansi@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "slice-ansi@npm:4.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.0.0"
-    astral-regex: "npm:^2.0.0"
-    is-fullwidth-code-point: "npm:^3.0.0"
-  checksum: 6c25678db1270d4793e0327620f1e0f9f5bea4630123f51e9e399191bc52c87d6e6de53ed33538609e5eacbd1fab769fae00f3705d08d029f02102a540648918
   languageName: node
   linkType: hard
 
@@ -10108,7 +9970,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through@npm:2, through@npm:^2.3.8, through@npm:~2.3, through@npm:~2.3.1":
+"through@npm:2, through@npm:~2.3, through@npm:~2.3.1":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
@@ -10686,15 +10548,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
-  languageName: node
-  linkType: hard
-
 "v8-compile-cache-lib@npm:^3.0.1":
   version: 3.0.1
   resolution: "v8-compile-cache-lib@npm:3.0.1"
@@ -11235,13 +11088,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yauzl@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "yauzl@npm:2.10.0"
+"yauzl@npm:^3.3.1":
+  version: 3.4.0
+  resolution: "yauzl@npm:3.4.0"
   dependencies:
-    buffer-crc32: "npm:~0.2.3"
-    fd-slicer: "npm:~1.1.0"
-  checksum: f265002af7541b9ec3589a27f5fb8f11cf348b53cc15e2751272e3c062cd73f3e715bc72d43257de71bbaecae446c3f1b14af7559e8ab0261625375541816422
+    pend: "npm:~1.2.0"
+  checksum: 17a98c42c0065e8af429eb8a61f7a0e4562181ed54080366b838f34f741b6829f167f804787c86b7646bb042707f35871739f053de0548285e405a2eae4da025
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Background

Hi, I'm a maintainer of cypress, `Cypress.env()` has been migrated to the new `expose`/`Cypress.expose()` API. `Cypress.expose()` was introduced in **Cypress 15.10.0**, and the legacy `Cypress.env()` path is **slated for removal in v16**

We received a report from a user whose Chromatic run ignored the `expose` configuration after they migrated their own project to `Cypress.expose()`: because this integration was still reading config via `Cypress.env()`, the exposed values were no longer visible to it, so snapshot options (and the auto-snapshot toggle) silently stopped taking effect. This PR brings the integration in line with the new API so it keeps working through the v16 removal.

## What Changed

All values this package reads are **non-sensitive Chromatic configuration** (snapshot diff thresholds, animation flags, `assetDomains`, `disableAutoSnapshot`, etc.), so they move to the synchronous `Cypress.expose()`, a drop-in for the synchronous `Cypress.env()`. None required the async `cy.env()` path reserved for secrets.

**`package.json`**
- Added a `peerDependencies` entry: `"cypress": ">=15.10.0"` — the minimum version that ships `Cypress.expose()`.

## How to test

20 `{ env: { … } }` test-config options across 10 e2e specs switched to `{ expose: { … } }`, in lockstep with the source change (the runner now reads these via `Cypress.expose()`).
