### PR TITLE
ci: skip chromatic publish on fork PRs, add manual workflow

### DIFF
--- a/.github/workflows/test-cypress.yml
+++ b/.github/workflows/test-cypress.yml
@@ -3,6 +3,27 @@ name: Test Cypress
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: Git ref (branch, tag, or SHA) to check out. Defaults to the triggering ref.
+        required: false
+        type: string
+        default: ''
+      chromaticSha:
+        description: Commit SHA to attribute the Chromatic build to. Defaults to auto-detection from the GitHub context.
+        required: false
+        type: string
+        default: ''
+      chromaticBranch:
+        description: Branch name to attribute the Chromatic build to. Required when chromaticSha is set.
+        required: false
+        type: string
+        default: ''
+      chromaticSlug:
+        description: Repository slug (owner/name) to attribute the Chromatic build to. Required when chromaticSha is set.
+        required: false
+        type: string
+        default: ''
     secrets:
       chromaticProjectToken:
         required: true
@@ -14,6 +35,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -40,7 +62,12 @@ jobs:
           pnpm test:cypress
 
       - name: Publish to Chromatic
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: chromaui/action@latest
+        env:
+          CHROMATIC_SHA: ${{ inputs.chromaticSha }}
+          CHROMATIC_BRANCH: ${{ inputs.chromaticBranch }}
+          CHROMATIC_SLUG: ${{ inputs.chromaticSlug }}
         with:
           projectToken: ${{ secrets.chromaticProjectToken }}
           buildScriptName: build-archive-storybook:cypress

--- a/.github/workflows/test-fork-pr.yml
+++ b/.github/workflows/test-fork-pr.yml
@@ -1,0 +1,69 @@
+name: Test Fork PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to test. Review the diff before running.
+        required: true
+        type: string
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      sha: ${{ steps.head.outputs.sha }}
+      branch: ${{ steps.head.outputs.branch }}
+    steps:
+      - name: Resolve PR head
+        id: head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr }}
+        run: |
+          pr_info=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json headRefOid,headRefName,headRepositoryOwner,isCrossRepository)
+          sha=$(jq -r .headRefOid <<< "$pr_info")
+          branch=$(jq -r .headRefName <<< "$pr_info")
+          if [ "$(jq -r .isCrossRepository <<< "$pr_info")" = "true" ]; then
+            branch="$(jq -r .headRepositoryOwner.login <<< "$pr_info"):$branch"
+          fi
+
+          echo "Resolved PR #$PR_NUMBER to $sha (branch: $branch)"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+  test_cypress:
+    needs: resolve
+    uses: ./.github/workflows/test-cypress.yml
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+      chromaticSha: ${{ needs.resolve.outputs.sha }}
+      chromaticBranch: ${{ needs.resolve.outputs.branch }}
+      chromaticSlug: ${{ github.repository }}
+    secrets:
+      chromaticProjectToken: ${{ secrets.CHROMATIC_CYPRESS_PROJECT_TOKEN }}
+
+  test_playwright:
+    needs: resolve
+    uses: ./.github/workflows/test-playwright.yml
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+      chromaticSha: ${{ needs.resolve.outputs.sha }}
+      chromaticBranch: ${{ needs.resolve.outputs.branch }}
+      chromaticSlug: ${{ github.repository }}
+    secrets:
+      chromaticProjectToken: ${{ secrets.CHROMATIC_PLAYWRIGHT_PROJECT_TOKEN }}
+
+  test_vitest:
+    needs: resolve
+    uses: ./.github/workflows/test-vitest.yml
+    with:
+      ref: ${{ needs.resolve.outputs.sha }}
+      chromaticSha: ${{ needs.resolve.outputs.sha }}
+      chromaticBranch: ${{ needs.resolve.outputs.branch }}
+      chromaticSlug: ${{ github.repository }}
+    secrets:
+      chromaticProjectToken: ${{ secrets.CHROMATIC_VITEST_PROJECT_TOKEN }}

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -6,6 +6,27 @@ env:
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: Git ref (branch, tag, or SHA) to check out. Defaults to the triggering ref.
+        required: false
+        type: string
+        default: ''
+      chromaticSha:
+        description: Commit SHA to attribute the Chromatic build to. Defaults to auto-detection from the GitHub context.
+        required: false
+        type: string
+        default: ''
+      chromaticBranch:
+        description: Branch name to attribute the Chromatic build to. Required when chromaticSha is set.
+        required: false
+        type: string
+        default: ''
+      chromaticSlug:
+        description: Repository slug (owner/name) to attribute the Chromatic build to. Required when chromaticSha is set.
+        required: false
+        type: string
+        default: ''
     secrets:
       chromaticProjectToken:
         required: true
@@ -17,6 +38,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -45,7 +67,12 @@ jobs:
           pnpm test:playwright
 
       - name: Publish to Chromatic
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: chromaui/action@latest
+        env:
+          CHROMATIC_SHA: ${{ inputs.chromaticSha }}
+          CHROMATIC_BRANCH: ${{ inputs.chromaticBranch }}
+          CHROMATIC_SLUG: ${{ inputs.chromaticSlug }}
         with:
           projectToken: ${{ secrets.chromaticProjectToken }}
           buildScriptName: build-archive-storybook:playwright

--- a/.github/workflows/test-vitest.yml
+++ b/.github/workflows/test-vitest.yml
@@ -6,6 +6,27 @@ env:
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: Git ref (branch, tag, or SHA) to check out. Defaults to the triggering ref.
+        required: false
+        type: string
+        default: ''
+      chromaticSha:
+        description: Commit SHA to attribute the Chromatic build to. Defaults to auto-detection from the GitHub context.
+        required: false
+        type: string
+        default: ''
+      chromaticBranch:
+        description: Branch name to attribute the Chromatic build to. Required when chromaticSha is set.
+        required: false
+        type: string
+        default: ''
+      chromaticSlug:
+        description: Repository slug (owner/name) to attribute the Chromatic build to. Required when chromaticSha is set.
+        required: false
+        type: string
+        default: ''
     secrets:
       chromaticProjectToken:
         required: true
@@ -17,6 +38,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -45,7 +67,12 @@ jobs:
           pnpm test:vitest
 
       - name: Publish to Chromatic
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
         uses: chromaui/action@latest
+        env:
+          CHROMATIC_SHA: ${{ inputs.chromaticSha }}
+          CHROMATIC_BRANCH: ${{ inputs.chromaticBranch }}
+          CHROMATIC_SLUG: ${{ inputs.chromaticSlug }}
         with:
           projectToken: ${{ secrets.chromaticProjectToken }}
           buildScriptName: build-archive-storybook:vitest


### PR DESCRIPTION
Issue: Part of https://github.com/chromaui/chromatic-e2e/issues/348

## What Changed

- Skip `Publish to Chromatic` on fork PRs to avoid failing CIs.
- Add manual workflow that can replace #413 kind of unnecessary PRs

## How to test

<!-- Add an explanation below for the reviewers to help them test your changes. Test against the published, canary versions of the packages (which are published along with this PR). -->
