### PR TITLE
feat(vitest): add remaining telemetry events

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,6 +60,7 @@ export default tseslint.config(
     files: ['**/*.test.ts', '**/*.spec.ts'],
     rules: {
       'no-restricted-syntax': 'off',
+      'no-empty-pattern': 'off',
     },
   },
   eslintConfigPrettier

--- a/packages/vitest/src/browser/getCurrentTest.ts
+++ b/packages/vitest/src/browser/getCurrentTest.ts
@@ -10,6 +10,10 @@ export function getCurrentTest() {
   return hooks.getCurrentTest<Test | undefined>();
 }
 
+export function getCurrentSuite() {
+  return hooks.getCurrentSuite();
+}
+
 async function resolveHooks() {
   // TestRunner API is available on vitest@4.1.0
   if (vitest.TestRunner) {

--- a/packages/vitest/src/browser/public/configure.ts
+++ b/packages/vitest/src/browser/public/configure.ts
@@ -1,6 +1,7 @@
 import { beforeAll } from 'vitest';
-import { getCurrentTest, type Test } from '../getCurrentTest';
+import { getCurrentSuite, getCurrentTest, type Test } from '../getCurrentTest';
 import { isChromium } from '../isChromium';
+import { trackEvent } from '../telemetry';
 import type { ConfigureOptions } from '../../types';
 
 /**
@@ -75,13 +76,18 @@ export function configure(options: ConfigureOptions) {
       ...test.meta.__chromatic_options,
       ...options,
     };
-    return;
+
+    return trackConfigure('test');
   }
+
+  const scope = getCurrentSuite()?.suite ? 'suite' : 'file';
 
   // Called at top level or within describe().
   // Wrap suite traversal in beforeAll to make sure it runs after test collection.
   // eslint-disable-next-line no-empty-pattern
   beforeAll(({}, suite) => {
+    trackConfigure(scope);
+
     traverseTests(suite);
 
     function traverseTests(task: (typeof suite.tasks)[0]) {
@@ -99,4 +105,15 @@ export function configure(options: ConfigureOptions) {
       task.tasks.forEach(traverseTests);
     }
   });
+
+  function trackConfigure(scope: 'test' | 'suite' | 'file') {
+    trackEvent({
+      eventType: 'configure_called',
+      level: 'info',
+      payload: {
+        options: Object.keys(options) as (keyof typeof options)[],
+        scope,
+      },
+    });
+  }
 }

--- a/packages/vitest/src/browser/public/takeSnapshot.ts
+++ b/packages/vitest/src/browser/public/takeSnapshot.ts
@@ -5,10 +5,11 @@ import { serializedNodeWithId } from '@rrweb/types';
 import { type DOMSnapshots } from '@chromatic-com/shared-e2e';
 import { getCurrentTest } from '../getCurrentTest';
 import { isChromium } from '../isChromium';
+import { trackEvent } from '../telemetry';
 import type {} from '../../node/commands';
 
 interface Options {
-  ignoreUnawaited?: boolean;
+  isAutomaticSnapshot: boolean;
 }
 
 /**
@@ -27,10 +28,22 @@ async function takeSnapshot(name?: string, options?: Options): Promise<void> {
   const test = getCurrentTest();
 
   if (!test) {
+    trackEvent({
+      eventType: 'take_snapshot_invalid_call',
+      level: 'error',
+      payload: { isInsideTest: false, isRegisteredTest: undefined, isAwaited: undefined },
+    });
+
     throw new TypeError('takeSnapshot() must be called within a test()');
   }
 
   if (!test.meta.__chromatic_isRegistered) {
+    trackEvent({
+      eventType: 'take_snapshot_invalid_call',
+      level: 'error',
+      payload: { isInsideTest: true, isRegisteredTest: false, isAwaited: undefined },
+    });
+
     throw new TypeError(
       'takeSnapshot() cannot be called in a test that is not registered for Chromatic plugin.' +
         `\nMake sure ${test.file.projectName || 'root'} project has chromaticPlugin() enabled.`
@@ -53,11 +66,17 @@ async function takeSnapshot(name?: string, options?: Options): Promise<void> {
 
   const save = async () => {
     await replaceBlobUrls(domSnapshot);
-    await commands.__chromatic_uploadDOMSnapshot(test.id, domSnapshot, pseudoClassIds, name);
+    await commands.__chromatic_uploadDOMSnapshot(
+      test.id,
+      domSnapshot,
+      pseudoClassIds,
+      name ?? null, // Convert undefined to null to avoid https://github.com/vitest-dev/vitest/issues/10864
+      options
+    );
   };
 
-  // Ignore is set when called by automatic snapshots
-  if (options?.ignoreUnawaited) {
+  // Automatic snapshots are always awaited
+  if (options?.isAutomaticSnapshot) {
     return await save();
   }
 

--- a/packages/vitest/src/browser/public/waitForIdleNetwork.test.ts
+++ b/packages/vitest/src/browser/public/waitForIdleNetwork.test.ts
@@ -20,13 +20,13 @@ test("throws when used in a test that isn't registered", async () => {
      FAIL   chromium  wait-for-idle-network.test.ts > test #1
     TypeError: waitForIdleNetwork() cannot be called in a test that is not registered for Chromatic plugin.
     Make sure chromium project has chromaticPlugin() enabled.
-     ❯ wait-for-idle-network.test.ts:7:8
-          5|   document.body.innerHTML = '<h1>Example heading</h1>';
-          6|
-          7|   await waitForIdleNetwork(1);
-           |        ^
+     ❯ wait-for-idle-network.test.ts:9:8
+          7|   document.body.innerHTML = '<h1>Example heading</h1>';
           8|
-          9|   expect.fail('Should not reach this point');
+          9|   await waitForIdleNetwork(1);
+           |        ^
+         10|
+         11|   expect.fail('Should not reach this point');
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯"
   `);
@@ -44,13 +44,13 @@ test('throws when used outside of a test()', async () => {
 
      FAIL   chromium  wait-for-idle-network.test.ts > suite
     TypeError: waitForIdleNetwork() must be called within a test()
-     ❯ wait-for-idle-network.test.ts:14:10
-         12| describe.runIf(inject('testName') === 'two')('suite', async () => {
-         13|   beforeAll(async () => {
-         14|     await waitForIdleNetwork(1);
+     ❯ wait-for-idle-network.test.ts:16:10
+         14| describe.runIf(inject('testName') === 'two')('suite', async () => {
+         15|   beforeAll(async () => {
+         16|     await waitForIdleNetwork(1);
            |          ^
-         15|   });
-         16|
+         17|   });
+         18|
 
     ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯"
   `);

--- a/packages/vitest/src/browser/public/waitForIdleNetwork.ts
+++ b/packages/vitest/src/browser/public/waitForIdleNetwork.ts
@@ -1,7 +1,12 @@
 import { commands } from 'vitest/browser';
 import { getCurrentTest } from '../getCurrentTest';
 import { isChromium } from '../isChromium';
+import { trackEvent } from '../telemetry';
 import type {} from '../../node/commands';
+
+interface Options {
+  _internal: boolean;
+}
 
 /**
  * Wait for network to be idle, meaning no new network requests for at least `idleNetworkInterval` ms.
@@ -16,23 +21,71 @@ import type {} from '../../node/commands';
  *
  * Use `timeout` argument to reject if network doesn't become idle within given time.
  */
-export async function waitForIdleNetwork(timeout: number) {
+async function waitForIdleNetwork(timeout: number): Promise<void>;
+
+/** @internal Pass options when called internally by the plugin */
+async function waitForIdleNetwork(timeout: number, options: Options): Promise<void>;
+
+async function waitForIdleNetwork(timeout: number, options?: Options): Promise<void> {
   if (!isChromium()) {
     return;
+  }
+
+  const isCalledByUser = options?._internal !== true;
+
+  if (isCalledByUser) {
+    trackEvent({ eventType: 'wait_for_idle_network_called', level: 'info', payload: { timeout } });
   }
 
   const test = getCurrentTest();
 
   if (!test) {
+    trackEvent({
+      eventType: 'wait_for_idle_network_invalid_call',
+      level: 'error',
+      payload: {
+        isInsideTest: false,
+        isRegisteredTest: undefined,
+        isCalledByUser,
+      },
+    });
+
     throw new TypeError('waitForIdleNetwork() must be called within a test()');
   }
 
   if (!test.meta.__chromatic_isRegistered) {
+    trackEvent({
+      eventType: 'wait_for_idle_network_invalid_call',
+      level: 'error',
+      payload: {
+        isInsideTest: true,
+        isRegisteredTest: false,
+        isCalledByUser,
+      },
+    });
+
     throw new TypeError(
       'waitForIdleNetwork() cannot be called in a test that is not registered for Chromatic plugin.' +
         `\nMake sure ${test.file.projectName || 'root'} project has chromaticPlugin() enabled.`
     );
   }
 
-  return await commands.__chromatic_waitForIdleNetwork(timeout);
+  try {
+    await commands.__chromatic_waitForIdleNetwork(timeout);
+  } catch (error) {
+    const isTimeoutError =
+      error instanceof Error && error.message.includes('Timed out waiting for network to be idle');
+
+    if (isTimeoutError) {
+      trackEvent({
+        eventType: 'wait_for_idle_network_timeout',
+        level: 'error',
+        payload: { timeout, isCalledByUser },
+      });
+    }
+
+    throw error;
+  }
 }
+
+export { waitForIdleNetwork };

--- a/packages/vitest/src/browser/public/waitForIdleNetwork.ts
+++ b/packages/vitest/src/browser/public/waitForIdleNetwork.ts
@@ -32,11 +32,6 @@ async function waitForIdleNetwork(timeout: number, options?: Options): Promise<v
   }
 
   const isCalledByUser = options?._internal !== true;
-
-  if (isCalledByUser) {
-    trackEvent({ eventType: 'wait_for_idle_network_called', level: 'info', payload: { timeout } });
-  }
-
   const test = getCurrentTest();
 
   if (!test) {
@@ -68,6 +63,10 @@ async function waitForIdleNetwork(timeout: number, options?: Options): Promise<v
       'waitForIdleNetwork() cannot be called in a test that is not registered for Chromatic plugin.' +
         `\nMake sure ${test.file.projectName || 'root'} project has chromaticPlugin() enabled.`
     );
+  }
+
+  if (isCalledByUser) {
+    trackEvent({ eventType: 'wait_for_idle_network_called', level: 'info', payload: { timeout } });
   }
 
   try {

--- a/packages/vitest/src/browser/setupFile.ts
+++ b/packages/vitest/src/browser/setupFile.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, inject } from 'vitest';
 import { commands } from 'vitest/browser';
 import { takeSnapshot } from './public/takeSnapshot';
 import { waitForIdleNetwork } from './public/waitForIdleNetwork';
+import { trackEvent } from './telemetry';
 import { type InternalTestContext } from '../types';
 import type {} from '../node/commands';
 import type {} from '../node/plugin';
@@ -90,12 +91,12 @@ afterEach<InternalTestContext>(async ({ task }) => {
 
   if (testOptions.resourceArchiveTimeout !== 0) {
     await document.fonts.ready;
-    await waitForIdleNetwork(testOptions.resourceArchiveTimeout);
+    await waitForIdleNetwork(testOptions.resourceArchiveTimeout, { _internal: true });
   }
 
   // Take automatic snapshot
   if (!options.disableAutoSnapshot) {
-    await takeSnapshot(undefined, { ignoreUnawaited: true });
+    await takeSnapshot(undefined, { isAutomaticSnapshot: true });
   }
 });
 
@@ -106,5 +107,15 @@ class PendingSnapshotsError extends AggregateError {
       `${pendingCalls.length} unawaited takeSnapshot() call(s)`
     );
     this.name = 'PendingSnapshotsError';
+
+    trackEvent({
+      eventType: 'take_snapshot_invalid_call',
+      level: 'error',
+      payload: {
+        isAwaited: false,
+        isInsideTest: true,
+        isRegisteredTest: true,
+      },
+    });
   }
 }

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -20,6 +20,7 @@ import {
 import { trackEvent } from './telemetry';
 import { NetworkIdleTracker } from './NetworkIdleTracker';
 import { ChromaticReporter } from './reporter';
+import { TelemetryReporter } from './telemetry-reporter';
 import { WebpackStatsReporter } from './webpack-stats-reporter';
 
 type TestID = TestCase['id'];
@@ -53,7 +54,8 @@ export function createCommands(options: ResolvedOptions) {
       id: TestID,
       snapshot: serializedNodeWithId,
       pseudoClassIds: DOMSnapshots[string]['pseudoClassIds'],
-      name?: string
+      name: string | undefined,
+      snapshotOptions?: { isAutomaticSnapshot: boolean }
     ) {
       const entity = context.project.vitest.state.getReportedEntityById(id);
       assert(
@@ -68,6 +70,7 @@ export function createCommands(options: ResolvedOptions) {
         snapshots.set(id, sessionSnapshots);
       }
 
+      const isCustomName = name !== undefined;
       name ||= `Snapshot #${sessionSnapshots.size + 1}`;
 
       const frame = await context.frame();
@@ -84,6 +87,11 @@ export function createCommands(options: ResolvedOptions) {
       sessionSnapshots.set(name, { snapshot, viewport, colorScheme, pseudoClassIds });
 
       ChromaticReporter.onSnapshot(context.project.vitest, entity);
+      TelemetryReporter.onSnapshot(context.project.vitest, {
+        isCustomName,
+        colorScheme,
+        isAutomaticSnapshot: snapshotOptions?.isAutomaticSnapshot ?? false,
+      });
     },
 
     /**
@@ -200,6 +208,16 @@ export function createCommands(options: ResolvedOptions) {
       if (options.turboSnap) {
         WebpackStatsReporter.onStoryFileWrite(context.project.vitest, entity, storiesFile);
       }
+
+      trackEvent(
+        {
+          eventType: 'archives_created',
+          level: 'info',
+          payload: { count: Object.keys(snapshotBuffers).length },
+        },
+        context.project.vitest,
+        options
+      );
     },
 
     /**

--- a/packages/vitest/src/node/commands.ts
+++ b/packages/vitest/src/node/commands.ts
@@ -213,7 +213,7 @@ export function createCommands(options: ResolvedOptions) {
         {
           eventType: 'archives_created',
           level: 'info',
-          payload: { count: Object.keys(snapshotBuffers).length },
+          payload: { archiveCount: Object.keys(snapshotBuffers).length },
         },
         context.project.vitest,
         options

--- a/packages/vitest/src/node/plugin.test.ts
+++ b/packages/vitest/src/node/plugin.test.ts
@@ -4,9 +4,7 @@ import { beforeEach, expect, onTestFinished, test } from 'vitest';
 import { createVitest, type TestModule } from 'vitest/node';
 import { uniqueId } from '@chromatic-com/shared-e2e/write-archive/stories-files';
 import { chromaticPlugin } from './plugin';
-import type { WireTelemetryEvent } from './telemetry';
 import {
-  createTelemetryServer,
   createOutputStreams,
   getBrowserConfig,
   getResolvedConfig,
@@ -266,122 +264,5 @@ test('works in multi project instance setup', { timeout: 30_000 }, async () => {
       "public-apis-1.stories.json",
       "public-apis-2.stories.json",
     ]
-  `);
-});
-
-test('sends plugin init telemetry event', async () => {
-  const { onRequest, setup } = createTelemetryServer();
-  const cleanup = setup();
-  onTestFinished(cleanup);
-
-  process.env.CHROMATIC_DISABLE_TELEMETRY = '0';
-  onTestFinished(() => void (process.env.CHROMATIC_DISABLE_TELEMETRY = '1'));
-
-  await getResolvedConfig(undefined, {
-    ignoreSelectors: ['.ignore-me'],
-    assetDomains: ['https://one.chromatic.com', 'https://two.chromatic.com'],
-    tags: ['first', 'second', 'third'],
-    turboSnap: true,
-    resourceArchiveTimeout: 1234,
-    disableAutoSnapshot: true,
-  });
-
-  const initEvents = onRequest.mock.calls.filter(
-    ([event]) => event.eventType === 'vitest_plugin_configured'
-  );
-  expect(initEvents).toHaveLength(1);
-
-  const event = initEvents[0][0];
-
-  expect(event).toHaveProperty('eventType', 'vitest_plugin_configured');
-  expect(event).toHaveProperty('level', 'info');
-  expect(event.payload).toMatchInlineSnapshot(`
-    {
-      "assetDomainsCount": 2,
-      "disableAutoSnapshot": true,
-      "idleNetworkInterval": 100,
-      "ignoreSelectorsCount": 1,
-      "isCustomOutputDirectory": false,
-      "reporter": "verbose",
-      "resourceArchiveTimeout": 1234,
-      "tagsCount": 3,
-      "turboSnap": true,
-    }
-  `);
-});
-
-test('sends multiple plugin init telemetry events when multiple projects', async () => {
-  const { onRequest, setup } = createTelemetryServer();
-  const cleanup = setup();
-  onTestFinished(cleanup);
-
-  process.env.CHROMATIC_DISABLE_TELEMETRY = '0';
-  onTestFinished(() => void (process.env.CHROMATIC_DISABLE_TELEMETRY = '1'));
-
-  await runFixture(
-    {
-      projects: [
-        {
-          plugins: [chromaticPlugin({ delay: 1111 })],
-          test: {
-            name: 'first-project',
-            browser: getBrowserConfig('first-browser'),
-            include: ['**/dom.test.ts'],
-            root: resolve(import.meta.dirname, '../../test/fixtures'),
-          },
-        },
-        {
-          plugins: [chromaticPlugin({ delay: 2222 })],
-          test: {
-            name: 'second-project',
-            browser: getBrowserConfig('second-browser'),
-            include: ['**/dom.test.ts'],
-            root: resolve(import.meta.dirname, '../../test/fixtures'),
-          },
-        },
-      ],
-    },
-    { disabled: true }
-  );
-
-  const initEvents = onRequest.mock.calls.flatMap(([event]) =>
-    event.eventType === 'vitest_plugin_configured'
-      ? [event as WireTelemetryEvent<'plugin_configured'>]
-      : []
-  );
-
-  expect.soft(initEvents).toHaveLength(2);
-  expect.soft(initEvents.map((event) => event.payload.delay).sort()).toEqual([1111, 2222]);
-});
-
-test('sends project_ineligible telemetry event', async () => {
-  const { onRequest, setup } = createTelemetryServer();
-  const cleanup = setup();
-  onTestFinished(cleanup);
-
-  process.env.CHROMATIC_DISABLE_TELEMETRY = '0';
-  onTestFinished(() => void (process.env.CHROMATIC_DISABLE_TELEMETRY = '1'));
-
-  await runFixture({
-    name: 'unit',
-    include: ['**/dom.test.ts'],
-    browser: { enabled: false },
-    root: resolve(import.meta.dirname, '../../test/fixtures'),
-  });
-
-  const events = onRequest.mock.calls.map(([event]) => event);
-
-  expect(events).toHaveLength(2);
-  expect(events[0].eventType).toBe('vitest_plugin_configured');
-
-  const { eventType, payload } = events[1];
-  expect({ eventType, payload }).toMatchInlineSnapshot(`
-    {
-      "eventType": "vitest_project_ineligible",
-      "payload": {
-        "isBrowser": false,
-        "isChromium": false,
-      },
-    }
   `);
 });

