### PR TITLE
feat(vitest): CLI telemetry to include `chromaticProjectId`

### DIFF
--- a/packages/vitest/src/bin/archive-storybook.ts
+++ b/packages/vitest/src/bin/archive-storybook.ts
@@ -45,6 +45,7 @@ function onArchivesCheck(error?: unknown) {
       error,
       isCustomLocation: process.env.CHROMATIC_ARCHIVE_LOCATION != undefined,
       command: 'archiveStorybook',
+      chromaticProjectId: undefined,
     },
   });
 }

--- a/packages/vitest/src/bin/build-archive-storybook.ts
+++ b/packages/vitest/src/bin/build-archive-storybook.ts
@@ -10,16 +10,17 @@ import { type EventType, type TelemetryEvent, trackCliEvent } from '../node/tele
 const args = process.argv.slice(2);
 const configDir = path.resolve(import.meta.dirname, '../storybook-config');
 
+// These environment variables are set by chromatic-cli:
+const isCalledFromCLI = process.env.STORYBOOK_INVOKED_BY === 'chromatic';
+const chromaticProjectId = process.env.CHROMATIC_PROJECT_ID || 'unknown';
+
 let queue = Promise.resolve();
 
 try {
   trackEvent({
     eventType: 'storybook_build_started',
     level: 'info',
-    payload: {
-      // chromatic cli sets `STORYBOOK_INVOKED_BY=chromatic`
-      isCalledFromCLI: process.env.STORYBOOK_INVOKED_BY === 'chromatic',
-    },
+    payload: { isCalledFromCLI, chromaticProjectId },
   });
 
   await buildArchiveStorybook(args, configDir, DEFAULT_OUTPUT_DIR, { onArchivesCheck });
@@ -27,13 +28,13 @@ try {
   trackEvent({
     eventType: 'storybook_build_completed',
     level: 'info',
-    payload: { success: true, error: undefined },
+    payload: { success: true, error: undefined, chromaticProjectId },
   });
 } catch (err) {
   trackEvent({
     eventType: 'storybook_build_completed',
     level: 'error',
-    payload: { success: false, error: err },
+    payload: { success: false, error: err, chromaticProjectId },
   });
 
   // Throwing the error results in a large output of minified code and a stacktrace that is
@@ -62,6 +63,7 @@ function onArchivesCheck(error?: unknown) {
       error,
       isCustomLocation: process.env.CHROMATIC_ARCHIVE_LOCATION != undefined,
       command: 'buildArchiveStorybook',
+      chromaticProjectId,
     },
   });
 }

--- a/packages/vitest/src/node/telemetry/telemetry.test.ts
+++ b/packages/vitest/src/node/telemetry/telemetry.test.ts
@@ -928,12 +928,14 @@ describe('events', () => {
         {
           "eventType": "vitest_storybook_build_started",
           "payload": {
+            "chromaticProjectId": "unknown",
             "isCalledFromCLI": false,
           },
         },
         {
           "eventType": "vitest_archives_resolved",
           "payload": {
+            "chromaticProjectId": "unknown",
             "command": "buildArchiveStorybook",
             "isCustomLocation": true,
             "success": true,
@@ -942,6 +944,7 @@ describe('events', () => {
         {
           "eventType": "vitest_storybook_build_completed",
           "payload": {
+            "chromaticProjectId": "unknown",
             "success": true,
           },
         },
@@ -954,6 +957,7 @@ describe('events', () => {
     onRequest,
   }) => {
     vi.stubEnv('STORYBOOK_INVOKED_BY', 'chromatic');
+    vi.stubEnv('CHROMATIC_PROJECT_ID', 'example-project-id');
 
     await runBinary('build-archive-storybook', { archivesDirectory });
 
@@ -964,12 +968,14 @@ describe('events', () => {
         {
           "eventType": "vitest_storybook_build_started",
           "payload": {
+            "chromaticProjectId": "example-project-id",
             "isCalledFromCLI": true,
           },
         },
         {
           "eventType": "vitest_archives_resolved",
           "payload": {
+            "chromaticProjectId": "example-project-id",
             "command": "buildArchiveStorybook",
             "isCustomLocation": true,
             "success": true,
@@ -978,6 +984,7 @@ describe('events', () => {
         {
           "eventType": "vitest_storybook_build_completed",
           "payload": {
+            "chromaticProjectId": "example-project-id",
             "success": true,
           },
         },
@@ -998,12 +1005,14 @@ describe('events', () => {
         {
           "eventType": "vitest_storybook_build_started",
           "payload": {
+            "chromaticProjectId": "unknown",
             "isCalledFromCLI": false,
           },
         },
         {
           "eventType": "vitest_archives_resolved",
           "payload": {
+            "chromaticProjectId": "unknown",
             "command": "buildArchiveStorybook",
             "isCustomLocation": true,
             "success": true,
@@ -1012,6 +1021,7 @@ describe('events', () => {
         {
           "eventType": "vitest_storybook_build_completed",
           "payload": {
+            "chromaticProjectId": "unknown",
             "error": "Example error with <process-cwd> and <homedir>
       Stack: Example stack:
       with cwd <process-cwd>

--- a/packages/vitest/src/node/telemetry/types.ts
+++ b/packages/vitest/src/node/telemetry/types.ts
@@ -134,15 +134,18 @@ type TelemetryPayloads = {
     success: boolean;
     error: unknown;
     command: 'archiveStorybook' | 'buildArchiveStorybook';
+    chromaticProjectId: string | undefined;
   };
 
   storybook_build_started: {
     isCalledFromCLI: boolean;
+    chromaticProjectId: string | undefined;
   };
 
   storybook_build_completed: {
     success: boolean;
     error: unknown;
+    chromaticProjectId: string | undefined;
   };
 
   storybook_dev_started: Record<string, never>;


### PR DESCRIPTION
Issue:
- Stacks on #427
- Requires https://github.com/chromaui/chromatic-cli/pull/1437

## What Changed

Adds `chromaticProjectId` in the telemetry events triggered from `chromatic --vitest` CLI run.

## How to test

- [x] Added failing tests
- [x] Verified preview builds with https://github.com/AriPerkkio/visual-regression-example and local telemetry server
