### PR TITLE
refactor(vitest): replace `getOptions` browser command with `provide`/`inject` pattern

### DIFF
--- a/packages/vitest/src/browser/setupFile.ts
+++ b/packages/vitest/src/browser/setupFile.ts
@@ -1,13 +1,14 @@
-import { afterEach, beforeEach } from 'vitest';
+import { afterEach, beforeEach, inject } from 'vitest';
 import { commands } from 'vitest/browser';
 import { takeSnapshot } from './public/takeSnapshot';
 import { waitForIdleNetwork } from './public/waitForIdleNetwork';
 import { type InternalTestContext } from '../types';
 import type {} from '../node/commands';
+import type {} from '../node/plugin';
 
 // Destructuring the context is important, so that possible user-provided fixtures work too
 beforeEach<InternalTestContext>(async ({ task }) => {
-  const options = await commands.__chromatic_getOptions();
+  const options = inject('__chromatic_options');
 
   if (options.tags) {
     // If user has defined plugin tags we register only the tests that match those tags

--- a/packages/vitest/src/node/commands.browser.test.ts
+++ b/packages/vitest/src/node/commands.browser.test.ts
@@ -14,7 +14,6 @@ test('browser commands are available', () => {
 
   expect(Object.fromEntries(chromaticCommands)).toMatchInlineSnapshot(`
     {
-      "__chromatic_getOptions": [Function],
       "__chromatic_getSnapshots": [Function],
       "__chromatic_interceptFetch": [Function],
       "__chromatic_reset": [Function],
@@ -22,23 +21,6 @@ test('browser commands are available', () => {
       "__chromatic_uploadDOMSnapshot": [Function],
       "__chromatic_waitForIdleNetwork": [Function],
       "__chromatic_writeTestResult": [Function],
-    }
-  `);
-});
-
-test('getOptions', async () => {
-  await expect(commands.__chromatic_getOptions()).resolves.toMatchInlineSnapshot(`
-    {
-      "assetDomains": [],
-      "disableAutoSnapshot": false,
-      "idleNetworkInterval": 100,
-      "outputDirectory": ".vitest/chromatic",
-      "reporter": {
-        "enabled": true,
-        "verbose": true,
-      },
-      "resourceArchiveTimeout": 10000,
-      "turboSnap": false,
     }
   `);
 });

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -44,14 +44,6 @@ export function createCommands(options: ResolvedOptions) {
 
   return {
     /**
-     * Get resolved options on the client side.
-     * All options must be serializable at this point.
-     */
-    async __chromatic_getOptions() {
-      return options;
-    },
-
-    /**
      * Store a `@rrweb` generated DOM snapshot for the test.
      * Can be called multiple times during a single test case.
      */

--- a/packages/vitest/src/node/plugin.browser.test.ts
+++ b/packages/vitest/src/node/plugin.browser.test.ts
@@ -1,0 +1,18 @@
+import { test, expect, inject } from 'vitest';
+
+test('provided __chromatic_options', async () => {
+  expect(inject('__chromatic_options')).toMatchInlineSnapshot(`
+    {
+      "assetDomains": [],
+      "disableAutoSnapshot": false,
+      "idleNetworkInterval": 100,
+      "outputDirectory": ".vitest/chromatic",
+      "reporter": {
+        "enabled": true,
+        "verbose": true,
+      },
+      "resourceArchiveTimeout": 10000,
+      "turboSnap": false,
+    }
+  `);
+});

--- a/packages/vitest/src/node/plugin.test.ts
+++ b/packages/vitest/src/node/plugin.test.ts
@@ -33,7 +33,6 @@ test('adds browser commands', async () => {
 
   expect(config.browser.commands).toMatchInlineSnapshot(`
     {
-      "__chromatic_getOptions": [Function],
       "__chromatic_getSnapshots": [Function],
       "__chromatic_interceptFetch": [Function],
       "__chromatic_reset": [Function],

--- a/packages/vitest/src/node/plugin.ts
+++ b/packages/vitest/src/node/plugin.ts
@@ -42,6 +42,9 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
           entries: [setupFile],
         },
         test: {
+          provide: {
+            __chromatic_options: options,
+          },
           browser: {
             commands: createCommands(options),
           },
@@ -154,4 +157,11 @@ function resolveReporterOptions(reporter: Options['reporter']): ResolvedOptions[
     enabled: reporter.enabled ?? true,
     verbose: reporter.verbose ?? true,
   };
+}
+
+/** @internal */
+declare module 'vitest' {
+  export interface ProvidedContext {
+    __chromatic_options: ResolvedOptions;
+  }
 }


### PR DESCRIPTION
Issue:
- Refactoring split from https://github.com/chromaui/chromatic-e2e/pull/427

## What Changed

Currently `getOptions` has been browser command that can transfer resolved plugin options to browser side via WS, on-demand. We always need this information when a test case starts, in the setup file.

This PR replaces the browser command with [Vitest's `provide` + `inject` pattern](https://vitest.dev/config/provide.html#provide), that serializes and passes the data to browser/worker before any tests have loaded. It's no longer on-demand. Calling `inject()` multiple times in a single browser context does not cause any WS requests. This is small perf win too.

## How to test

- All tests pass on CI
