### PR TITLE
fix(vitest): turbosnap to track `setupFiles` too

### DIFF
--- a/.changeset/petite-ads-see.md
+++ b/.changeset/petite-ads-see.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: TurboSnap to consider `setupFiles` too

--- a/packages/vitest/src/node/webpack-stats-reporter.test.ts
+++ b/packages/vitest/src/node/webpack-stats-reporter.test.ts
@@ -34,6 +34,27 @@ test('TurboSnap enabled, source files', async () => {
         ],
       },
       {
+        "id": "css-setup.css",
+        "name": "css-setup.css",
+        "reasons": [
+          {
+            "moduleName": "css-setup-file.ts",
+          },
+        ],
+      },
+      {
+        "id": "css-setup-file.ts",
+        "name": "css-setup-file.ts",
+        "reasons": [
+          {
+            "moduleName": "turbo-snap-1.test.ts",
+          },
+          {
+            "moduleName": "turbo-snap-2.test.ts",
+          },
+        ],
+      },
+      {
         "id": "components/button/button.ts",
         "name": "components/button/button.ts",
         "reasons": [

--- a/packages/vitest/src/node/webpack-stats-reporter.test.ts
+++ b/packages/vitest/src/node/webpack-stats-reporter.test.ts
@@ -13,7 +13,11 @@ afterEach(() => {
 
 test('TurboSnap enabled, source files', async () => {
   const root = resolve(import.meta.dirname, '../../test/fixtures');
-  await runFixture({ root }, { turboSnap: true });
+  await runFixture(
+    /** {@link file://./../../test/fixtures/css-setup-file.ts} */
+    { root, setupFiles: [resolve(import.meta.dirname, '../../test/fixtures/css-setup-file.ts')] },
+    { turboSnap: true }
+  );
 
   const stats = readStats(root);
   const modules = stats.modules.filter(excludeNodeModules).filter(excludePluginSources);

--- a/packages/vitest/src/node/webpack-stats-reporter.test.ts
+++ b/packages/vitest/src/node/webpack-stats-reporter.test.ts
@@ -446,6 +446,41 @@ test('TurboSnap enabled, CSS imports', async () => {
   `);
 });
 
+test('TurboSnap enabled, Tailwind-like content scanner watch files', async () => {
+  const root = resolve(import.meta.dirname, '../../test/fixtures');
+
+  await runFixture(
+    {
+      root,
+      /** {@link file://./../../test/fixtures/configs/vitest.config.fake-tailwind.ts} */
+      config: resolve(root, 'configs/vitest.config.fake-tailwind.ts'),
+      /** {@link file://./../../test/fixtures/turbo-snap-css.test.ts} */
+      include: [resolve(root, 'turbo-snap-css.test.ts')],
+    },
+    { turboSnap: true }
+  );
+
+  const stats = readStats(root);
+  const ids = stats.modules.map((mod) => mod.id);
+
+  // Non-CSS files and glob patterns watched by the CSS module are content
+  // scanner registrations, not real dependencies, and must be filtered out
+  expect(ids).not.toContain('turbo-snap-1.test.ts');
+  expect(ids.filter((id) => id.includes('*'))).toEqual([]);
+
+  // CSS files watched by the CSS module are real dependencies and are kept
+  expect(stats.modules).toContainEqual({
+    id: 'css-setup.css',
+    name: 'css-setup.css',
+    reasons: [{ moduleName: 'components/styled/styles.css' }],
+  });
+
+  // Regular CSS `@import` chain is unaffected
+  expect(stats.modules).toContainEqual(
+    expect.objectContaining({ id: 'components/styled/base.css' })
+  );
+});
+
 test('TurboSnap enabled with custom output directory', async () => {
   const root = resolve(import.meta.dirname, '../../test/fixtures');
   const outputDirectory = '.vitest/custom-output-directory';

--- a/packages/vitest/src/node/webpack-stats-reporter.ts
+++ b/packages/vitest/src/node/webpack-stats-reporter.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname, relative, resolve, sep } from 'node:path';
-import type { TestCase, TestModule, Vite, Vitest } from 'vitest/node';
+import { isCSSRequest, type TestCase, type TestModule, type Vite, type Vitest } from 'vitest/node';
 import type { Reporter } from 'vitest/reporters';
 import type { ResolvedOptions } from '../types';
 
@@ -172,6 +172,12 @@ export class WebpackStatsReporter implements Reporter {
       // File-only entries have no `id`, e.g. Sass partials and CSS `@import`s
       if (imported.id == null) {
         if (imported.file) {
+          // Tailwind's content scanner watches every single file in the project by default.
+          // It marks CSS files as dependent on every file in the project (even .github/workflows/ci.yml).
+          // Cut the import chain early when a CSS file imports a non-CSS file.
+          if (mod.file && isCSSRequest(mod.file) && !isCSSRequest(imported.file)) {
+            continue;
+          }
           importedModules.push({ id: imported.file, isInModuleGraph: false });
         }
         continue;

--- a/packages/vitest/src/node/webpack-stats-reporter.ts
+++ b/packages/vitest/src/node/webpack-stats-reporter.ts
@@ -109,20 +109,29 @@ export class WebpackStatsReporter implements Reporter {
       }
 
       const id = this.normalize(testModule.moduleId);
+      const additionalModules: { id: string; isInModuleGraph?: boolean }[] = [];
 
       // Test module is imported by all its story files
       statsMap.set(id, this.createStatsMapModule(id, [...storyFiles]));
 
-      // Test module also depends on Vitest config
+      // Test module depends on Vitest config
       if (testModule.project.config.config) {
-        const configId = this.normalize(testModule.project.config.config);
-        const configEntry = statsMap.get(configId) || this.createStatsMapModule(configId, []);
-
-        configEntry.reasons.push({ moduleName: id });
-        statsMap.set(configId, configEntry);
+        additionalModules.push({ id: testModule.project.config.config, isInModuleGraph: false });
       }
 
-      this.addModule(testModule.moduleId, statsMap, vite.moduleGraph, vite.config.cacheDir);
+      // Test module depends on setup files
+      for (const setupFile of testModule.project.config.setupFiles) {
+        additionalModules.push({ id: setupFile, isInModuleGraph: true });
+      }
+
+      this.addModule(
+        testModule.moduleId,
+        statsMap,
+        vite.moduleGraph,
+        vite.config.cacheDir,
+        new Set<Vite.ModuleNode['id']>(),
+        additionalModules
+      );
     }
 
     if (!existsSync(dirname(this.options.outputFile))) {
@@ -141,7 +150,8 @@ export class WebpackStatsReporter implements Reporter {
     statsMap: Map<Module['id'], Module>,
     moduleGraph: Vite.ModuleGraph,
     cacheDir: Vite.UserConfig['cacheDir'],
-    visited = new Set<Vite.ModuleNode['id']>()
+    visited: Set<Vite.ModuleNode['id']>,
+    additionalModules: { id: string; isInModuleGraph?: boolean }[] = []
   ) {
     if (visited.has(id)) {
       return;
@@ -156,7 +166,7 @@ export class WebpackStatsReporter implements Reporter {
       );
     }
 
-    const importedModules: { id: string; isInModuleGraph?: boolean }[] = [];
+    const importedModules = [...additionalModules];
 
     for (const imported of mod.importedModules) {
       // File-only entries have no `id`, e.g. Sass partials and CSS `@import`s

--- a/packages/vitest/test/fixtures/configs/vitest.config.fake-tailwind.ts
+++ b/packages/vitest/test/fixtures/configs/vitest.config.fake-tailwind.ts
@@ -1,0 +1,34 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+const fixturesRoot = resolve(import.meta.dirname, '..');
+
+export default defineConfig({
+  plugins: [
+    /**
+     * Mimics `@tailwindcss/vite` without depending on Tailwind: its content scanner
+     * registers every scanned project file and its glob patterns via `addWatchFile`
+     * while transforming the CSS entry. Vite's `vite:css-analysis` plugin then turns
+     * these into file-only module graph entries (`id: null`) on the CSS module.
+     */
+    {
+      name: 'fake-tailwind-scanner',
+      enforce: 'pre',
+      transform(_code, id) {
+        if (!id.includes('components/styled/styles.css')) {
+          return;
+        }
+
+        // A scanned non-CSS content file, like `.github/workflows/ci.yml`
+        this.addWatchFile(resolve(fixturesRoot, 'turbo-snap-1.test.ts'));
+
+        // Scanner glob patterns are registered as watch files too
+        this.addWatchFile(resolve(fixturesRoot, 'components/**/*.{ts,html}'));
+
+        // Tailwind also registers its CSS build dependencies (`@import`ed
+        // stylesheets) as watch files — these are real dependencies
+        this.addWatchFile(resolve(fixturesRoot, 'css-setup.css'));
+      },
+    },
+  ],
+});

--- a/packages/vitest/test/fixtures/css-setup-file.ts
+++ b/packages/vitest/test/fixtures/css-setup-file.ts
@@ -1,0 +1,7 @@
+import { beforeEach } from 'vitest';
+
+import './css-setup.css';
+
+beforeEach(() => {
+  // Some setup
+});

--- a/packages/vitest/test/fixtures/css-setup.css
+++ b/packages/vitest/test/fixtures/css-setup.css
@@ -1,0 +1,3 @@
+body {
+  background: red;
+}


### PR DESCRIPTION
Issue: QA part of https://github.com/chromaui/chromatic-e2e/issues/419

Modules imported from `setupFiles` are not included in `preview-stats.json`, as test file's module graphs don't contain those. If `setupFile` imports `global-styles.css`, changes in that file are not detected by TurboSnap.

## What Changed

When traversing test modules, mark them to depend on their `setupFiles` entries.

Adds also fix for cases where `@tailwindcss/vite` would pull every single file into the `preview-stats.json`. In development mode, Tailwind's file watcher tracks every file the project has. That's their default configuration. And that makes Vite's module graphs to show that "`src/index.css` imports `.github/workflows/ci.yml` and `README.md`". As we are consuming Vite's module graph when building `preview-stats.json`, this all ends up there too. 

## How to test

- [x] Added test cases
- [x] Validate on QA failure with https://github.com/AriPerkkio/visual-regression-example