### PR TITLE
fix: resolve storybook properly when `hoist: false` in pnpm

### DIFF
--- a/.changeset/great-pandas-repair.md
+++ b/.changeset/great-pandas-repair.md
@@ -1,0 +1,7 @@
+---
+'@chromatic-com/playwright': patch
+'@chromatic-com/cypress': patch
+'@chromatic-com/vitest': patch
+---
+
+Fix `Module not found: Error: Can't resolve 'storybook/internal/csf'` when the archive Storybook is built in a project where `storybook` is not reachable from the project root (e.g. pnpm, regardless of the `hoist` setting). Webpack now falls back to resolving `storybook/*` imports from the `storybook` install these packages depend on.

--- a/docs/decisions/0001-embed-storybook-dependencies.md
+++ b/docs/decisions/0001-embed-storybook-dependencies.md
@@ -50,6 +50,7 @@ We use **Option B (embedded folder)** so that consumers get at most two storyboo
 - `@chromatic-com/playwright` and `@chromatic-com/cypress` publish an `embedded/` directory containing the Storybook 10.x stack (except the `storybook` package itself).
 - Root build runs `prepare-embedded` after workspace builds; each package’s build is `prebuild && tsup` only.
 - The three `@storybook/*` packages are devDependencies for the monorepo build and do not appear in the published dependencies list.
+- Storybook's webpack builder places its virtual entry modules in the consumer's project root, and their `storybook/*` imports resolve by node_modules walk-up from there. With pnpm the consumer's root `node_modules` does not contain our `storybook` dependency (regardless of the `hoist` setting), so each package's Storybook config adds the directory containing our `storybook` install to webpack's `resolve.modules` as a fallback (see `storybookParentNodeModulesDir`, chromaui/chromatic-e2e#416).
 - If we ever need to support only npm/yarn and can accept pnpm limitations, revisiting `bundledDependencies` would be reasonable.
 
 ## References

--- a/packages/cypress/src/storybook-config/main.ts
+++ b/packages/cypress/src/storybook-config/main.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import type { StorybookConfig } from '@storybook/server-webpack5';
 import { archivesDir } from '@chromatic-com/shared-e2e/utils/filePaths';
+import { storybookParentNodeModulesDir } from '@chromatic-com/shared-e2e/utils/storybookPaths';
 import { DEFAULT_OUTPUT_DIR } from '../constants';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -10,8 +12,7 @@ const __dirname = path.dirname(__filename);
 const packageRoot = path.resolve(__dirname, '..', '..');
 const embeddedDir = path.join(packageRoot, 'embedded', 'node_modules');
 
