### PR TITLE
fix(vitest): alias `vitest/suite` for dep optimizer

### DIFF
--- a/.changeset/curvy-peaches-sniff.md
+++ b/.changeset/curvy-peaches-sniff.md
@@ -1,0 +1,5 @@
+---
+'@chromatic-com/vitest': patch
+---
+
+Fix: Vitest@5.0.0-rc.2 compatibility fixes

--- a/packages/vitest/src/node/plugin.ts
+++ b/packages/vitest/src/node/plugin.ts
@@ -37,20 +37,18 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
 
   return {
     name: 'vitest:chromatic',
-    enforce: 'pre',
-
-    resolveId(id) {
-      // vitest/suite is available in 4.0 only. Importing it in 4.1 logs error, in 5.0 it's removed.
-      if (id === 'vitest/suite' && !vitestVersion.startsWith('4.0')) {
-        return 'vitest';
-      }
-    },
 
     config() {
       return {
         optimizeDeps: {
           entries: [setupFile],
         },
+
+        // vitest/suite is available in 4.0 only. Importing it in 4.1 logs error, in 5.0 it's removed.
+        resolve: vitestVersion.startsWith('4.0')
+          ? undefined
+          : { alias: { 'vitest/suite': 'vitest' } },
+
         test: {
           provide: {
             __chromatic_options: options,

--- a/packages/vitest/test/utils/node.ts
+++ b/packages/vitest/test/utils/node.ts
@@ -53,12 +53,12 @@ export async function runFixture(
 
   function suiteImportPlugin() {
     return {
-      name: 'hack',
+      name: 'test:suite-import-rewrite',
       enforce: 'pre',
-      resolveId(id: string) {
+      config() {
         // vitest/suite is available in 4.0 only. Importing it in 4.1 logs error, in 5.0 it's removed.
-        if (id === 'vitest/suite' && !vitestVersion.startsWith('4.0')) {
-          return 'vitest';
+        if (!vitestVersion.startsWith('4.0')) {
+          return { resolve: { alias: { 'vitest/suite': 'vitest' } } };
         }
       },
     };

--- a/packages/vitest/vitest.config.unit.ts
+++ b/packages/vitest/vitest.config.unit.ts
@@ -1,23 +1,11 @@
 import { defineProject } from 'vitest/config';
-import { version as vitestVersion } from 'vitest/node';
 
 const isWatch = process.argv.includes('--watch');
 
 export default defineProject({
   resolve: { tsconfigPaths: true },
   publicDir: 'test/fixtures/public-dir',
-  plugins: [
-    {
-      name: 'hack',
-      enforce: 'pre',
-      resolveId(id) {
-        // vitest/suite is available in 4.0 only. Importing it in 4.1 logs error, in 5.0 it's removed.
-        if (id === 'vitest/suite' && !vitestVersion.startsWith('4.0')) {
-          return 'vitest';
-        }
-      },
-    },
-  ],
+
   test: {
     name: { label: 'Vitest Unit', color: 'yellow' },
     include: ['src/**/*.test.ts', 'embedded.test.ts'],


### PR DESCRIPTION
## What Changed

When Vite dependency optimizer runs, it does not load plugins in that pipeline. Our `resolveId` hack for `vitest/suite` doesn't work at that phase. However `resolve.alias` is respected by dep optimizer.

## How to test

- Test run pass in Vitest Ecosystem CI https://github.com/vitest-dev/vitest-ecosystem-ci/pull/57