--- a/packages/vitest/src/node/plugin.test.ts
+++ b/packages/vitest/src/node/plugin.test.ts
@@ -9,6 +9,7 @@ import {
   getBrowserConfig,
   getResolvedConfig,
   runFixture,
+  setupTelemetryServer,
 } from '../../test/utils/node';
 
 beforeEach(() => {
@@ -77,6 +78,9 @@ test('does not override user-defined tags', async () => {
 });
 
 test('warns if tags are used with Vitest 4.0', async () => {
+  const { cleanup, onRequest } = setupTelemetryServer();
+  onTestFinished(cleanup);
+
   const { streams, getOutput } = createOutputStreams();
   const plugin = chromaticPlugin({ tags: ['my-tag-for-vrt'] });
   const vitest = await createVitest(
@@ -100,6 +104,24 @@ test('warns if tags are used with Vitest 4.0', async () => {
   expect(getOutput().stderr).toContain(
     'chromatic  Tags cannot be used with Vitest 4.0.1. Please upgrade to Vitest 4.1 or later to use this feature.'
   );
+
+  await vitest.close();
+
+  const tagsLowVersionEvents = onRequest.mock.calls.flatMap(([event]) =>
+    event.eventType === 'vitest_tags_low_version'
+      ? [{ eventType: event.eventType, payload: event.payload, level: event.level }]
+      : []
+  );
+
+  expect(tagsLowVersionEvents).toMatchInlineSnapshot(`
+    [
+      {
+        "eventType": "vitest_tags_low_version",
+        "level": "warn",
+        "payload": {},
+      },
+    ]
+  `);
 });
 
 test('can be scoped to a Vitest project', async () => {

--- a/packages/vitest/src/node/plugin.ts
+++ b/packages/vitest/src/node/plugin.ts
@@ -5,13 +5,16 @@ import type { Vite } from 'vitest/node';
 import colors from 'tinyrainbow';
 import { DEFAULT_GLOBAL_RESOURCE_ARCHIVE_TIMEOUT_MS } from '@chromatic-com/shared-e2e';
 import { createCommands } from './commands';
-import { ChromaticReporter } from './reporter';
 import {
   cleanTelemetryLogFile,
   resolveTelemetryOptions,
   setupTelemetryCleanup,
-  trackEvent,
+  trackEvent as _trackEvent,
+  type EventType,
+  type TelemetryEvent,
 } from './telemetry';
+import { ChromaticReporter } from './reporter';
+import { TelemetryReporter } from './telemetry-reporter';
 import { mergePreviewStats, WebpackStatsReporter } from './webpack-stats-reporter';
 import { DEFAULT_OUTPUT_DIR } from '../constants';
 import { type ResolvedOptions, type Options } from '../types';
@@ -70,54 +73,44 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
       if (options.telemetry.enabled) {
         setupTelemetryCleanup(context.vitest);
 
-        void trackEvent(
-          {
-            eventType: 'plugin_configured',
-            level: 'info',
-            payload: {
-              cropToViewport: options.cropToViewport,
-              delay: options.delay,
-              diffIncludeAntiAliasing: options.diffIncludeAntiAliasing,
-              diffThreshold: options.diffThreshold,
-              disableAutoSnapshot: options.disableAutoSnapshot,
-              forcedColors: options.forcedColors,
-              idleNetworkInterval: options.idleNetworkInterval,
-              pauseAnimationAtEnd: options.pauseAnimationAtEnd,
-              prefersReducedMotion: options.prefersReducedMotion,
-              resourceArchiveTimeout: options.resourceArchiveTimeout,
-              turboSnap: options.turboSnap,
-              reporter: !options.reporter.enabled
-                ? 'off'
-                : options.reporter.verbose
-                  ? 'verbose'
-                  : 'non-verbose',
+        trackEvent({
+          eventType: 'plugin_configured',
+          level: 'info',
+          payload: {
+            isShardedRun: project.config.shard != null,
+            cropToViewport: options.cropToViewport,
+            delay: options.delay,
+            diffIncludeAntiAliasing: options.diffIncludeAntiAliasing,
+            diffThreshold: options.diffThreshold,
+            disableAutoSnapshot: options.disableAutoSnapshot,
+            forcedColors: options.forcedColors,
+            idleNetworkInterval: options.idleNetworkInterval,
+            pauseAnimationAtEnd: options.pauseAnimationAtEnd,
+            prefersReducedMotion: options.prefersReducedMotion,
+            resourceArchiveTimeout: options.resourceArchiveTimeout,
+            turboSnap: options.turboSnap,
+            reporter: !options.reporter.enabled
+              ? 'off'
+              : options.reporter.verbose
+                ? 'verbose'
+                : 'non-verbose',
 
-              // Don't attach any user-defined strings values:
-              isCustomOutputDirectory: options.outputDirectory !== DEFAULT_OUTPUT_DIR,
-              assetDomainsCount: options.assetDomains?.length ?? 0,
-              ignoreSelectorsCount: options.ignoreSelectors?.length ?? 0,
-              tagsCount: options.tags?.length ?? 0,
-            },
+            // Don't attach any user-defined strings values:
+            isCustomOutputDirectory: options.outputDirectory !== DEFAULT_OUTPUT_DIR,
+            assetDomainsCount: options.assetDomains?.length ?? 0,
+            ignoreSelectorsCount: options.ignoreSelectors?.length ?? 0,
+            tagsCount: options.tags?.length ?? 0,
           },
-          context.vitest,
-          options
-        );
+        });
       }
 
       // browser.name is instances[].browser, not instances[].name: https://github.com/vitest-dev/vitest/blob/d22b029ae056b9515033d75c1249e9db26612770/packages/vitest/src/node/projects/resolveProjects.ts#L307
       if (!browser.enabled || browser.name !== 'chromium') {
-        trackEvent(
-          {
-            eventType: 'project_ineligible',
-            level: 'warn',
-            payload: {
-              isBrowser: browser.enabled,
-              isChromium: browser.name === 'chromium',
-            },
-          },
-          context.vitest,
-          options
-        );
+        trackEvent({
+          eventType: 'project_ineligible',
+          level: 'warn',
+          payload: { isBrowser: browser.enabled, isChromium: browser.name === 'chromium' },
+        });
 
         return clean();
       }
@@ -130,12 +123,22 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
         WebpackStatsReporter.apply(context.vitest, options);
       }
 
+      if (options.telemetry.enabled) {
+        TelemetryReporter.apply(context.vitest, options);
+      }
+
       // Ensure our setup file is registered first so that afterEach runs before any user-defined hooks.
       if (sequence.hooks === 'stack') {
         project.config.setupFiles.push(setupFile);
       } else if (sequence.hooks === 'list') {
         project.config.setupFiles.unshift(setupFile);
       } else {
+        trackEvent({
+          eventType: 'setup_files_parallel',
+          level: 'warn',
+          payload: { setupFileCount: project.config.setupFiles.length },
+        });
+
         project.config.setupFiles.push(setupFile);
 
         context.vitest.logger.warn(
@@ -154,6 +157,8 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
             `Tags cannot be used with Vitest ${context.vitest.version}. Please upgrade to Vitest 4.1 or later to use this feature.`
           )
         );
+
+        trackEvent({ eventType: 'tags_low_version', level: 'warn', payload: {} });
       }
 
       if (options.tags) {
@@ -197,6 +202,10 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
             }
           }
         }
+      }
+
+      function trackEvent<T extends EventType = EventType>(event: TelemetryEvent<T>): void {
+        _trackEvent(event, context.vitest, options);
       }
     },
   };

--- a/packages/vitest/src/node/reporter.test.ts
+++ b/packages/vitest/src/node/reporter.test.ts
@@ -4,8 +4,8 @@ import { expect, onTestFinished, test, vi } from 'vitest';
 import * as shared from '@chromatic-com/shared-e2e';
 import {
   runFixture as baseRunFixture,
-  createTelemetryServer,
   StableTestFileOrderSorter,
+  setupTelemetryServer,
 } from '../../test/utils/node';
 import { DEFAULT_OUTPUT_DIR } from '../constants';
 
@@ -192,15 +192,11 @@ test('summary with TurboSnap enabled', async () => {
 });
 
 test('summary with telemetry.logToFile enabled', async () => {
-  const { setup } = createTelemetryServer();
-  const cleanup = setup();
+  const { cleanup } = setupTelemetryServer();
   onTestFinished(cleanup);
-
-  process.env.CHROMATIC_DISABLE_TELEMETRY = '0';
 
   onTestFinished(() => {
     const reports = resolve(process.cwd(), DEFAULT_OUTPUT_DIR);
-    process.env.CHROMATIC_DISABLE_TELEMETRY = '1';
 
     if (existsSync(reports)) {
       rmSync(reports, { recursive: true, force: true });

--- a/packages/vitest/src/node/telemetry-reporter.ts
+++ b/packages/vitest/src/node/telemetry-reporter.ts
@@ -1,0 +1,69 @@
+import { Vitest } from 'vitest/node';
+import { Reporter } from 'vitest/reporters';
+import { type TelemetryEvent, trackEvent } from './telemetry';
+import { type ResolvedOptions } from '../types';
+
+const REPORTER_NAME = 'chromatic-telemetry-reporter';
+
+export class TelemetryReporter implements Reporter {
+  public name = REPORTER_NAME;
+  private snapshotCount = 0;
+
+  private constructor(
+    private ctx: Vitest,
+    private options: ResolvedOptions
+  ) {}
+
+  /**
+   * Add `TelemetryReporter` to Vitest reporters unless it's already included.
+   */
+  static apply(ctx: Vitest, options: ResolvedOptions) {
+    if (!options.telemetry.enabled) {
+      return;
+    }
+
+    for (const reporter of ctx.config.reporters) {
+      // Apply TelemetryReporter just once
+      if (isTelemetryReporter(reporter)) {
+        return;
+      }
+    }
+
+    ctx.config.reporters.push(new TelemetryReporter(ctx, options));
+  }
+
+  /**
+   * Custom reporter life-cycle called when `takeSnapshot()` is called.
+   */
+  static onSnapshot(ctx: Vitest, payload: TelemetryEvent<'snapshot_captured'>['payload']) {
+    const reporter = ctx.config.reporters.find(isTelemetryReporter);
+
+    reporter?._onSnapshot(payload);
+  }
+
+  private _onSnapshot(payload: TelemetryEvent<'snapshot_captured'>['payload']) {
+    this.snapshotCount++;
+
+    trackEvent({ eventType: 'snapshot_captured', level: 'info', payload }, this.ctx, this.options);
+  }
+
+  onTestRunStart() {
+    this.snapshotCount = 0;
+
+    trackEvent({ eventType: 'run_started', level: 'info', payload: {} }, this.ctx, this.options);
+  }
+
+  onTestRunEnd() {
+    trackEvent(
+      { eventType: 'run_ended', level: 'info', payload: { snapshotCount: this.snapshotCount } },
+      this.ctx,
+      this.options
+    );
+  }
+}
+
+function isTelemetryReporter(
+  reporter: Vitest['config']['reporters'][number]
+): reporter is TelemetryReporter {
+  return 'name' in reporter && reporter.name === REPORTER_NAME;
+}

--- a/packages/vitest/src/node/telemetry.test.ts
+++ b/packages/vitest/src/node/telemetry.test.ts
@@ -1,198 +1,322 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { beforeEach, expect, onTestFinished, test, vi } from 'vitest';
+import { beforeEach, describe, expect, onTestFinished, test as base, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { chromaticPlugin } from './plugin';
+import { type WireTelemetryEvent } from './telemetry';
 import {
-  createTelemetryServer,
   getBrowserConfig,
   runFixture,
   getResolvedConfig as runVitest,
+  setupTelemetryServer,
 } from '../../test/utils/node';
 
-const { server, setup, onRequest } = createTelemetryServer();
-
-beforeEach(async () => {
+beforeEach(() => {
   vi.unstubAllEnvs();
-  const cleanup = setup();
-
-  process.env.CHROMATIC_DISABLE_TELEMETRY = '0';
-
-  return function afterEach() {
-    cleanup();
-    process.env.CHROMATIC_DISABLE_TELEMETRY = '1';
-  };
 });
 
-test('telemetry is enabled by default', async () => {
-  await runVitest();
-
-  expect(onRequest).toHaveBeenCalled();
-});
-
-test('telemetry is disabled when { telemetry: false }', async () => {
-  await runVitest({}, { telemetry: false });
-
-  expect(onRequest).not.toHaveBeenCalled();
-});
-
-test.each(['CHROMATIC_DISABLE_TELEMETRY', 'DO_NOT_TRACK'])(
-  'telemetry is disabled when %s is set',
-  async (envVar) => {
-    vi.stubEnv(envVar, '1');
+describe('configuration', () => {
+  test('telemetry is enabled by default', async ({ onRequest }) => {
     await runVitest();
 
+    expect(onRequest).toHaveBeenCalled();
+  });
+
+  test('telemetry is disabled when { telemetry: false }', async ({ onRequest }) => {
+    await runVitest({}, { telemetry: false });
+
     expect(onRequest).not.toHaveBeenCalled();
-  }
-);
+  });
 
-test('telemetry is sent to custom telemetry endpoint when CHROMATIC_TELEMETRY_URL is set', async () => {
-  const url = 'https://custom-endpoint.chromatic.com/telemetry';
-  vi.stubEnv('CHROMATIC_TELEMETRY_URL', url);
+  test.for(['CHROMATIC_DISABLE_TELEMETRY', 'DO_NOT_TRACK'])(
+    'telemetry is disabled when %s is set',
+    async (envVar, { onRequest }) => {
+      vi.stubEnv(envVar, '1');
+      await runVitest();
 
-  const onCustomEndpointRequest = vi.fn();
-
-  server.use(
-    http.post(`${url}/telemetry/v1/vitest/events`, async () => {
-      onCustomEndpointRequest('called here');
-      return HttpResponse.json({ ok: true });
-    })
+      expect(onRequest).not.toHaveBeenCalled();
+    }
   );
-  await runVitest();
 
-  expect(onCustomEndpointRequest).toHaveBeenCalledWith('called here');
-});
+  test('telemetry is sent to custom endpoint when CHROMATIC_TELEMETRY_URL is set', async ({
+    onRequest,
+    server,
+  }) => {
+    const url = 'https://custom-endpoint.chromatic.com/telemetry';
+    vi.stubEnv('CHROMATIC_TELEMETRY_URL', url);
 
-test('hanging telemetry endpoint does not block Vitest shutdown', async () => {
-  // Patch AbortSignal as Sinon does not support mocking it: https://github.com/sinonjs/fake-timers/issues/521
-  {
-    const timeout = AbortSignal.timeout;
-    onTestFinished(() => void (AbortSignal.timeout = timeout));
+    const onCustomEndpointRequest = vi.fn();
 
-    AbortSignal.timeout = function mockedTimeout(n: number) {
-      const controller = new AbortController();
-      setTimeout(() => controller.abort(), n);
-      return controller.signal;
-    };
-  }
-
-  const url = 'https://unresponsive-endpoint.chromatic.com/telemetry';
-  vi.stubEnv('CHROMATIC_TELEMETRY_URL', url);
-
-  const isFetching = new Promise<void>((fetchStarted) => {
     server.use(
       http.post(`${url}/telemetry/v1/vitest/events`, async () => {
-        fetchStarted();
-        await new Promise((_resolve) => {});
+        onCustomEndpointRequest('called here');
+        return HttpResponse.json({ ok: true });
       })
     );
+    await runVitest();
+
+    expect.soft(onRequest).not.toHaveBeenCalled();
+    expect.soft(onCustomEndpointRequest).toHaveBeenCalledWith('called here');
   });
 
-  vi.useFakeTimers({ toFake: ['setTimeout'] });
-  onTestFinished(() => void vi.useRealTimers());
+  test('telemetry is logged to file when { telemetry: { logToFile: true }} ', async () => {
+    const { root } = await runVitest({}, { telemetry: { logToFile: true } });
 
-  let done = false;
-  const promise = runVitest().then(() => (done = true));
+    const rows = readLogFile(root);
 
-  await isFetching;
-
-  vi.advanceTimersByTime(3_000);
-  expect(done).toBe(false);
-
-  vi.advanceTimersByTime(1_999);
-  expect(done).toBe(false);
-
-  vi.advanceTimersByTime(1);
-
-  // Vitest should exit without hanging forever
-  await expect(promise).resolves.toBeTruthy();
-});
-
-test('telemetry is logged to file when { telemetry: { logToFile: true }} ', async () => {
-  const { root } = await runVitest({}, { telemetry: { logToFile: true } });
-
-  const rows = readLogFile(root);
-
-  const configureEvents = rows.filter((row) => row.eventType === 'vitest_plugin_configured');
-  expect(configureEvents.length).toBe(1);
-});
-
-test('telemetry is logged to file when CHROMATIC_TELEMETRY_LOG_TO_FILE is set', async () => {
-  vi.stubEnv('CHROMATIC_TELEMETRY_LOG_TO_FILE', '1');
-  const { root } = await runVitest();
-
-  const rows = readLogFile(root);
-
-  const configureEvents = rows.filter((row) => row.eventType === 'vitest_plugin_configured');
-  expect(configureEvents.length).toBe(1);
-});
-
-test('telemetry is not logged to file by default ', async () => {
-  const { root } = await runVitest();
-
-  expect(existsSync(resolve(root, '.vitest/chromatic/telemetry.jsonl'))).toBe(false);
-});
-
-test('attaches common fields and metadata to telemetry events', async () => {
-  const time = '2026-01-01T00:00:00.000Z';
-  vi.setSystemTime(new Date(time));
-  onTestFinished(() => void vi.useRealTimers());
-
-  await runVitest();
-
-  const event = vi.mocked(onRequest).mock.calls[0][0];
-
-  expect(event).toMatchObject({
-    id: expect.any(String),
-    sessionId: expect.any(String),
-    projectId: expect.any(String),
-    timestamp: time,
-    eventType: expect.any(String),
-    level: expect.toBeOneOf(['info', 'warn', 'error']),
-    payload: expect.any(Object),
-    metadata: {
-      isCI: expect.toBeOneOf([true, false]),
-      isVitestProjects: false,
-      pluginVersion: expect.any(String),
-      nodeVersion: process.versions.node,
-      vitestVersion: expect.any(String),
-      packageManager: 'pnpm',
-      packageManagerVersion: expect.any(String),
-      chromaticVersion: expect.any(String),
-    },
+    const configureEvents = rows.filter((row) => row.eventType === 'vitest_plugin_configured');
+    expect(configureEvents.length).toBe(1);
   });
-});
 
-test('sets isVitestProjects true when multiple Vitest projects', async () => {
-  await runFixture(
+  test('telemetry is logged to file when CHROMATIC_TELEMETRY_LOG_TO_FILE is set', async () => {
+    vi.stubEnv('CHROMATIC_TELEMETRY_LOG_TO_FILE', '1');
+    const { root } = await runVitest();
+
+    const rows = readLogFile(root);
+
+    const configureEvents = rows.filter((row) => row.eventType === 'vitest_plugin_configured');
+    expect(configureEvents.length).toBe(1);
+  });
+
+  test('telemetry is not logged to file by default ', async () => {
+    const { root } = await runVitest();
+
+    expect(existsSync(resolve(root, '.vitest/chromatic/telemetry.jsonl'))).toBe(false);
+  });
+
+  test('hanging telemetry endpoint does not block Vitest shutdown', async ({ server }) => {
+    // Patch AbortSignal as Sinon does not support mocking it: https://github.com/sinonjs/fake-timers/issues/521
     {
-      projects: [
-        {
-          plugins: [chromaticPlugin()],
-          test: {
-            include: ['**/dom.test.ts'],
-            root: resolve(import.meta.dirname, '../../test/fixtures'),
-            browser: getBrowserConfig('first-browser'),
-          },
-        },
-        {
-          plugins: [chromaticPlugin()],
-          test: {
-            include: ['**/dom.test.ts'],
-            root: resolve(import.meta.dirname, '../../test/fixtures'),
-            browser: getBrowserConfig('second-browser'),
-          },
-        },
-      ],
-    },
-    { disabled: true }
-  );
-  const events = vi.mocked(onRequest).mock.calls.map(([event]) => event);
+      const timeout = AbortSignal.timeout;
+      onTestFinished(() => void (AbortSignal.timeout = timeout));
 
-  expect.soft(events).toHaveLength(2);
-  expect.soft(events[0]?.metadata).toHaveProperty('isVitestProjects', true);
-  expect.soft(events[1]?.metadata).toHaveProperty('isVitestProjects', true);
+      AbortSignal.timeout = function mockedTimeout(n: number) {
+        const controller = new AbortController();
+        setTimeout(() => controller.abort(), n);
+        return controller.signal;
+      };
+    }
+
+    const url = 'https://unresponsive-endpoint.chromatic.com/telemetry';
+    vi.stubEnv('CHROMATIC_TELEMETRY_URL', url);
+
+    const isFetching = new Promise<void>((fetchStarted) => {
+      server.use(
+        http.post(`${url}/telemetry/v1/vitest/events`, async () => {
+          fetchStarted();
+          await new Promise((_resolve) => {});
+        })
+      );
+    });
+
+    vi.useFakeTimers({ toFake: ['setTimeout'] });
+    onTestFinished(() => void vi.useRealTimers());
+
+    let done = false;
+    const promise = runVitest().then(() => (done = true));
+
+    await isFetching;
+
+    vi.advanceTimersByTime(3_000);
+    expect(done).toBe(false);
+
+    vi.advanceTimersByTime(1_999);
+    expect(done).toBe(false);
+
+    vi.advanceTimersByTime(1);
+
+    // Vitest should exit without hanging forever
+    await expect(promise).resolves.toBeTruthy();
+  });
 });
+
+describe('automatic fields', () => {
+  test('attaches common fields and metadata to telemetry events', async ({ onRequest }) => {
+    const time = '2026-01-01T00:00:00.000Z';
+    vi.setSystemTime(new Date(time));
+    onTestFinished(() => void vi.useRealTimers());
+
+    await runVitest();
+
+    const event = onRequest.mock.calls[0][0];
+
+    expect(event).toMatchObject({
+      id: expect.any(String),
+      sessionId: expect.any(String),
+      projectId: expect.any(String),
+      timestamp: time,
+      eventType: expect.any(String),
+      level: expect.toBeOneOf(['info', 'warn', 'error']),
+      payload: expect.any(Object),
+      metadata: {
+        isCI: expect.toBeOneOf([true, false]),
+        isVitestProjects: false,
+        pluginVersion: expect.any(String),
+        nodeVersion: process.versions.node,
+        vitestVersion: expect.any(String),
+        packageManager: 'pnpm',
+        packageManagerVersion: expect.any(String),
+        chromaticVersion: expect.any(String),
+      },
+    });
+  });
+
+  test('sets isVitestProjects true when multiple Vitest projects', async ({ onRequest }) => {
+    await runFixture(
+      {
+        projects: [
+          {
+            plugins: [chromaticPlugin()],
+            test: {
+              include: ['**/dom.test.ts'],
+              root: resolve(import.meta.dirname, '../../test/fixtures'),
+              browser: getBrowserConfig('first-browser'),
+            },
+          },
+          {
+            plugins: [chromaticPlugin()],
+            test: {
+              include: ['**/dom.test.ts'],
+              root: resolve(import.meta.dirname, '../../test/fixtures'),
+              browser: getBrowserConfig('second-browser'),
+            },
+          },
+        ],
+      },
+      { disabled: true }
+    );
+    const events = vi.mocked(onRequest).mock.calls.map(([event]) => event);
+
+    expect.soft(events.length).toBeGreaterThanOrEqual(2);
+    expect.soft(events[0]?.metadata).toHaveProperty('isVitestProjects', true);
+    expect.soft(events[1]?.metadata).toHaveProperty('isVitestProjects', true);
+  });
+});
+
+describe('events', () => {
+  test.todo('all events in order');
+
+  test('plugin_configured', async ({ getEvents }) => {
+    const pluginConfiguredEvents = getEvents('vitest_plugin_configured');
+
+    expect(pickTypeAndPayload(pluginConfiguredEvents)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_plugin_configured",
+          "payload": {
+            "assetDomainsCount": 2,
+            "disableAutoSnapshot": false,
+            "idleNetworkInterval": 100,
+            "ignoreSelectorsCount": 1,
+            "isCustomOutputDirectory": false,
+            "reporter": "verbose",
+            "resourceArchiveTimeout": 1234,
+            "tagsCount": 0,
+            "turboSnap": true,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('plugin_configured in Vitest projects setup', async ({ onRequest }) => {
+    await runFixture(
+      {
+        projects: [
+          {
+            plugins: [chromaticPlugin({ delay: 1111 })],
+            test: {
+              name: 'first-project',
+              browser: getBrowserConfig('first-browser'),
+              include: ['**/dom.test.ts'],
+              root: resolve(import.meta.dirname, '../../test/fixtures'),
+            },
+          },
+          {
+            plugins: [chromaticPlugin({ delay: 2222 })],
+            test: {
+              name: 'second-project',
+              browser: getBrowserConfig('second-browser'),
+              include: ['**/dom.test.ts'],
+              root: resolve(import.meta.dirname, '../../test/fixtures'),
+            },
+          },
+        ],
+      },
+      { disabled: true }
+    );
+
+    const configuredEvents = onRequest.mock.calls.flatMap(([event]) =>
+      event.eventType === 'vitest_plugin_configured'
+        ? [event as WireTelemetryEvent<'plugin_configured'>]
+        : []
+    );
+
+    expect.soft(configuredEvents).toHaveLength(2);
+    expect.soft(configuredEvents.map((event) => event.payload.delay).sort()).toEqual([1111, 2222]);
+  });
+
+  test('project_ineligible', async ({ onRequest }) => {
+    await runFixture({
+      include: ['**/dom.test.ts'],
+      browser: { enabled: false },
+    });
+
+    const projectIneligibleEvents = onRequest.mock.calls.flatMap(([event]) =>
+      event.eventType === 'vitest_project_ineligible'
+        ? [event as WireTelemetryEvent<'project_ineligible'>]
+        : []
+    );
+
+    expect(pickTypeAndPayload(projectIneligibleEvents)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_project_ineligible",
+          "payload": {
+            "isBrowser": false,
+            "isChromium": false,
+          },
+        },
+      ]
+    `);
+  });
+});
+
+const test = base
+  .extend('telemetry', { scope: 'file' }, async ({}, { onCleanup }) => {
+    const { cleanup, server, onRequest } = setupTelemetryServer();
+
+    // Run a common fixture once before any tests start.
+    // Tests that aren't validating edge cases can assert this data.
+    await runFixture(
+      { include: ['take-snapshot.test.ts'], provide: { testName: 'five' } },
+      {
+        ignoreSelectors: ['.ignore-me'],
+        assetDomains: ['https://one.chromatic.com', 'https://two.chromatic.com'],
+        turboSnap: true,
+        resourceArchiveTimeout: 1234,
+        disableAutoSnapshot: false,
+      }
+    );
+
+    const events = onRequest.mock.calls
+      .map((call) => call[0])
+      .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+    onCleanup(cleanup);
+
+    return { events, cleanup, server, onRequest };
+  })
+  .extend('server', ({ telemetry }) => telemetry.server)
+  .extend('onRequest', ({ telemetry }) => telemetry.onRequest)
+  .extend('getEvents', ({ telemetry }) => {
+    return function getEvents(type?: WireTelemetryEvent['eventType']) {
+      if (!type) {
+        return telemetry.events;
+      }
+      return telemetry.events.filter((event) => event.eventType === type);
+    };
+  });
 
 function readLogFile(root: string) {
   const output = readFileSync(resolve(root, '.vitest/chromatic/telemetry.jsonl'), 'utf8');
@@ -207,4 +331,8 @@ function readLogFile(root: string) {
   }
 
   return rows;
+}
+
+function pickTypeAndPayload(events: WireTelemetryEvent[]) {
+  return events.map(({ eventType, payload }) => ({ eventType, payload }));
 }

--- a/packages/vitest/src/node/telemetry.test.ts
+++ b/packages/vitest/src/node/telemetry.test.ts
@@ -487,13 +487,13 @@ describe('events', () => {
         {
           "eventType": "vitest_archives_created",
           "payload": {
-            "count": 3,
+            "archiveCount": 3,
           },
         },
         {
           "eventType": "vitest_archives_created",
           "payload": {
-            "count": 2,
+            "archiveCount": 2,
           },
         },
       ]

--- a/packages/vitest/src/node/telemetry.test.ts
+++ b/packages/vitest/src/node/telemetry.test.ts
@@ -194,7 +194,22 @@ describe('automatic fields', () => {
 });
 
 describe('events', () => {
-  test.todo('all events in order');
+  test('all events in order', async ({ getEvents }) => {
+    expect(getEvents().map((event) => event.eventType)).toMatchInlineSnapshot(`
+      [
+        "vitest_plugin_configured",
+        "vitest_run_started",
+        "vitest_snapshot_captured",
+        "vitest_snapshot_captured",
+        "vitest_snapshot_captured",
+        "vitest_archives_created",
+        "vitest_snapshot_captured",
+        "vitest_snapshot_captured",
+        "vitest_archives_created",
+        "vitest_run_ended",
+      ]
+    `);
+  });
 
   test('plugin_configured', async ({ getEvents }) => {
     const pluginConfiguredEvents = getEvents('vitest_plugin_configured');
@@ -209,10 +224,42 @@ describe('events', () => {
             "idleNetworkInterval": 100,
             "ignoreSelectorsCount": 1,
             "isCustomOutputDirectory": false,
+            "isShardedRun": false,
             "reporter": "verbose",
             "resourceArchiveTimeout": 1234,
             "tagsCount": 0,
             "turboSnap": true,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('plugin_configured in Vitest sharded run', async ({ onRequest }) => {
+    /** See {@link file://./../../test/fixtures/take-snapshot.test.ts} */
+    await runVitest({ shard: '1/2' });
+
+    const pluginConfiguredEvents = onRequest.mock.calls.flatMap(([event]) =>
+      event.eventType === 'vitest_plugin_configured'
+        ? [event as WireTelemetryEvent<'plugin_configured'>]
+        : []
+    );
+
+    expect(pickTypeAndPayload(pluginConfiguredEvents)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_plugin_configured",
+          "payload": {
+            "assetDomainsCount": 0,
+            "disableAutoSnapshot": false,
+            "idleNetworkInterval": 100,
+            "ignoreSelectorsCount": 0,
+            "isCustomOutputDirectory": false,
+            "isShardedRun": true,
+            "reporter": "verbose",
+            "resourceArchiveTimeout": 10000,
+            "tagsCount": 0,
+            "turboSnap": false,
           },
         },
       ]
@@ -263,9 +310,7 @@ describe('events', () => {
     });
 
     const projectIneligibleEvents = onRequest.mock.calls.flatMap(([event]) =>
-      event.eventType === 'vitest_project_ineligible'
-        ? [event as WireTelemetryEvent<'project_ineligible'>]
-        : []
+      event.eventType === 'vitest_project_ineligible' ? [event] : []
     );
 
     expect(pickTypeAndPayload(projectIneligibleEvents)).toMatchInlineSnapshot(`
@@ -280,6 +325,351 @@ describe('events', () => {
       ]
     `);
   });
+
+  test('run_started', async ({ getEvents }) => {
+    const startEvents = getEvents('vitest_run_started');
+
+    expect(pickTypeAndPayload(startEvents)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_run_started",
+          "payload": {},
+        },
+      ]
+    `);
+  });
+
+  test('run_ended', async ({ getEvents }) => {
+    const endEvents = getEvents('vitest_run_ended');
+
+    expect(pickTypeAndPayload(endEvents)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_run_ended",
+          "payload": {
+            "snapshotCount": 5,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('snapshot_captured', async ({ getEvents }) => {
+    const snapshotsCapturedEvents = getEvents('vitest_snapshot_captured');
+
+    expect(pickTypeAndPayload(snapshotsCapturedEvents)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_snapshot_captured",
+          "payload": {
+            "colorScheme": "light",
+            "isAutomaticSnapshot": false,
+            "isCustomName": true,
+          },
+        },
+        {
+          "eventType": "vitest_snapshot_captured",
+          "payload": {
+            "colorScheme": "light",
+            "isAutomaticSnapshot": false,
+            "isCustomName": true,
+          },
+        },
+        {
+          "eventType": "vitest_snapshot_captured",
+          "payload": {
+            "colorScheme": "light",
+            "isAutomaticSnapshot": true,
+            "isCustomName": true,
+          },
+        },
+        {
+          "eventType": "vitest_snapshot_captured",
+          "payload": {
+            "colorScheme": "light",
+            "isAutomaticSnapshot": false,
+            "isCustomName": true,
+          },
+        },
+        {
+          "eventType": "vitest_snapshot_captured",
+          "payload": {
+            "colorScheme": "light",
+            "isAutomaticSnapshot": true,
+            "isCustomName": true,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('take_snapshot_invalid_call - called outside test', async ({ onRequest }) => {
+    /** See {@link file://./../../test/fixtures/take-snapshot.test.ts} */
+    await runFixture({
+      include: ['**/take-snapshot.test.ts'],
+      provide: { testName: 'two' },
+    });
+
+    const events = onRequest.mock.calls.flatMap(([event]) =>
+      event.eventType === 'vitest_take_snapshot_invalid_call' ? [event] : []
+    );
+
+    expect(pickTypeAndPayload(events)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_take_snapshot_invalid_call",
+          "payload": {
+            "isInsideTest": false,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('take_snapshot_invalid_call - not registered test', async ({ onRequest }) => {
+    /** See {@link file://./../../test/fixtures/take-snapshot.test.ts} */
+    await runFixture(
+      {
+        include: ['**/take-snapshot.test.ts'],
+        provide: { testName: 'one' },
+        tags: [{ name: 'example' }],
+      },
+      { tags: ['example'] }
+    );
+
+    const events = onRequest.mock.calls.flatMap(([event]) =>
+      event.eventType === 'vitest_take_snapshot_invalid_call' ? [event] : []
+    );
+
+    expect(pickTypeAndPayload(events)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_take_snapshot_invalid_call",
+          "payload": {
+            "isInsideTest": true,
+            "isRegisteredTest": false,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('take_snapshot_invalid_call - not awaited', async ({ onRequest }) => {
+    /** See {@link file://./../../test/fixtures/take-snapshot.test.ts} */
+    await runFixture({
+      include: ['**/take-snapshot.test.ts'],
+      provide: { testName: 'three' },
+    });
+
+    const events = onRequest.mock.calls.flatMap(([event]) =>
+      event.eventType === 'vitest_take_snapshot_invalid_call' ? [event] : []
+    );
+
+    expect(pickTypeAndPayload(events)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_take_snapshot_invalid_call",
+          "payload": {
+            "isAwaited": false,
+            "isInsideTest": true,
+            "isRegisteredTest": true,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('archives_created', async ({ getEvents }) => {
+    const archivesCreatedEvents = getEvents('vitest_archives_created');
+
+    expect(pickTypeAndPayload(archivesCreatedEvents)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_archives_created",
+          "payload": {
+            "count": 3,
+          },
+        },
+        {
+          "eventType": "vitest_archives_created",
+          "payload": {
+            "count": 2,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('configure_called', async ({ onRequest }) => {
+    /** See {@link file://./../../test/fixtures/configure-calls.test.ts} */
+    await runFixture({ include: ['**/configure-calls.test.ts'] });
+
+    const events = onRequest.mock.calls.flatMap(([event]) =>
+      event.eventType === 'vitest_configure_called' ? [event] : []
+    );
+
+    expect(pickTypeAndPayload(events)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_configure_called",
+          "payload": {
+            "options": [
+              "delay",
+              "title",
+            ],
+            "scope": "file",
+          },
+        },
+        {
+          "eventType": "vitest_configure_called",
+          "payload": {
+            "options": [
+              "diffThreshold",
+              "resourceArchiveTimeout",
+            ],
+            "scope": "test",
+          },
+        },
+        {
+          "eventType": "vitest_configure_called",
+          "payload": {
+            "options": [
+              "ignoreSelectors",
+            ],
+            "scope": "suite",
+          },
+        },
+      ]
+    `);
+  });
+
+  test('wait_for_idle_network_called', async ({ onRequest }) => {
+    /** See {@link file://./../../test/fixtures/wait-for-idle-network.test.ts} */
+    await runFixture({
+      include: ['**/wait-for-idle-network.test.ts'],
+      provide: { testName: 'three' },
+    });
+
+    const events = onRequest.mock.calls.flatMap(([event]) =>
+      event.eventType === 'vitest_wait_for_idle_network_called' ? [event] : []
+    );
+
+    expect(pickTypeAndPayload(events)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_wait_for_idle_network_called",
+          "payload": {
+            "timeout": 2,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('wait_for_idle_network_invalid_call - called outside test', async ({ onRequest }) => {
+    /** See {@link file://./../../test/fixtures/wait-for-idle-network.test.ts} */
+    await runFixture({
+      include: ['**/wait-for-idle-network.test.ts'],
+      provide: { testName: 'two' },
+    });
+
+    const events = onRequest.mock.calls.flatMap(([event]) =>
+      event.eventType === 'vitest_wait_for_idle_network_invalid_call' ? [event] : []
+    );
+
+    expect(pickTypeAndPayload(events)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_wait_for_idle_network_invalid_call",
+          "payload": {
+            "isCalledByUser": true,
+            "isInsideTest": false,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('wait_for_idle_network_invalid_call - not registered test', async ({ onRequest }) => {
+    /** See {@link file://./../../test/fixtures/wait-for-idle-network.test.ts} */
+    await runFixture(
+      {
+        include: ['**/wait-for-idle-network.test.ts'],
+        provide: { testName: 'one' },
+        tags: [{ name: 'example' }],
+      },
+      { tags: ['example'] }
+    );
+
+    const events = onRequest.mock.calls.flatMap(([event]) =>
+      event.eventType === 'vitest_wait_for_idle_network_invalid_call' ? [event] : []
+    );
+
+    expect(pickTypeAndPayload(events)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_wait_for_idle_network_invalid_call",
+          "payload": {
+            "isCalledByUser": true,
+            "isInsideTest": true,
+            "isRegisteredTest": false,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('wait_for_idle_network_timeout', async ({ onRequest }) => {
+    /** See {@link file://./../../test/fixtures/wait-for-idle-network.test.ts} */
+    await runFixture(
+      {
+        include: ['**/wait-for-idle-network.test.ts'],
+        provide: { testName: 'three' },
+      },
+      { idleNetworkInterval: 1 }
+    );
+
+    const events = onRequest.mock.calls.flatMap(([event]) =>
+      event.eventType === 'vitest_wait_for_idle_network_timeout' ? [event] : []
+    );
+
+    expect(pickTypeAndPayload(events)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_wait_for_idle_network_timeout",
+          "payload": {
+            "isCalledByUser": true,
+            "timeout": 2,
+          },
+        },
+      ]
+    `);
+  });
+
+  test('setup_files_parallel', async ({ onRequest }) => {
+    /** See {@link file://./../../test/fixtures/take-snapshot.test.ts} */
+    await runFixture({
+      include: ['**/take-snapshot.test.ts'],
+      provide: { testName: 'four' },
+      setupFiles: ['custom-setup-file.ts'],
+      sequence: { hooks: 'parallel' },
+    });
+
+    const events = onRequest.mock.calls.flatMap(([event]) =>
+      event.eventType === 'vitest_setup_files_parallel' ? [event] : []
+    );
+
+    expect(pickTypeAndPayload(events)).toMatchInlineSnapshot(`
+      [
+        {
+          "eventType": "vitest_setup_files_parallel",
+          "payload": {
+            "setupFileCount": 1,
+          },
+        },
+      ]
+    `);
+  });
 });
 
 const test = base
@@ -289,6 +679,7 @@ const test = base
     // Run a common fixture once before any tests start.
     // Tests that aren't validating edge cases can assert this data.
     await runFixture(
+      /** See {@link file://./../../test/fixtures/take-snapshot.test.ts} */
       { include: ['take-snapshot.test.ts'], provide: { testName: 'five' } },
       {
         ignoreSelectors: ['.ignore-me'],
@@ -303,6 +694,7 @@ const test = base
       .map((call) => call[0])
       .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
 
+    onRequest.mockClear();
     onCleanup(cleanup);
 
     return { events, cleanup, server, onRequest };

--- a/packages/vitest/src/node/telemetry.ts
+++ b/packages/vitest/src/node/telemetry.ts
@@ -6,7 +6,7 @@ import { join, resolve } from 'node:path';
 import { x } from 'tinyexec';
 import { env, isCI, nodeVersion } from 'std-env';
 import type { Vitest } from 'vitest/node';
-import { type Options, type ResolvedOptions } from '../types';
+import type { ConfigureOptions, Options, ResolvedOptions } from '../types';
 import { version as pluginVersion } from '../../package.json';
 
 const EVENT_TYPE_PREFIX = 'vitest_';
@@ -92,6 +92,7 @@ export function trackEvent<T extends EventType = EventType>(
 async function _trackEvent(event: TelemetryEvent, vitest: Vitest, options: ResolvedOptions) {
   const url = env.CHROMATIC_TELEMETRY_URL || TELEMETRY_URL;
   const root = vitest.config.root;
+  const timestamp = new Date().toISOString();
 
   session.projectId ||= await createProjectId(root);
   session.chromaticVersion ||= getChromaticVersion(root);
@@ -100,7 +101,7 @@ async function _trackEvent(event: TelemetryEvent, vitest: Vitest, options: Resol
     id: randomUUID(),
     sessionId: session.id,
     projectId: session.projectId,
-    timestamp: new Date().toISOString(),
+    timestamp,
     eventType: `${EVENT_TYPE_PREFIX}${event.eventType}`,
     level: event.level,
     payload: event.payload,
@@ -259,10 +260,59 @@ type TelemetryPayloads = {
     cropToViewport: boolean | undefined;
     assetDomainsCount: number;
     ignoreSelectorsCount: number;
+    isShardedRun: boolean;
   };
 
   project_ineligible: {
     isBrowser: boolean;
     isChromium: boolean;
   };
+
+  run_started: Record<string, never>;
+
+  run_ended: {
+    snapshotCount: number;
+  };
+
+  snapshot_captured: {
+    isCustomName: boolean;
+    colorScheme: string;
+    isAutomaticSnapshot: boolean;
+  };
+
+  take_snapshot_invalid_call: {
+    isInsideTest: boolean;
+    isRegisteredTest: boolean | undefined;
+    isAwaited: boolean | undefined;
+  };
+
+  archives_created: {
+    count: number;
+  };
+
+  configure_called: {
+    options: (keyof ConfigureOptions)[];
+    scope: 'test' | 'suite' | 'file';
+  };
+
+  wait_for_idle_network_called: {
+    timeout: number;
+  };
+
+  wait_for_idle_network_invalid_call: {
+    isInsideTest: boolean;
+    isRegisteredTest: boolean | undefined;
+    isCalledByUser: boolean;
+  };
+
+  wait_for_idle_network_timeout: {
+    timeout: number;
+    isCalledByUser: boolean;
+  };
+
+  setup_files_parallel: {
+    setupFileCount: number;
+  };
+
+  tags_low_version: Record<string, unknown>;
 };

--- a/packages/vitest/src/node/telemetry.ts
+++ b/packages/vitest/src/node/telemetry.ts
@@ -287,7 +287,7 @@ type TelemetryPayloads = {
   };
 
   archives_created: {
-    count: number;
+    archiveCount: number;
   };
 
   configure_called: {

--- a/packages/vitest/test/fixtures/configure-calls.test.ts
+++ b/packages/vitest/test/fixtures/configure-calls.test.ts
@@ -1,0 +1,14 @@
+import { describe, test } from 'vitest';
+import { configure } from '../../src';
+
+configure({ delay: 1234, title: 'Configure calls on different scopes' });
+
+test('test #1', () => {
+  configure({ diffThreshold: 1, resourceArchiveTimeout: 1234 });
+});
+
+describe('', () => {
+  configure({ ignoreSelectors: ['.example'] });
+
+  test('test #2', () => {});
+});

--- a/packages/vitest/test/fixtures/wait-for-idle-network.test.ts
+++ b/packages/vitest/test/fixtures/wait-for-idle-network.test.ts
@@ -1,5 +1,7 @@
-import { beforeAll, describe, expect, test, inject } from 'vitest';
+import { beforeAll, describe, expect, test, inject, onTestFinished } from 'vitest';
+import { setupWorker } from 'msw/browser';
 import { waitForIdleNetwork } from '../../src';
+import { http } from 'msw';
 
 test.runIf(inject('testName') === 'one')('test #1', async () => {
   document.body.innerHTML = '<h1>Example heading</h1>';
@@ -15,4 +17,20 @@ describe.runIf(inject('testName') === 'two')('suite', async () => {
   });
 
   test('test #2', async () => {});
+});
+
+test.runIf(inject('testName') === 'three')('test #3', async () => {
+  const worker = setupWorker();
+  await worker.start({ quiet: true });
+  onTestFinished(() => void worker.stop());
+
+  const onRequest = new Promise((resolve) =>
+    worker.use(http.get('/example', () => new Promise(resolve)))
+  );
+
+  const controller = new AbortController();
+  void fetch('/example', { signal: controller.signal }).catch(() => {});
+  await onRequest;
+
+  await waitForIdleNetwork(2).catch(() => controller.abort());
 });

--- a/packages/vitest/test/utils/node.ts
+++ b/packages/vitest/test/utils/node.ts
@@ -55,7 +55,7 @@ export async function runFixture(
 }
 
 export async function getResolvedConfig(
-  options: InlineConfig = {},
+  options: InlineConfig & { shard?: string } = {},
   pluginOptions: Parameters<typeof chromaticPlugin>[0] = {}
 ) {
   const vitest = await createVitest(

--- a/packages/vitest/test/utils/node.ts
+++ b/packages/vitest/test/utils/node.ts
@@ -104,30 +104,30 @@ export class StableTestFileOrderSorter implements TestSequencer {
   }
 }
 
-export function createTelemetryServer(url = TELEMETRY_URL) {
-  const server = setupServer();
+export function setupTelemetryServer(_server?: ReturnType<typeof setupServer>) {
+  const server = _server || setupServer();
   const onRequest = vi.fn<(event: WireTelemetryEvent) => void>();
 
-  const setup = () => {
-    onRequest.mockClear();
+  server.listen({ onUnhandledRequest: 'warn' });
 
-    server.listen({ onUnhandledRequest: 'warn' });
+  server.use(
+    http.post<undefined, WireTelemetryEvent>(
+      `${TELEMETRY_URL}/telemetry/v1/vitest/events`,
+      async ({ request }) => {
+        onRequest(await request.json());
+        return HttpResponse.json({ ok: true });
+      }
+    )
+  );
 
-    server.use(
-      http.post<undefined, WireTelemetryEvent>(
-        `${url}/telemetry/v1/vitest/events`,
-        async ({ request }) => {
-          onRequest(await request.json());
-          return HttpResponse.json({ ok: true });
-        }
-      )
-    );
+  process.env.CHROMATIC_DISABLE_TELEMETRY = '0';
 
-    return function cleanup() {
-      server.resetHandlers();
-      server.close();
-    };
-  };
+  function cleanup() {
+    process.env.CHROMATIC_DISABLE_TELEMETRY = '1';
 
-  return { server, setup, onRequest };
+    server.resetHandlers();
+    server.close();
+  }
+
+  return { server, onRequest, cleanup };
 }


### PR DESCRIPTION
Issue:
- Milestone 4 of https://github.com/chromaui/chromatic-e2e/issues/419
- Stacks on https://github.com/chromaui/chromatic-e2e/pull/427

I recommend reviewing commit-by-commit as the first one is refactoring test cases quite much.

## What Changed

Adds telemetry events that are sent during Vitest test run.

## How to test

- Added tests for each event
- Preview release