### PR TITLE
ci: fix publish by updating `@changesets/cli`

### DIFF
--- a/.changeset/clean-boats-float.md
+++ b/.changeset/clean-boats-float.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Feat: Add TurboSnap support

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "*.{ts,js,css,md}": "prettier --write"
   },
   "devDependencies": {
-    "@changesets/cli": "^2.27.1",
+    "@changesets/cli": "^2.31.1",
     "@eslint/js": "^9.15.0",
     "@testing-library/dom": "^8.1.0",
     "@testing-library/react": "^12.0.0",

--- a/packages/vitest/CHANGELOG.md
+++ b/packages/vitest/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @chromatic-com/vitest
 
-## 0.1.7
-
-### Patch Changes
-
-- 663cb3d: Feat: Add TurboSnap support
-
 ## 0.1.6
 
 ### Patch Changes

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chromatic-com/vitest",
-  "version": "0.1.7",
+  "version": "0.1.6",
   "description": "Chromatic Visual Regression Testing for Vitest",
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@changesets/cli':
-        specifier: ^2.27.1
-        version: 2.31.0(@types/node@22.20.1)
+        specifier: ^2.31.1
+        version: 2.31.1(@types/node@22.20.1)
       '@eslint/js':
         specifier: ^9.15.0
         version: 9.39.5
@@ -329,8 +329,8 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
-  '@changesets/cli@2.31.0':
-    resolution: {integrity: sha512-AhI4enNTgHu2IZr6K4WZyf0EPch4XVMn1yOMFmCD9gsfBGqMYaHXls5HyDv6/CL5axVQABz68eG30eCtbr2wFg==}
+  '@changesets/cli@2.31.1':
+    resolution: {integrity: sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==}
     hasBin: true
 
   '@changesets/config@3.1.4':
@@ -4436,7 +4436,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.31.0(@types/node@22.20.1)':
+  '@changesets/cli@2.31.1(@types/node@22.20.1)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10


### PR DESCRIPTION
## What Changed

Release failed in https://github.com/chromaui/chromatic-e2e/actions/runs/29814171245/job/88581570292 with the error `🦋  error TypeError: Cannot read properties of undefined (reading 'includes')`. This error is mentioned on https://github.com/changesets/changesets/issues/2164 that's fixed in https://github.com/changesets/changesets/releases/tag/%40changesets%2Fcli%402.31.1.

Also reverts the failed version bump commit.

## How to test

Merge and retry release on CI.