### PR TITLE
fix(vitest): descriptive warning when no chromium projects found

### DIFF
--- a/packages/vitest/src/node/plugin.ts
+++ b/packages/vitest/src/node/plugin.ts
@@ -68,14 +68,16 @@ export function chromaticPlugin(userOptions: Options = {}): Vite.Plugin {
       // Enabled when "vitest --merge-reports" is run. It's used after sharded runs ("vitest --shard=1/2", "vitest --shard=2/2").
       const isMergeReports = project.globalConfig.mergeReports;
 
+      if (options.reporter.enabled) {
+        ChromaticReporter.apply(context.vitest, options);
+      }
+
       // browser.name is instances[].browser, not instances[].name: https://github.com/vitest-dev/vitest/blob/d22b029ae056b9515033d75c1249e9db26612770/packages/vitest/src/node/projects/resolveProjects.ts#L307
       if (!browser.enabled || browser.name !== 'chromium') {
         return clean();
       }
 
-      if (options.reporter.enabled) {
-        ChromaticReporter.apply(context.vitest, options);
-      }
+      ChromaticReporter.onPluginActivated(context.vitest);
 
       if (options.turboSnap && !isMergeReports) {
         WebpackStatsReporter.apply(context.vitest, options);

--- a/packages/vitest/src/node/reporter.test.ts
+++ b/packages/vitest/src/node/reporter.test.ts
@@ -4,6 +4,7 @@ import { expect, onTestFinished, test, vi } from 'vitest';
 import * as shared from '@chromatic-com/shared-e2e';
 import {
   runFixture as baseRunFixture,
+  getBrowserConfig,
   isVitest5,
   StableTestFileOrderSorter,
 } from '../../test/utils/node';
@@ -234,6 +235,19 @@ test('summary when custom output directory', async () => {
 
     Archives saved in <process-cwd>/.vitest/custom-output-directory
     To upload archives into Chromatic run CHROMATIC_ARCHIVE_LOCATION=.vitest/custom-output-directory chromatic --vitest --project-token=<TOKEN>"
+  `);
+});
+
+test('summary when no eligible projects', async () => {
+  const { stdout } = await runFixture({
+    reporters: 'default',
+    browser: { ...getBrowserConfig(), instances: [{ browser: 'webkit' }] },
+  });
+
+  expect(trimSummary(stdout)).toMatchInlineSnapshot(`
+    "Chromatic Visual Regression
+
+    No archives captured. Chromatic plugin requires a browser mode project with Chromium project."
   `);
 });
 

--- a/packages/vitest/src/node/reporter.ts
+++ b/packages/vitest/src/node/reporter.ts
@@ -21,7 +21,8 @@ export class ChromaticReporter implements Reporter {
   private constructor(
     private ctx: Vitest,
     private options: Options,
-    private snapshotCountPerEntity = new Map<TestCase['id'] | TestModule['id'], number>()
+    private snapshotCountPerEntity = new Map<TestCase['id'] | TestModule['id'], number>(),
+    private isPluginActivated = false
   ) {}
 
   /**
@@ -65,6 +66,15 @@ export class ChromaticReporter implements Reporter {
     reporter?._onSnapshot(test);
   }
 
+  /**
+   * Custom reporter life-cycle called when plugin is activated for a project.
+   */
+  static onPluginActivated(ctx: Vitest) {
+    const reporter = ctx.config.reporters.find(isChromaticReporter);
+
+    reporter?._onPluginActivated();
+  }
+
   onTestCaseResult(testCase: TestCase) {
     if (this.options.builtInReporter !== 'verbose') {
       return;
@@ -104,12 +114,25 @@ export class ChromaticReporter implements Reporter {
     const snapshotCount = [...this.snapshotCountPerEntity.values()].reduce((a, b) => a + b, 0);
     this.snapshotCountPerEntity.clear();
 
+    const separator = colors.dim('─'.repeat(this.ctx.logger.getColumns()));
+
+    if (!this.isPluginActivated) {
+      return this.ctx.logger.log(
+        `${separator}`,
+
+        `\n${colors.inverse(' Chromatic Visual Regression ')}`,
+
+        `\n\n${colors.red('No archives captured. Chromatic plugin requires a browser mode project with Chromium project.')}`,
+
+        `\n\n${separator}\n`
+      );
+    }
+
     if (snapshotCount === 0) {
       return;
     }
 
     const output = resolve(this.ctx.config.root, this.options.outputDirectory);
-    const separator = colors.dim('─'.repeat(this.ctx.logger.getColumns()));
 
     let uploadCommand = 'chromatic --vitest --project-token=<TOKEN>';
 
@@ -164,6 +187,10 @@ export class ChromaticReporter implements Reporter {
 
     const previousCount = this.snapshotCountPerEntity.get(key) ?? 0;
     this.snapshotCountPerEntity.set(key, previousCount + 1);
+  }
+
+  private _onPluginActivated() {
+    this.isPluginActivated = true;
   }
 }
 


### PR DESCRIPTION
Issue: TE-5

## What Changed

If user doesn't have Chromium browser mode project enabled, show descriptive warning when tests finish. 

<img width="600" src="https://github.com/user-attachments/assets/7c192fe3-b45e-43fa-bcc4-72f376f4de3c" />


## How to test

- [x] Added test cases
- [x] Verified preview build on https://github.com/AriPerkkio/visual-regression-example locally
