### PR TITLE
fix(vitest): turboSnap with sharded runs

### DIFF
--- a/.changeset/cute-pets-dress.md
+++ b/.changeset/cute-pets-dress.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: TurboSnap with `vitest --shard` to contain `preview-stats.json` info from all runs.

--- a/packages/vitest/src/node/plugin.test.ts
+++ b/packages/vitest/src/node/plugin.test.ts
@@ -205,6 +205,8 @@ test('does not clean existing output directory when "vitest --merge-reports" is 
   const outputDir = resolve(options.root, '.vitest-reports');
   const outputFile = resolve(outputDir, 'blob.json');
 
+  await rm(outputDir, { recursive: true, force: true });
+
   // First run to generate blob
   await runFixture({ reporters: [['blob', { outputFile }]], ...options });
 

--- a/packages/vitest/src/node/plugin.ts
+++ b/packages/vitest/src/node/plugin.ts
@@ -1,4 +1,4 @@
-import { rmSync } from 'node:fs';
+import { existsSync, readdirSync, rmSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type {} from 'vitest/config';
 import type { Vite } from 'vitest/node';
@@ -6,7 +6,7 @@ import colors from 'tinyrainbow';
 import { DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS } from '@chromatic-com/shared-e2e';
 import { createCommands } from './commands';
 import { ChromaticReporter } from './reporter';
-import { WebpackStatsReporter } from './webpack-stats-reporter';
+import { mergePreviewStats, WebpackStatsReporter } from './webpack-stats-reporter';
 import { DEFAULT_OUTPUT_DIR } from '../constants';
 import { type ResolvedOptions, type Options } from '../types';
 
@@ -49,10 +49,13 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
       };
     },
 