-/** @type { import('@storybook/server-webpack5').StorybookConfig } */
-export default {
+export default <StorybookConfig>{
   stories: [path.resolve(archivesDir(DEFAULT_OUTPUT_DIR), '*.stories.json')],
   managerEntries: [path.resolve(__dirname, 'manager.mjs')],
   previewAnnotations: [path.resolve(__dirname, 'preview.mjs')],
@@ -21,11 +22,28 @@ export default {
   },
   core: {
     // ESM does not support directory imports; point to the package entry file.
-    builder: pathToFileURL(path.join(embeddedDir, '@storybook', 'builder-webpack5', 'dist', 'index.js')).href,
+    builder: pathToFileURL(
+      path.join(embeddedDir, '@storybook', 'builder-webpack5', 'dist', 'index.js')
+    ).href,
     renderer: pathToFileURL(path.join(embeddedDir, '@storybook', 'server', 'preset.js')).href,
   },
   staticDirs: [path.resolve(archivesDir(DEFAULT_OUTPUT_DIR), 'archive')],
   features: {
     sidebarOnboardingChecklist: false,
+  },
+  webpackFinal: async (config) => {
+    // Storybook's virtual entry modules live in the user's project root, where imports like
+    // `storybook/internal/csf` may not resolve by node_modules walk-up (e.g. with pnpm).
+    // Fall back to the `storybook` install this package depends on.
+    const storybookNodeModules = storybookParentNodeModulesDir(import.meta.url);
+    if (storybookNodeModules) {
+      config.resolve ??= {};
+      config.resolve.modules = [
+        ...(config.resolve.modules ?? ['node_modules']),
+        storybookNodeModules,
+      ];
+    }
+
+    return config;
   },
 };

--- a/packages/playwright/src/storybook-config/main.ts
+++ b/packages/playwright/src/storybook-config/main.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import type { StorybookConfig } from '@storybook/server-webpack5';
 import { archivesDir } from '@chromatic-com/shared-e2e/utils/filePaths';
+import { storybookParentNodeModulesDir } from '@chromatic-com/shared-e2e/utils/storybookPaths';
 import { DEFAULT_OUTPUT_DIR } from '../constants';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -10,8 +12,7 @@ const __dirname = path.dirname(__filename);
 const packageRoot = path.resolve(__dirname, '..', '..');
 const embeddedDir = path.join(packageRoot, 'embedded', 'node_modules');
 
-/** @type { import('@storybook/server-webpack5').StorybookConfig } */
-export default {
+export default <StorybookConfig>{
   stories: [path.resolve(archivesDir(DEFAULT_OUTPUT_DIR), '*.stories.json')],
   managerEntries: [path.resolve(__dirname, 'manager.mjs')],
   previewAnnotations: [path.resolve(__dirname, 'preview.mjs')],
@@ -21,11 +22,28 @@ export default {
   },
   core: {
     // ESM does not support directory imports; point to the package entry file.
-    builder: pathToFileURL(path.join(embeddedDir, '@storybook', 'builder-webpack5', 'dist', 'index.js')).href,
+    builder: pathToFileURL(
+      path.join(embeddedDir, '@storybook', 'builder-webpack5', 'dist', 'index.js')
+    ).href,
     renderer: pathToFileURL(path.join(embeddedDir, '@storybook', 'server', 'preset.js')).href,
   },
   staticDirs: [path.resolve(archivesDir(DEFAULT_OUTPUT_DIR), 'archive')],
   features: {
     sidebarOnboardingChecklist: false,
+  },
+  webpackFinal: async (config) => {
+    // Storybook's virtual entry modules live in the user's project root, where imports like
+    // `storybook/internal/csf` may not resolve by node_modules walk-up (e.g. with pnpm).
+    // Fall back to the `storybook` install this package depends on.
+    const storybookNodeModules = storybookParentNodeModulesDir(import.meta.url);
+    if (storybookNodeModules) {
+      config.resolve ??= {};
+      config.resolve.modules = [
+        ...(config.resolve.modules ?? ['node_modules']),
+        storybookNodeModules,
+      ];
+    }
+
+    return config;
   },
 };

--- a/packages/shared/src/utils/storybookPaths.ts
+++ b/packages/shared/src/utils/storybookPaths.ts
@@ -1,0 +1,22 @@
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+/**
+ * Directory of the `node_modules` that contains the `storybook` package this package depends on.
+ *
+ * Storybook's webpack builder places its virtual entry modules in the user's project root, so
+ * their imports (e.g. `storybook/internal/csf`) are resolved by walking up from there. With
+ * pnpm's isolated linker the user's `node_modules` only contains their own direct dependencies,
+ * so `storybook` is not reachable and the build fails (chromaui/chromatic-e2e#416). Adding this
+ * directory as a `resolve.modules` fallback makes those imports resolve to the same `storybook`
+ * install this package uses, regardless of package manager or hoisting settings.
+ */
+export function storybookParentNodeModulesDir(importMetaUrl: string): string | null {
+  const require = createRequire(importMetaUrl);
+  const dir = path.dirname(path.dirname(require.resolve('storybook/package.json')));
+
+  // If `storybook` resolves through a link to a source checkout (e.g. `pnpm link`, `portal:`),
+  // its parent directory is not a node_modules dir and its siblings are not packages, so it
+  // must not be offered to webpack as a module directory.
+  return path.basename(dir) === 'node_modules' ? dir : null;
+}

--- a/packages/vitest/src/storybook-config/main.ts
+++ b/packages/vitest/src/storybook-config/main.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { StorybookConfig } from '@storybook/server-webpack5';
 import { archivesDir } from '@chromatic-com/shared-e2e/utils/filePaths';
+import { storybookParentNodeModulesDir } from '@chromatic-com/shared-e2e/utils/storybookPaths';
 import { DEFAULT_OUTPUT_DIR } from '../constants';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -34,6 +35,18 @@ export default <StorybookConfig>{
     // Webpack defaults to `target: 'browserslist'`, which makes 'storybook build' transform
     // files based on the user's `.browserslistrc`: https://webpack.js.org/configuration/target/
     config.target = ['web'];
+
+    // Storybook's virtual entry modules live in the user's project root, where imports like
+    // `storybook/internal/csf` may not resolve by node_modules walk-up (e.g. with pnpm).
+    // Fall back to the `storybook` install this package depends on.
+    const storybookNodeModules = storybookParentNodeModulesDir(import.meta.url);
+    if (storybookNodeModules) {
+      config.resolve ??= {};
+      config.resolve.modules = [
+        ...(config.resolve.modules ?? ['node_modules']),
+        storybookNodeModules,
+      ];
+    }
 
     return config;
   },


### PR DESCRIPTION
Issue:
- Fixes https://github.com/chromaui/chromatic-e2e/issues/416

This PR is fully from Fable 5. I created minimal reproduction for it and it found the root cause and provided the fix. I've verified the fix using preview builds in separate project.

<details>
<summary>PR description from Claude</summary>

> ### Problem
> 
> Building the archive Storybook fails on pnpm projects with:
> 
> Module not found: Error: Can't resolve 'storybook/internal/csf'
> 
> Storybook's webpack builder places its virtual entry modules in the user's project root, and the entry's `storybook/internal/csf` import (the only one not covered by webpack `externals`) is resolved by `node_modules` walk-up from there. With npm/yarn our `storybook` dependency is hoisted to the project root so this works, but with pnpm it never is — regardless of the `hoist` setting — so resolution fails unless the user happens to have their own `storybook` installed.
> 
> ### Fix
> 
> Each package's Storybook config now appends the `node_modules` directory containing our own `storybook` install (resolved from the package's dependency context, so it works under any package manager/linker) to webpack's `resolve.modules` as a fallback. Walk-up resolution is still tried first, so existing setups are unaffected.
> 
> ### Testing
> 
> - Reproduced the failure in a pnpm project (both `hoist: false` and `hoist: true`), verified the built package fixes it.
> - Monorepo archive builds for playwright/cypress/vitest still pass (yarn layout, no regression).


</details>

## What Changed

Pass an additional `config.resolve.modules` to Webpack config, so that Storybook that's run in `node_modules/.pnpm/storybook@10.2.13_…/node_modules/storybook/package.json` can see modules outside the `.pnpm` directory.

## How to test

- [x] Tested in https://github.com/AriPerkkio/visual-regression-example
- [x] Wait for bug author to verify fix: https://github.com/chromaui/chromatic-e2e/issues/416#issuecomment-4959455869
