### PR TITLE
fix(vitest): remove `telemetry` plugin option, support only env vars

### DIFF
--- a/packages/vitest/src/node/plugin.ts
+++ b/packages/vitest/src/node/plugin.ts
@@ -34,7 +34,7 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
     turboSnap: false,
     ...userOptions,
     reporter: resolveReporterOptions(userOptions.reporter),
-    telemetry: resolveTelemetryOptions(userOptions.telemetry),
+    telemetry: resolveTelemetryOptions(),
   };
 
   const isDist = import.meta.url.includes('dist/plugin.js');

--- a/packages/vitest/src/node/reporter.test.ts
+++ b/packages/vitest/src/node/reporter.test.ts
@@ -191,11 +191,14 @@ test('summary with TurboSnap enabled', async () => {
   `);
 });
 
-test('summary with telemetry.logToFile enabled', async () => {
+test('summary with `CHROMATIC_TELEMETRY_LOG_TO_FILE` enabled', async () => {
   const { cleanup } = setupTelemetryServer();
-  onTestFinished(cleanup);
+  vi.stubEnv('CHROMATIC_TELEMETRY_LOG_TO_FILE', '1');
 
   onTestFinished(() => {
+    vi.unstubAllEnvs();
+    cleanup();
+
     const reports = resolve(process.cwd(), DEFAULT_OUTPUT_DIR);
 
     if (existsSync(reports)) {
@@ -203,10 +206,7 @@ test('summary with telemetry.logToFile enabled', async () => {
     }
   });
 
-  const { stdout } = await runFixture(
-    { reporters: 'default', root: process.cwd() },
-    { telemetry: { logToFile: true } }
-  );
+  const { stdout } = await runFixture({ reporters: 'default', root: process.cwd() });
 
   expect(trimSummary(stdout)).toMatchInlineSnapshot(`
     "Chromatic Visual Regression

--- a/packages/vitest/src/node/telemetry/env.ts
+++ b/packages/vitest/src/node/telemetry/env.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import util from 'node:util';
 import { env } from 'std-env';
-import type { Options, ResolvedOptions } from '../../types';
+import type { ResolvedOptions } from '../../types';
 
 /** Contents of `.env` */
 let dotEnv: Record<string, string> | undefined = undefined;
@@ -29,27 +29,16 @@ export function getEnv(name: string): string | undefined {
   return env[name] ?? dotEnv[name];
 }
 
-export function resolveTelemetryOptions(
-  telemetry: Options['telemetry']
-): ResolvedOptions['telemetry'] {
-  const resolved =
-    typeof telemetry === 'object'
-      ? { enabled: telemetry?.enabled ?? true, logToFile: telemetry?.logToFile ?? false }
-      : { enabled: telemetry ?? true, logToFile: false };
+export function resolveTelemetryOptions(): ResolvedOptions['telemetry'] {
+  return {
+    // Enabled by default, disabled by env variables
+    enabled:
+      isTruthyEnv(getEnv('CHROMATIC_DISABLE_TELEMETRY')) === false &&
+      isTruthyEnv(getEnv('DO_NOT_TRACK')) === false,
 
-  if (isDisabledByEnv()) {
-    resolved.enabled = false;
-  }
-
-  if (isTruthyEnv(getEnv('CHROMATIC_TELEMETRY_LOG_TO_FILE'))) {
-    resolved.logToFile = true;
-  }
-
-  return resolved;
-}
-
-export function isDisabledByEnv() {
-  return isTruthyEnv(getEnv('CHROMATIC_DISABLE_TELEMETRY')) || isTruthyEnv(getEnv('DO_NOT_TRACK'));
+    // Disabled by default, enabled by env variable
+    logToFile: isTruthyEnv(getEnv('CHROMATIC_TELEMETRY_LOG_TO_FILE')),
+  };
 }
 
 function isTruthyEnv(value: string | undefined): boolean {

--- a/packages/vitest/src/node/telemetry/metadata.ts
+++ b/packages/vitest/src/node/telemetry/metadata.ts
@@ -7,7 +7,6 @@ import { x } from 'tinyexec';
 import { env } from 'std-env';
 import { TELEMETRY_METADATA_FILE } from './constants';
 import type { WireTelemetryEvent } from './types';
-import type { ResolvedOptions } from '../../types';
 
 const userAgentMatch = env.npm_config_user_agent?.match(/^([^/\s]+)\/(\S+)/);
 
@@ -23,7 +22,6 @@ export interface TelemetryMetadata {
   chromaticVersion: WireTelemetryEvent['metadata']['chromaticVersion'];
   vitestVersion: WireTelemetryEvent['metadata']['vitestVersion'];
   isVitestProjects: WireTelemetryEvent['metadata']['isVitestProjects'];
-  logToFile: ResolvedOptions['telemetry']['logToFile'];
 }
 
 export async function createProjectId(root: string): Promise<string> {
@@ -87,36 +85,27 @@ export async function writeTelemetryMetadata(outputDirectory: string, data: Tele
  * Reads the `.vitest/chromatic/telemetry-metadata.json` file and returns the telemetry metadata.
  * This will be read when `chromatic --vitest` CLI is run, outside of Vitest test run.
  */
-export async function readTelemetryMetadata(
-  outputDirectory: string
-): Promise<{ disabled: true } | TelemetryMetadata> {
+export async function readTelemetryMetadata(outputDirectory: string): Promise<TelemetryMetadata> {
+  const defaults: TelemetryMetadata = {
+    sessionId: 'unknown',
+    projectId: 'unknown',
+    chromaticVersion: 'unknown',
+    vitestVersion: 'unknown',
+    isVitestProjects: false,
+  };
+
   try {
     const filename = resolve(outputDirectory, TELEMETRY_METADATA_FILE);
 
-    // Missing metadata indicates telemetry was disabled during Vitest run.
     if (!existsSync(filename)) {
-      return { disabled: true };
+      return defaults;
     }
 
     const content = await readFile(filename, 'utf8');
     const json = JSON.parse(content);
 
-    return {
-      sessionId: json.sessionId || 'unknown',
-      projectId: json.projectId || 'unknown',
-      chromaticVersion: json.chromaticVersion || 'unknown',
-      vitestVersion: json.vitestVersion || 'unknown',
-      isVitestProjects: json.isVitestProjects ?? false,
-      logToFile: json.logToFile ?? false,
-    };
+    return { ...defaults, ...json };
   } catch {
-    return {
-      sessionId: 'unknown',
-      projectId: 'unknown',
-      chromaticVersion: 'unknown',
-      vitestVersion: 'unknown',
-      isVitestProjects: false,
-      logToFile: false,
-    };
+    return defaults;
   }
 }

--- a/packages/vitest/src/node/telemetry/session.ts
+++ b/packages/vitest/src/node/telemetry/session.ts
@@ -28,7 +28,7 @@ export const session = {
   isMetadataWritten: false,
 
   /** Contents of `.vitest/chromatic/telemetry-metadata.json` */
-  telemetryMetadata: undefined as undefined | { disabled: true } | TelemetryMetadata,
+  telemetryMetadata: undefined as undefined | TelemetryMetadata,
 };
 
 /**

--- a/packages/vitest/src/node/telemetry/telemetry.test.ts
+++ b/packages/vitest/src/node/telemetry/telemetry.test.ts
@@ -29,22 +29,16 @@ describe('configuration', () => {
     expect(onRequest).toHaveBeenCalled();
   });
 
-  test('telemetry is disabled when { telemetry: false }', async ({ onRequest }) => {
-    const { root } = await runVitest({}, { telemetry: false });
-
-    expect(onRequest).not.toHaveBeenCalled();
-
-    const metadataJson = resolve(root, `.vitest/chromatic/${TELEMETRY_METADATA_FILE}`);
-    expect(existsSync(metadataJson), `Expected ${metadataJson} not to exist`).toBe(false);
-  });
-
   test.for(['CHROMATIC_DISABLE_TELEMETRY', 'DO_NOT_TRACK'])(
     'telemetry is disabled when %s is set',
     async (envVar, { onRequest }) => {
       vi.stubEnv(envVar, '1');
-      await runVitest();
+      const { root } = await runVitest();
 
       expect(onRequest).not.toHaveBeenCalled();
+
+      const metadataJson = resolve(root, `.vitest/chromatic/${TELEMETRY_METADATA_FILE}`);
+      expect(existsSync(metadataJson), `Expected ${metadataJson} not to exist`).toBe(false);
     }
   );
 
@@ -84,15 +78,6 @@ describe('configuration', () => {
 
     expect.soft(onRequest).not.toHaveBeenCalled();
     expect.soft(onCustomEndpointRequest).toHaveBeenCalledWith('called here');
-  });
-
-  test('telemetry is logged to file when { telemetry: { logToFile: true }} ', async () => {
-    const { root } = await runVitest({}, { telemetry: { logToFile: true } });
-
-    const rows = readLogFile(root);
-
-    const configureEvents = rows.filter((row) => row.eventType === 'vitest_plugin_configured');
-    expect(configureEvents.length).toBe(1);
   });
 
   test('telemetry is logged to file when CHROMATIC_TELEMETRY_LOG_TO_FILE is set', async () => {

--- a/packages/vitest/src/node/telemetry/track.ts
+++ b/packages/vitest/src/node/telemetry/track.ts
@@ -10,7 +10,7 @@ import {
   TELEMETRY_LOG_FILE,
   TELEMETRY_URL,
 } from './constants';
-import { getEnv, isDisabledByEnv } from './env';
+import { getEnv, resolveTelemetryOptions } from './env';
 import {
   createProjectId,
   getChromaticVersion,
@@ -49,7 +49,9 @@ export async function trackCliEvent<T extends EventType = EventType>(
   event: TelemetryEvent<T>,
   options: { outputDirectory: string }
 ): Promise<void> {
-  if (isDisabledByEnv()) {
+  const telemetry = resolveTelemetryOptions();
+
+  if (!telemetry.enabled) {
     return;
   }
 
@@ -66,21 +68,16 @@ export async function trackCliEvent<T extends EventType = EventType>(
     }
   }
 
-  // If we don't find telemetry metadata written by Vitest test run, we consider telemetry to be disabled.
-  if (!telemetryMetadata || 'disabled' in telemetryMetadata) {
-    return;
-  }
-
   await _trackEvent(
     event,
     {
-      version: telemetryMetadata.vitestVersion || 'unknown',
+      version: telemetryMetadata.vitestVersion,
       config: { root: options.outputDirectory },
       projects: telemetryMetadata.isVitestProjects ? [1, 2] : [],
     },
     {
       outputDirectory: options.outputDirectory,
-      telemetry: { enabled: true, logToFile: telemetryMetadata.logToFile },
+      telemetry,
     }
   );
 }
@@ -157,7 +154,6 @@ async function _trackEvent(
       ...wireEvent.metadata,
       sessionId: wireEvent.sessionId,
       projectId: wireEvent.projectId,
-      logToFile: options.telemetry.logToFile,
     });
   }
 }

--- a/packages/vitest/src/types.test-d.ts
+++ b/packages/vitest/src/types.test-d.ts
@@ -44,7 +44,6 @@ test('chromaticPlugin', () => {
   expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('outputDirectory');
   expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('idleNetworkInterval');
   expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('reporter');
-  expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('telemetry');
 
   expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('delay');
   expectTypeOf(chromaticPlugin).parameter(0).toHaveProperty('diffIncludeAntiAliasing');
@@ -68,15 +67,4 @@ test('chromaticPlugin({ reporter })', () => {
   assertType<Reporter>({ enabled: true });
   assertType<Reporter>({ verbose: true, enabled: true });
   assertType<Reporter>({ verbose: false, enabled: false });
-});
-
-test('chromaticPlugin({ telemetry })', () => {
-  type Telemetry = Parameters<typeof chromaticPlugin>[0]['telemetry'];
-
-  assertType<Telemetry>(true);
-  assertType<Telemetry>(false);
-  assertType<Telemetry>({ logToFile: false });
-  assertType<Telemetry>({ enabled: true });
-  assertType<Telemetry>({ logToFile: true, enabled: true });
-  assertType<Telemetry>({ logToFile: false, enabled: false });
 });

--- a/packages/vitest/src/types.ts
+++ b/packages/vitest/src/types.ts
@@ -66,31 +66,6 @@ export interface Options extends ChromaticConfig {
    * @default false
    */
   turboSnap?: boolean;
-
-  /**
-   * Anonymous usage telemetry.
-   * Can also be disabled by setting the `CHROMATIC_DISABLE_TELEMETRY` or `DO_NOT_TRACK` environment variable.
-   *
-   * @default true
-   */
-  telemetry?:
-    | boolean
-    | {
-        /**
-         * Whether telemetry is enabled.
-         *
-         * @default true
-         */
-        enabled?: boolean;
-
-        /**
-         * Write all telemetry events to `${outputDirectory}/telemetry.jsonl`, one JSON event per line.
-         * Can also be enabled by setting the `CHROMATIC_TELEMETRY_LOG_TO_FILE` environment variable.
-         *
-         * @default false
-         */
-        logToFile?: boolean;
-      };
 }
 
 /** Additional `parameters` added into the Story JSON file. */
@@ -120,9 +95,25 @@ export interface ResolvedOptions
   extends
     Required<Pick<Options, ResolvedOptionKeys>>,
     Pick<Options, UnresolvedOptionKeys | 'reporter'> {
-  //
   reporter: Required<Exclude<Options['reporter'], boolean>>;
-  telemetry: Required<Exclude<Options['telemetry'], boolean>>;
+
+  telemetry: {
+    /**
+     * Whether telemetry is enabled.
+     * Value is resolved from `CHROMATIC_DISABLE_TELEMETRY` and `DO_NOT_TRACK` environment variables.
+     *
+     * @default true
+     */
+    enabled?: boolean;
+
+    /**
+     * Write all telemetry events to `${outputDirectory}/telemetry.jsonl`, one JSON event per line.
+     * Value is resolved from `CHROMATIC_TELEMETRY_LOG_TO_FILE` environment variable.
+     *
+     * @default false
+     */
+    logToFile?: boolean;
+  };
 }
 
 /**

--- a/packages/vitest/test/vitest.config.e2e.ts
+++ b/packages/vitest/test/vitest.config.e2e.ts
@@ -2,8 +2,11 @@ import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 import { chromaticPlugin } from '../dist/plugin';
 
+// Prevent sending telemetry during test run
+process.env.CHROMATIC_DISABLE_TELEMETRY = '1';
+
 export default defineConfig({
-  plugins: [chromaticPlugin({ telemetry: false })],
+  plugins: [chromaticPlugin()],
 
   server: {
     proxy: testServerProxy(),

--- a/packages/vitest/vitest.config.browser.ts
+++ b/packages/vitest/vitest.config.browser.ts
@@ -5,9 +5,12 @@ import { type ConfigureOptions } from './src/types';
 
 const isWatch = process.argv.includes('--watch');
 
+// Prevent sending telemetry during test run
+process.env.CHROMATIC_DISABLE_TELEMETRY = '1';
+
 export default defineProject({
   resolve: { tsconfigPaths: true },
-  plugins: [chromaticPlugin({ telemetry: false })],
+  plugins: [chromaticPlugin()],
 
   // To always catch errors that happen on first test run
   optimizeDeps: { force: true },


### PR DESCRIPTION
Issue:
- Stacks on #427

## What Changed

As `chromatic --vitest` CLI run cannot read `vitest.config.ts`, it cannot know if user had `chromaticPlugin({ telemetry: false })` in the their configuration. Let's remove plugin option completely and support only environment variables.

## How to test

- Tests pass on CI