-    configureVitest(context) {
+    async configureVitest(context) {
       const project = context.project;
       const browser = project.config.browser;
       const sequence = context.vitest.config.sequence;
+
+      // Enabled when "vitest --merge-reports" is run. It's used after sharded runs ("vitest --shard=1/2", "vitest --shard=2/2").
+      const isMergeReports = project.globalConfig.mergeReports;
 
       // browser.name is instances[].browser, not instances[].name: https://github.com/vitest-dev/vitest/blob/d22b029ae056b9515033d75c1249e9db26612770/packages/vitest/src/node/projects/resolveProjects.ts#L307
       if (!browser.enabled || browser.name !== 'chromium') {
@@ -63,7 +66,7 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
         ChromaticReporter.apply(context.vitest, options);
       }
 
-      if (options.turboSnap) {
+      if (options.turboSnap && !isMergeReports) {
         WebpackStatsReporter.apply(context.vitest, options);
       }
 
@@ -105,7 +108,14 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
         }
       }
 
-      if (!project.globalConfig.mergeReports) {
+      if (isMergeReports) {
+        if (options.turboSnap) {
+          await mergePreviewStats({
+            root: project.vitest.config.root,
+            outputDirectory: options.outputDirectory,
+          });
+        }
+      } else {
         clean();
       }
 
@@ -117,8 +127,14 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
       function clean() {
         const outputDirectory = resolve(project.vitest.config.root, options.outputDirectory);
 
-        for (const output of ['chromatic-archives', 'preview-stats.json']) {
-          rmSync(resolve(outputDirectory, output), { recursive: true, force: true });
+        rmSync(resolve(outputDirectory, 'chromatic-archives'), { recursive: true, force: true });
+
+        if (existsSync(outputDirectory)) {
+          for (const file of readdirSync(outputDirectory)) {
+            if (file.startsWith('preview-stats') && file.endsWith('.json')) {
+              rmSync(resolve(outputDirectory, file), { force: true });
+            }
+          }
         }
       }
     },

--- a/packages/vitest/src/node/webpack-stats-reporter.test.ts
+++ b/packages/vitest/src/node/webpack-stats-reporter.test.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, rmSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { copyFile, mkdir, readdir, rm, rename } from 'node:fs/promises';
+import { basename, dirname, resolve } from 'node:path';
 import { afterEach, assert, expect, onTestFinished, test } from 'vitest';
 import { uniqueId } from '@chromatic-com/shared-e2e/write-archive/stories-files';
 import type { Module } from './webpack-stats-reporter';
@@ -254,6 +255,112 @@ test('TurboSnap enabled, circular imports', async () => {
   `);
 });
 
+test('TurboSnap enabled, sharded run', async () => {
+  const root = resolve(import.meta.dirname, '../../test/fixtures');
+  const reportsDirectory = resolve(root, '.vitest');
+  let blobReportsDir: string | undefined;
+
+  const outputDirectories = {
+    base: resolve(reportsDirectory, 'chromatic'),
+    first: resolve(reportsDirectory, 'chromatic-first-run'),
+    second: resolve(reportsDirectory, 'chromatic-second-run'),
+  };
+
+  await rm(reportsDirectory, { force: true, recursive: true });
+
+  // Run "vitest --shard=1/2", "vitest --shard=2/2"
+  for (const [index, output] of [outputDirectories.first, outputDirectories.second].entries()) {
+    const { stdout } = await runFixture(
+      { root, shard: `${1 + index}/2`, reporters: 'blob' },
+      { turboSnap: true }
+    );
+
+    if (!blobReportsDir) {
+      const filename = stdout.match(/blob report written to (.*)/m)[1];
+      blobReportsDir = dirname(filename);
+    }
+
+    // Store results in another directory. Simulates actions/upload-artifact behaviour.
+    await rename(outputDirectories.base, output);
+  }
+
+  // Copy both results to default directory for --merge-reports run. Simulates actions/download-artifact behavior.
+  await mergeChromaticDirectories(outputDirectories.base, [
+    outputDirectories.first,
+    outputDirectories.second,
+  ]);
+
+  // Run "vitest --merge-reports".
+  await runFixture({ root, mergeReports: blobReportsDir }, { turboSnap: true });
+
+  // preview-stats.json from both runs should be merged together:
+  const stats = readStats(root);
+  const modules = stats.modules.filter(excludeNodeModules).filter(excludePluginSources);
+
+  // Both test cases and their dependencies should be found:
+  expect(modules).toMatchInlineSnapshot(`
+    [
+      {
+        "id": "turbo-snap-1.test.ts",
+        "name": "turbo-snap-1.test.ts",
+        "reasons": [
+          {
+            "moduleName": ".vitest/chromatic/chromatic-archives/turbo-snap-1-1.stories.json",
+          },
+        ],
+      },
+      {
+        "id": "components/button/button.ts",
+        "name": "components/button/button.ts",
+        "reasons": [
+          {
+            "moduleName": "components/button/index.ts",
+          },
+        ],
+      },
+      {
+        "id": "components/button/index.ts",
+        "name": "components/button/index.ts",
+        "reasons": [
+          {
+            "moduleName": "components/accordion/accordion.ts",
+          },
+          {
+            "moduleName": "turbo-snap-2.test.ts",
+          },
+        ],
+      },
+      {
+        "id": "components/accordion/accordion.ts",
+        "name": "components/accordion/accordion.ts",
+        "reasons": [
+          {
+            "moduleName": "components/accordion/index.ts",
+          },
+        ],
+      },
+      {
+        "id": "components/accordion/index.ts",
+        "name": "components/accordion/index.ts",
+        "reasons": [
+          {
+            "moduleName": "turbo-snap-1.test.ts",
+          },
+        ],
+      },
+      {
+        "id": "turbo-snap-2.test.ts",
+        "name": "turbo-snap-2.test.ts",
+        "reasons": [
+          {
+            "moduleName": ".vitest/chromatic/chromatic-archives/turbo-snap-2-2.stories.json",
+          },
+        ],
+      },
+    ]
+  `);
+});
+
 test('TurboSnap enabled, CSS imports', async () => {
   const root = resolve(import.meta.dirname, '../../test/fixtures');
 
@@ -426,19 +533,22 @@ test('TurboSnap disabled', async () => {
   const root = resolve(import.meta.dirname, '../../test/fixtures');
   await runFixture({ root }, { turboSnap: false });
 
-  const stats = readStats(root);
-  expect(stats).toContain('ENOENT: no such file or directory');
-  expect(stats).toContain('.vitest/chromatic/preview-stats.json');
+  let error = '';
+
+  try {
+    readStats(root);
+  } catch (e) {
+    error = e.message;
+  }
+
+  expect(error).toContain('ENOENT: no such file or directory');
+  expect(error).toContain('.vitest/chromatic/preview-stats.json');
 });
 
 function readStats(root = process.cwd(), outputDir = DEFAULT_OUTPUT_DIR): { modules: Module[] } {
   const statsPath = resolve(root, outputDir, 'preview-stats.json');
 
-  try {
-    return JSON.parse(readFileSync(statsPath, 'utf-8'));
-  } catch (error) {
-    return error.message;
-  }
+  return JSON.parse(readFileSync(statsPath, 'utf-8'));
 }
 
 function runFixture(
@@ -468,4 +578,45 @@ function excludeNodeModules(mod: Module) {
 // Exclude plugin source files from the stats report, as they are not relevant to the test results.
 function excludePluginSources(mod: Module) {
   return !mod.id.includes('src/browser/') && !mod.id.includes('src/index.ts');
+}
+
+async function mergeChromaticDirectories(target: string, sources: string[]) {
+  await mkdir(resolve(target, 'chromatic-archives', 'archive'), { recursive: true });
+
+  for (const source of sources) {
+    const previewStats = await findFile(source, 'preview-stats');
+    await copyFile(previewStats, resolve(target, basename(previewStats)));
+
+    for (const filename of await readdir(resolve(source, 'chromatic-archives'))) {
+      if (filename === 'archive') continue;
+
+      const from = resolve(source, 'chromatic-archives', filename);
+      const to = resolve(target, 'chromatic-archives', filename);
+
+      await copyFile(from, to);
+    }
+
+    for (const filename of await readdir(resolve(source, 'chromatic-archives', 'archive'))) {
+      const from = resolve(source, 'chromatic-archives', 'archive', filename);
+      const to = resolve(target, 'chromatic-archives', 'archive', filename);
+
+      await copyFile(from, to);
+    }
+  }
+}
+
+async function findFile(directory: string, partialName: string) {
+  const files = await readdir(directory);
+  const matches = files.filter((filename) => filename.match(partialName));
+
+  assert(
+    matches.length !== 0,
+    `Expected ${directory} to contain file matching ${partialName}. Found ${files.join()}.`
+  );
+  assert(
+    matches.length === 1,
+    `Found ${matches.length} matches for ${partialName} in ${directory}: ${matches.join()}.`
+  );
+
+  return resolve(directory, matches[0]);
 }

--- a/packages/vitest/src/node/webpack-stats-reporter.ts
+++ b/packages/vitest/src/node/webpack-stats-reporter.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, relative, resolve, sep } from 'node:path';
 import type { TestCase, TestModule, Vite, Vitest } from 'vitest/node';
 import type { Reporter } from 'vitest/reporters';
@@ -42,11 +42,15 @@ export class WebpackStatsReporter implements Reporter {
     const exists = ctx.config.reporters.some(isWebpackStatsReporter);
 
     if (!exists) {
-      const outputFile = resolve(
-        ctx.config.root,
-        pluginOptions.outputDirectory,
-        'preview-stats.json'
-      );
+      const filename = [
+        'preview-stats',
+        ctx.config.shard && `-${ctx.config.shard.index}-${ctx.config.shard.count}`,
+        '.json',
+      ]
+        .filter(Boolean)
+        .join('');
+
+      const outputFile = resolve(ctx.config.root, pluginOptions.outputDirectory, filename);
 
       ctx.config.reporters.push(new WebpackStatsReporter(ctx, { outputFile }));
     }
@@ -324,4 +328,46 @@ function resolveMapSources(
 
     return [resolved];
   });
+}
+
+/**
+ * Merge multiple `preview-stats.json` files into a single one.
+ * When Vitest is run with `--shard` option, each stat file will have
+ * unique filenames like `preview-stats-1-4.json` and `preview-stats-2-4.json`.
+ *
+ * This helper will read all files matching this pattern and output a single `preview-stats.json`
+ * containing merged stats.
+ */
+export async function mergePreviewStats(options: { root: string; outputDirectory: string }) {
+  const outputDirectory = resolve(options.root, options.outputDirectory);
+  const merged = new Map<Module['id'], Module>();
+
+  for (const filename of await readdir(outputDirectory)) {
+    if (filename.startsWith('preview-stats') && filename.endsWith('.json')) {
+      const fullFilename = resolve(outputDirectory, filename);
+      const stats: { modules: Module[] } = JSON.parse(await readFile(fullFilename, 'utf-8'));
+
+      for (const mod of stats.modules) {
+        const previous = merged.get(mod.id);
+
+        if (previous) {
+          for (const reason of mod.reasons) {
+            if (!previous.reasons.some((r) => r.moduleName === reason.moduleName)) {
+              previous.reasons.push(reason);
+            }
+          }
+        } else {
+          merged.set(mod.id, mod);
+        }
+      }
+
+      await rm(fullFilename);
+    }
+  }
+
+  await writeFile(
+    resolve(outputDirectory, 'preview-stats.json'),
+    JSON.stringify({ modules: Array.from(merged.values()) }, null, 2),
+    'utf-8'
+  );
 }

--- a/packages/vitest/test/utils/node.ts
+++ b/packages/vitest/test/utils/node.ts
@@ -87,6 +87,16 @@ export class StableTestFileOrderSorter implements TestSequencer {
   }
 
   shard(files: TestSpecification[]) {
-    return files;
+    const shard = files[0]?.project?.config?.shard;
+
+    if (!shard) {
+      return files;
+    }
+
+    if (shard.count !== files.length) {
+      throw new Error(`Not Implemented: StableTestFileOrderSorter has simple sharding support.`);
+    }
+
+    return [files[shard.index - 1]];
   }
 }


### PR DESCRIPTION
Issue:
- Related to Milestone 1 of https://github.com/chromaui/chromatic-e2e/issues/419

When merging multiple `vitest --shard` runs with `vitest --merge-reports`, the `preview-stats.json` files override each other. The last one wins.

## What Changed

When `vitest --shard` is used, use the shard keys to create unique `preview-stats.json` for each run. When `vitest --merge-reports` is run, merge all `preview-stats**.json` files into a single `preview-stats.json`.

## How to test

Added failing test cases.

Tested in separate project.
- Before, see how it contains only a single test case. This is the one from last run: https://github.com/AriPerkkio/visual-regression-example/actions/runs/29902520769/job/88866495159#step:9:107
- After, see how it contains all test cases: https://github.com/AriPerkkio/visual-regression-example/actions/runs/29925285342/job/88940942489#step:11:107
